### PR TITLE
feat(reminders): implement reminder service and email channel

### DIFF
--- a/apps/backend/src/api/routes/callback.controller.ts
+++ b/apps/backend/src/api/routes/callback.controller.ts
@@ -1,25 +1,37 @@
 import {
   Controller,
   Get,
+  Post,
   Patch,
   Param,
   Body,
   Query,
-  ForbiddenException,
+  BadRequestException,
 } from "@nestjs/common";
-import { CurrentUser, createOwnershipContext } from "@ringee/platform";
+import {
+  CurrentUser,
+  CurrentUserData,
+  createOwnershipContext,
+} from "@ringee/platform";
 import { CallbackService } from "@ringee/services";
 import { CallbackStatus } from "@ringee/database";
 
-interface CurrentUserData {
-  id: string;
-  activeOrgId?: string | null;
+interface CreateCallbackBody {
+  contactId: string;
+  scheduledAt: string;
+  note?: string;
+  callId?: string;
 }
 
 @Controller("callbacks")
 export class CallbackController {
   constructor(private readonly callbackService: CallbackService) {}
 
+  /**
+   * List callbacks visible to the current ownership context.
+   * - Freelancer (no activeOrgId): personal callbacks only.
+   * - Organization: all callbacks within the organization.
+   */
   @Get()
   async listCallbacks(
     @CurrentUser() user: CurrentUserData,
@@ -27,27 +39,84 @@ export class CallbackController {
     @Query("page") page = "1",
     @Query("limit") limit = "20"
   ) {
-    if (!user.activeOrgId) {
-      throw new ForbiddenException("Organization required");
-    }
     const ctx = createOwnershipContext(user);
-    return this.callbackService.listByAgent(ctx.userId, {
+    return this.callbackService.listForOwner(ctx, {
       status: status as CallbackStatus | undefined,
       page: Number(page),
       limit: Number(limit),
     });
   }
 
+  /**
+   * Schedule a standalone callback against a contact (optionally from a call).
+   * Campaign-bound callbacks are created from the dialer's disposition flow,
+   * not this endpoint.
+   */
+  @Post()
+  async create(
+    @CurrentUser() user: CurrentUserData,
+    @Body() body: CreateCallbackBody
+  ) {
+    if (!body.contactId) {
+      throw new BadRequestException("contactId is required");
+    }
+    if (!body.scheduledAt) {
+      throw new BadRequestException("scheduledAt is required");
+    }
+
+    const scheduledAt = new Date(body.scheduledAt);
+    if (Number.isNaN(scheduledAt.getTime())) {
+      throw new BadRequestException("scheduledAt must be a valid ISO date");
+    }
+    if (scheduledAt.getTime() <= Date.now()) {
+      throw new BadRequestException("scheduledAt must be in the future");
+    }
+
+    const ctx = createOwnershipContext(user);
+    return this.callbackService.scheduleFromContact({
+      userId: ctx.userId,
+      organizationId: ctx.organizationId ?? null,
+      contactId: body.contactId,
+      callId: body.callId ?? null,
+      scheduledAt,
+      note: body.note,
+    });
+  }
+
   @Patch(":id/cancel")
-  async cancel(@Param("id") id: string) {
+  async cancel(
+    @CurrentUser() user: CurrentUserData,
+    @Param("id") id: string
+  ) {
+    await this.callbackService.findOwnedById(id, createOwnershipContext(user));
     return this.callbackService.cancel(id);
+  }
+
+  @Patch(":id/complete")
+  async complete(
+    @CurrentUser() user: CurrentUserData,
+    @Param("id") id: string
+  ) {
+    await this.callbackService.findOwnedById(id, createOwnershipContext(user));
+    return this.callbackService.markCompleted(id);
   }
 
   @Patch(":id/reschedule")
   async reschedule(
+    @CurrentUser() user: CurrentUserData,
     @Param("id") id: string,
     @Body() body: { scheduledAt: string }
   ) {
-    return this.callbackService.reschedule(id, new Date(body.scheduledAt));
+    await this.callbackService.findOwnedById(id, createOwnershipContext(user));
+
+    const scheduledAt = new Date(body.scheduledAt);
+    if (Number.isNaN(scheduledAt.getTime())) {
+      throw new BadRequestException("scheduledAt must be a valid ISO date");
+    }
+    if (scheduledAt.getTime() <= Date.now()) {
+      throw new BadRequestException("scheduledAt must be in the future");
+    }
+
+    return this.callbackService.reschedule(id, scheduledAt);
   }
 }

--- a/apps/backend/src/api/routes/dnc.controller.ts
+++ b/apps/backend/src/api/routes/dnc.controller.ts
@@ -6,20 +6,24 @@ import {
   Body,
   Param,
   Query,
-  ForbiddenException,
+  BadRequestException,
 } from "@nestjs/common";
-import { CurrentUser, createOwnershipContext } from "@ringee/platform";
+import {
+  CurrentUser,
+  CurrentUserData,
+  createOwnershipContext,
+} from "@ringee/platform";
 import { ComplianceService } from "@ringee/services";
-
-interface CurrentUserData {
-  id: string;
-  activeOrgId?: string | null;
-}
 
 @Controller("dnc")
 export class DNCController {
   constructor(private readonly complianceService: ComplianceService) {}
 
+  /**
+   * List DNC entries for the current scope.
+   * - Org context (user has activeOrgId): returns the organization's DNC list.
+   * - Freelancer context: returns the user's personal DNC list.
+   */
   @Get()
   async listDNC(
     @CurrentUser() user: CurrentUserData,
@@ -27,11 +31,8 @@ export class DNCController {
     @Query("page") page = "1",
     @Query("limit") limit = "20"
   ) {
-    if (!user.activeOrgId) {
-      throw new ForbiddenException("Organization required");
-    }
     const ctx = createOwnershipContext(user);
-    return this.complianceService.listDNC(ctx.organizationId!, {
+    return this.complianceService.listDNC(ctx, {
       search,
       page: Number(page),
       limit: Number(limit),
@@ -43,13 +44,14 @@ export class DNCController {
     @Body() body: { phoneNumber: string; reason?: string },
     @CurrentUser() user: CurrentUserData
   ) {
-    if (!user.activeOrgId) {
-      throw new ForbiddenException("Organization required");
+    if (!body.phoneNumber) {
+      throw new BadRequestException("phoneNumber is required");
     }
     const ctx = createOwnershipContext(user);
     return this.complianceService.addToDNC({
       phoneNumber: body.phoneNumber,
-      organizationId: ctx.organizationId!,
+      userId: ctx.userId,
+      organizationId: ctx.organizationId ?? null,
       reason: body.reason,
       source: "manual",
       addedByUserId: ctx.userId,
@@ -61,14 +63,15 @@ export class DNCController {
     @Body() body: { phoneNumbers: string[]; reason?: string },
     @CurrentUser() user: CurrentUserData
   ) {
-    if (!user.activeOrgId) {
-      throw new ForbiddenException("Organization required");
+    if (!Array.isArray(body.phoneNumbers) || body.phoneNumbers.length === 0) {
+      throw new BadRequestException("phoneNumbers must be a non-empty array");
     }
     const ctx = createOwnershipContext(user);
     return this.complianceService.bulkAddToDNC(
       body.phoneNumbers.map((phone) => ({
         phoneNumber: phone,
-        organizationId: ctx.organizationId!,
+        userId: ctx.userId,
+        organizationId: ctx.organizationId ?? null,
         reason: body.reason,
         source: "import",
         addedByUserId: ctx.userId,
@@ -81,19 +84,19 @@ export class DNCController {
     @Param("phoneNumber") phoneNumber: string,
     @CurrentUser() user: CurrentUserData
   ) {
-    if (!user.activeOrgId) {
-      throw new ForbiddenException("Organization required");
-    }
     const ctx = createOwnershipContext(user);
-    const isOnDNC = await this.complianceService.isOnDNC(
-      ctx.organizationId!,
-      phoneNumber
-    );
-    return { phoneNumber, isOnDNC };
+    const entry = await this.complianceService.findOnDNC(ctx, phoneNumber);
+    return {
+      phoneNumber,
+      isOnDNC: entry !== null,
+      reason: entry?.reason ?? null,
+      source: entry?.source ?? null,
+      addedAt: entry?.createdAt ?? null,
+    };
   }
 
   @Delete(":id")
   async removeFromDNC(@Param("id") id: string) {
-    return this.complianceService.checkDNCById(id);
+    return this.complianceService.deleteDNCById(id);
   }
 }

--- a/apps/backend/src/api/routes/reminder.controller.ts
+++ b/apps/backend/src/api/routes/reminder.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Query,
+  BadRequestException,
+} from "@nestjs/common";
+import {
+  CurrentUser,
+  CurrentUserData,
+  createOwnershipContext,
+} from "@ringee/platform";
+import { ReminderService } from "@ringee/services";
+import { ReminderSubjectType } from "@ringee/database";
+
+@Controller("reminders")
+export class ReminderController {
+  constructor(private readonly reminderService: ReminderService) {}
+
+  /**
+   * List upcoming (pending + snoozed) reminders for the current scope.
+   * Sent / failed / cancelled reminders are excluded — this is the
+   * agenda view, not an audit log.
+   */
+  @Get()
+  async listUpcoming(
+    @CurrentUser() user: CurrentUserData,
+    @Query("subjectType") subjectType?: string,
+    @Query("page") page = "1",
+    @Query("limit") limit = "20"
+  ) {
+    const ctx = createOwnershipContext(user);
+
+    let typed: ReminderSubjectType | undefined;
+    if (subjectType) {
+      const allowed = Object.values(ReminderSubjectType) as string[];
+      if (!allowed.includes(subjectType)) {
+        throw new BadRequestException(
+          `subjectType must be one of: ${allowed.join(", ")}`
+        );
+      }
+      typed = subjectType as ReminderSubjectType;
+    }
+
+    return this.reminderService.listUpcomingForOwner(ctx, {
+      subjectType: typed,
+      page: Number(page),
+      limit: Number(limit),
+    });
+  }
+
+  @Patch(":id/snooze")
+  async snooze(
+    @Param("id") id: string,
+    @Body() body: { minutes?: number }
+  ) {
+    const minutes = Number.isFinite(body.minutes) ? Number(body.minutes) : 10;
+    if (minutes <= 0 || minutes > 24 * 60) {
+      throw new BadRequestException("minutes must be in (0, 1440]");
+    }
+    return this.reminderService.snooze(id, minutes);
+  }
+}

--- a/apps/backend/src/api/routes/routes.module.ts
+++ b/apps/backend/src/api/routes/routes.module.ts
@@ -41,6 +41,7 @@ import { CustomFieldsController } from "./custom-fields.controller";
 import { EnrichmentFeatureGuard } from "../guards/enrichment-feature.guard";
 import { InboxController } from "./inbox.controller";
 import { MessagingWebhookController } from "./messaging.webhook.controller";
+import { ReminderController } from "./reminder.controller";
 
 @Module({
   controllers: [
@@ -77,6 +78,7 @@ import { MessagingWebhookController } from "./messaging.webhook.controller";
     CustomFieldsController,
     InboxController,
     MessagingWebhookController,
+    ReminderController,
   ],
   providers: [EnrichmentFeatureGuard],
   imports: [

--- a/apps/frontend/src/components/layout/app-sidebar.tsx
+++ b/apps/frontend/src/components/layout/app-sidebar.tsx
@@ -51,7 +51,7 @@ import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { cn } from '@ringee/frontend-shared/lib/utils';
 
 /** Groups that require an active organization session */
-const ORG_ONLY_GROUPS = ['Outreach'];
+const ORG_ONLY_GROUPS = [''];
 
 /** Maps the English labels in the shared `navGroups` constant to translation keys. */
 const GROUP_LABEL_KEYS: Record<string, string> = {

--- a/apps/frontend/src/features/callbacks/components/callback-list.tsx
+++ b/apps/frontend/src/features/callbacks/components/callback-list.tsx
@@ -24,21 +24,26 @@ import { CalendarClock, X } from 'lucide-react';
 
 interface CallbackEntry {
   id: string;
-  campaignLeadId: string;
-  agentUserId: string;
+  userId: string;
+  organizationId: string | null;
+  contactId: string;
+  callId: string | null;
+  campaignLeadId: string | null;
   scheduledAt: string;
   note: string | null;
   status: string;
   completedAt: string | null;
-  campaignLead?: {
-    contact?: {
-      name: string;
-      phoneNumber: string;
-    };
-    campaign?: {
-      name: string;
-    };
+  contact: {
+    id: string;
+    name: string | null;
+    phoneNumber: string;
+    company: string | null;
   };
+  campaignLead: {
+    id: string;
+    campaignId: string;
+    campaign: { id: string; name: string };
+  } | null;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -121,10 +126,10 @@ export function CallbackList() {
                   <TableCell>
                     <div>
                       <div className="font-medium">
-                        {cb.campaignLead?.contact?.name || 'Unknown'}
+                        {cb.contact.name || 'Unknown'}
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        {cb.campaignLead?.contact?.phoneNumber}
+                        {cb.contact.phoneNumber}
                       </div>
                     </div>
                   </TableCell>

--- a/apps/frontend/src/features/calls/components/dialer.tsx
+++ b/apps/frontend/src/features/calls/components/dialer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import 'react-phone-number-input/style.css';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Card, CardHeader, CardContent } from '@ringee/frontend-shared/components/ui/card';
 import { Separator } from '@ringee/frontend-shared/components/ui/separator';
 import { Circle, Clock } from 'lucide-react';
@@ -10,9 +10,11 @@ import { useSearchParams } from 'next/navigation';
 import { useCreditStore } from '@/features/credit/store/credit.store';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
 import { useDialerStore } from '@/features/calls/store/dialer.store';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { DialPad } from './dialer.pad';
 import { ContactSelector } from './contact.selector';
 import { NumberSelector } from './number.selector';
+import { DncWarningModal } from './dnc-warning-modal';
 import { cn } from '@ringee/frontend-shared/lib/utils';
 import { useTelnyxStore } from '../store/telnyx.store';
 import { useCall } from '../hooks/use.call';
@@ -26,6 +28,20 @@ export enum CallStatus {
   recording = 'recording',
   completed = 'completed',
   failed = 'failed'
+}
+
+interface DncCheckResponse {
+  phoneNumber: string;
+  isOnDNC: boolean;
+  reason: string | null;
+  source: string | null;
+  addedAt: string | null;
+}
+
+interface PendingDncDialog {
+  phoneNumber: string;
+  reason: string | null;
+  addedAt: string | null;
 }
 
 export function Dialer({
@@ -43,6 +59,10 @@ export function Dialer({
   const { canAccessAdminFeatures } = useMock
     ? { canAccessAdminFeatures: true }
     : useOrgRole();
+  const api = useApi();
+
+  const [dncDialog, setDncDialog] = useState<PendingDncDialog | null>(null);
+  const [checkingDnc, setCheckingDnc] = useState(false);
 
   const phoneNumberSelected = searchParams.get('phoneNumber');
   const status = activeCall?.state || CallStatus.idle;
@@ -56,71 +76,119 @@ export function Dialer({
     if (phoneNumberSelected) setNumber(`+${phoneNumberSelected.trim()}`);
   }, [phoneNumberSelected]);
 
-  return (
-    <div
-      className={cn('', {
-        'cursor-not-allowed opacity-50': !useMock && !client?.connected,
-        'grid grid-cols-1 md:grid-cols-3': !full,
-        'w-full': full
-      })}
-    >
-      <Card className='@container/card'>
-        <CardHeader className='flex items-center justify-between pb-3'>
-          {canAccessAdminFeatures && balanceStatus === 'success' ? (
-            <div className='flex items-center gap-2'>
-              {freeCallTrial ? (
-                <div className='flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2'>
-                  <Clock className='h-4 w-4 shrink-0 text-amber-500' />
-                  <div>
-                    <p className='text-sm font-semibold text-amber-600 dark:text-amber-400'>
-                      🎉 Free trial call available
-                    </p>
-                    <p className='text-muted-foreground text-xs'>
-                      Limited to 1 minute — call ends automatically
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <p className='text-muted-foreground text-sm'>Balance</p>
-                  <p className='text-base font-semibold'>
-                    ${balance.toFixed(2)}
-                  </p>
-                </>
-              )}
-            </div>
-          ) : canAccessAdminFeatures ? (
-            <Skeleton className='h-4 w-42' />
-          ) : (
-            <div />
-          )}
-          <Circle className={`h-3 w-3`} />
-        </CardHeader>
+  // Mock mode bypasses the DNC check — no backend available.
+  async function attemptCall(targetNumber: string) {
+    if (!targetNumber) return;
 
-        <CardContent className='space-y-3'>
-          <NumberSelector useMock={useMock} />
-          <Separator className='opacity-10' />
-          <ContactSelector number={number} onSelectNumber={setNumber} />
-          <Separator className='opacity-10' />
-          <PhoneInput
-            international
-            defaultCountry='US'
-            placeholder='Enter number'
-            // @ts-ignore
-            value={number}
-            onChange={(v) => setNumber(v || '')}
-            className='bg-background w-full rounded-md border-none text-center text-lg tracking-widest focus:outline-none'
-          />
-          <DialPad
-            number={number}
-            setNumber={setNumber}
-            onDelete={() => setNumber(number.slice(0, -1))}
-            onCall={async () => await handleCall(number)}
-            isCalling={isCalling}
-            showCreditPopover={canAccessAdminFeatures && !freeCallTrial && balance <= 0}
-          />
-        </CardContent>
-      </Card>
-    </div>
+    if (useMock) {
+      await handleCall(targetNumber);
+      return;
+    }
+
+    setCheckingDnc(true);
+    try {
+      const res = await api.get<DncCheckResponse>(
+        `/dnc/check/${encodeURIComponent(targetNumber)}`
+      );
+      if (res?.isOnDNC) {
+        setDncDialog({
+          phoneNumber: targetNumber,
+          reason: res.reason,
+          addedAt: res.addedAt
+        });
+        return;
+      }
+    } catch (err) {
+      // DNC check is best-effort: a 4xx/5xx must NOT block legitimate calls.
+      // Compliance is a backstop, not a single point of failure.
+      console.warn('DNC check failed, proceeding with call', err);
+    } finally {
+      setCheckingDnc(false);
+    }
+
+    await handleCall(targetNumber);
+  }
+
+  return (
+    <>
+      <div
+        className={cn('', {
+          'cursor-not-allowed opacity-50': !useMock && !client?.connected,
+          'grid grid-cols-1 md:grid-cols-3': !full,
+          'w-full': full
+        })}
+      >
+        <Card className='@container/card'>
+          <CardHeader className='flex items-center justify-between pb-3'>
+            {canAccessAdminFeatures && balanceStatus === 'success' ? (
+              <div className='flex items-center gap-2'>
+                {freeCallTrial ? (
+                  <div className='flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2'>
+                    <Clock className='h-4 w-4 shrink-0 text-amber-500' />
+                    <div>
+                      <p className='text-sm font-semibold text-amber-600 dark:text-amber-400'>
+                        🎉 Free trial call available
+                      </p>
+                      <p className='text-muted-foreground text-xs'>
+                        Limited to 1 minute — call ends automatically
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <p className='text-muted-foreground text-sm'>Balance</p>
+                    <p className='text-base font-semibold'>
+                      ${balance.toFixed(2)}
+                    </p>
+                  </>
+                )}
+              </div>
+            ) : canAccessAdminFeatures ? (
+              <Skeleton className='h-4 w-42' />
+            ) : (
+              <div />
+            )}
+            <Circle className={`h-3 w-3`} />
+          </CardHeader>
+
+          <CardContent className='space-y-3'>
+            <NumberSelector useMock={useMock} />
+            <Separator className='opacity-10' />
+            <ContactSelector number={number} onSelectNumber={setNumber} />
+            <Separator className='opacity-10' />
+            <PhoneInput
+              international
+              defaultCountry='US'
+              placeholder='Enter number'
+              // @ts-ignore
+              value={number}
+              onChange={(v) => setNumber(v || '')}
+              className='bg-background w-full rounded-md border-none text-center text-lg tracking-widest focus:outline-none'
+            />
+            <DialPad
+              number={number}
+              setNumber={setNumber}
+              onDelete={() => setNumber(number.slice(0, -1))}
+              onCall={async () => await attemptCall(number)}
+              isCalling={isCalling || checkingDnc}
+              showCreditPopover={canAccessAdminFeatures && !freeCallTrial && balance <= 0}
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      <DncWarningModal
+        open={dncDialog !== null}
+        phoneNumber={dncDialog?.phoneNumber ?? null}
+        reason={dncDialog?.reason}
+        addedAt={dncDialog?.addedAt}
+        onCancel={() => setDncDialog(null)}
+        onCallAnyway={async () => {
+          const target = dncDialog?.phoneNumber;
+          setDncDialog(null);
+          if (target) await handleCall(target);
+        }}
+      />
+    </>
   );
 }

--- a/apps/frontend/src/features/calls/components/dnc-warning-modal.tsx
+++ b/apps/frontend/src/features/calls/components/dnc-warning-modal.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@ringee/frontend-shared/components/ui/alert-dialog';
+import { ShieldAlert } from 'lucide-react';
+
+interface DncWarningModalProps {
+  open: boolean;
+  phoneNumber: string | null;
+  reason?: string | null;
+  addedAt?: string | null;
+  onCallAnyway: () => void;
+  onCancel: () => void;
+}
+
+export function DncWarningModal({
+  open,
+  phoneNumber,
+  reason,
+  addedAt,
+  onCallAnyway,
+  onCancel
+}: DncWarningModalProps) {
+  const t = useTranslations('dialer.dnc');
+
+  const formattedDate = addedAt
+    ? new Date(addedAt).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      })
+    : null;
+
+  return (
+    <AlertDialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className='flex items-start gap-3'>
+            <span className='bg-destructive/10 text-destructive flex h-10 w-10 shrink-0 items-center justify-center rounded-full'>
+              <ShieldAlert className='h-5 w-5' />
+            </span>
+            <div className='space-y-1'>
+              <AlertDialogTitle className='text-left'>
+                {t('title')}
+              </AlertDialogTitle>
+              {phoneNumber ? (
+                <p className='text-muted-foreground text-left font-mono text-sm'>
+                  {phoneNumber}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <AlertDialogDescription asChild>
+            <div className='space-y-3 pt-2 text-left'>
+              <p className='text-muted-foreground text-sm'>
+                {t('description')}
+              </p>
+
+              {reason || formattedDate ? (
+                <div className='bg-muted/50 space-y-1 rounded-md border px-3 py-2 text-xs'>
+                  {reason ? (
+                    <div>
+                      <span className='text-foreground font-medium'>
+                        {t('reasonLabel')}:
+                      </span>{' '}
+                      <span className='text-muted-foreground'>{reason}</span>
+                    </div>
+                  ) : null}
+                  {formattedDate ? (
+                    <div>
+                      <span className='text-foreground font-medium'>
+                        {t('addedLabel')}:
+                      </span>{' '}
+                      <span className='text-muted-foreground'>
+                        {formattedDate}
+                      </span>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              <p className='text-muted-foreground text-xs italic'>
+                {t('compliance')}
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>
+            {t('doNotCall')}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onCallAnyway}
+            className='bg-destructive text-destructive-foreground hover:bg-destructive/90 focus:ring-destructive/40'
+          >
+            {t('callAnyway')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/frontend/src/features/calls/components/post-call.view.tsx
+++ b/apps/frontend/src/features/calls/components/post-call.view.tsx
@@ -6,6 +6,7 @@ import { cn } from '@ringee/frontend-shared/lib/utils';
 import { useCallStore, type CallOutcome } from '../store/call.store';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import {
   CalendarCheck,
@@ -18,9 +19,11 @@ import {
   ShieldAlert,
   Loader2,
   DollarSign,
-  Check
+  Check,
+  PhoneCall
 } from 'lucide-react';
 import { BookMeetingForm } from './book-meeting.form';
+import { ScheduleCallbackForm } from './schedule-callback.form';
 
 const OUTCOMES: {
   id: CallOutcome;
@@ -54,6 +57,13 @@ const OUTCOMES: {
     id: 'follow_up',
     label: 'Follow Up',
     icon: Clock,
+    color: 'text-amber-500',
+    bgActive: 'bg-amber-500/10 border-amber-500 text-amber-600 ring-1 ring-amber-500/20'
+  },
+  {
+    id: 'callback_scheduled',
+    label: 'Schedule Callback',
+    icon: PhoneCall,
     color: 'text-amber-500',
     bgActive: 'bg-amber-500/10 border-amber-500 text-amber-600 ring-1 ring-amber-500/20'
   },
@@ -103,6 +113,7 @@ export function PostCallView({ onClose }: PostCallViewProps) {
     outcome,
     outcomeNote,
     meetingBooked,
+    callbackScheduled,
     callDuration,
     callContactName,
     callContactId,
@@ -110,11 +121,14 @@ export function PostCallView({ onClose }: PostCallViewProps) {
     callSessionId,
     setOutcome,
     setOutcomeNote,
-    setMeetingBooked
+    setMeetingBooked,
+    setCallbackScheduled
   } = useCallStore();
   const api = useApi();
+  const t = useTranslations('calls.callbacks');
   const [isSaving, setIsSaving] = useState(false);
   const [showBooking, setShowBooking] = useState(false);
+  const [showCallback, setShowCallback] = useState(false);
 
   const durationLabel = `${Math.floor(callDuration / 60)}:${(callDuration % 60).toString().padStart(2, '0')}`;
 
@@ -142,6 +156,22 @@ export function PostCallView({ onClose }: PostCallViewProps) {
   const handleMeetingBooked = () => {
     setMeetingBooked(true);
     setShowBooking(false);
+  };
+
+  const handleCallbackScheduled = () => {
+    setCallbackScheduled(true);
+    setShowCallback(false);
+  };
+
+  const handleOutcomeClick = (id: CallOutcome) => {
+    setOutcome(id);
+    // Selecting `callback_scheduled` immediately opens the date/time picker.
+    // Deselecting it (or picking something else) hides the form.
+    if (id === 'callback_scheduled') {
+      if (!callbackScheduled) setShowCallback(true);
+    } else if (showCallback) {
+      setShowCallback(false);
+    }
   };
 
   const showBookingPrompt =
@@ -172,6 +202,16 @@ export function PostCallView({ onClose }: PostCallViewProps) {
         </div>
       )}
 
+      {/* Callback scheduled badge */}
+      {callbackScheduled && (
+        <div className='flex items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5'>
+          <PhoneCall className='h-4 w-4 text-amber-500' />
+          <span className='text-sm font-medium text-amber-600'>
+            {t('badge')}
+          </span>
+        </div>
+      )}
+
       {/* Outcomes */}
       <div className='flex flex-col gap-3 mb-2'>
         <p className='text-xs font-medium uppercase tracking-wider text-muted-foreground'>Successful Outcomes</p>
@@ -182,7 +222,7 @@ export function PostCallView({ onClose }: PostCallViewProps) {
             return (
               <button
                 key={o.id}
-                onClick={() => setOutcome(o.id)}
+                onClick={() => handleOutcomeClick(o.id)}
                 className={cn(
                   'flex items-center gap-3 rounded-xl border p-3 text-sm font-semibold transition-all duration-200 active:scale-95',
                   isSelected
@@ -207,7 +247,7 @@ export function PostCallView({ onClose }: PostCallViewProps) {
             return (
               <button
                 key={o.id}
-                onClick={() => setOutcome(o.id)}
+                onClick={() => handleOutcomeClick(o.id)}
                 className={cn(
                   'flex flex-col items-center gap-1.5 rounded-lg border px-2 py-3 text-xs font-medium transition-all duration-200 active:scale-95',
                   isSelected
@@ -216,7 +256,9 @@ export function PostCallView({ onClose }: PostCallViewProps) {
                 )}
               >
                 <Icon className={cn('h-4 w-4 mb-0.5', isSelected ? '' : o.color)} />
-                <span className='leading-tight text-center'>{o.label}</span>
+                <span className='leading-tight text-center'>
+                  {o.id === 'callback_scheduled' ? t('disposition') : o.label}
+                </span>
               </button>
             );
           })}
@@ -244,6 +286,16 @@ export function PostCallView({ onClose }: PostCallViewProps) {
         />
       )}
 
+      {/* Inline callback scheduling form */}
+      {showCallback && callContactId && (
+        <ScheduleCallbackForm
+          contactId={callContactId}
+          callId={callId}
+          onScheduled={handleCallbackScheduled}
+          onCancel={() => setShowCallback(false)}
+        />
+      )}
+
       {/* Note */}
       <Textarea
         placeholder='Add a quick note...'
@@ -263,7 +315,11 @@ export function PostCallView({ onClose }: PostCallViewProps) {
         </button>
         <Button
           onClick={handleSave}
-          disabled={!outcome || isSaving}
+          disabled={
+            !outcome ||
+            isSaving ||
+            (outcome === 'callback_scheduled' && !callbackScheduled)
+          }
           className='flex-1'
           size='sm'
         >

--- a/apps/frontend/src/features/calls/components/schedule-callback.form.tsx
+++ b/apps/frontend/src/features/calls/components/schedule-callback.form.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { Input } from '@ringee/frontend-shared/components/ui/input';
+import { Textarea } from '@ringee/frontend-shared/components/ui/textarea';
+import { cn } from '@ringee/frontend-shared/lib/utils';
+import {
+  addDays,
+  addMinutes,
+  format,
+  isSameDay,
+  setHours,
+  setMinutes,
+  setSeconds,
+  startOfToday
+} from 'date-fns';
+import { ChevronLeft, ChevronRight, Loader2, PhoneCall } from 'lucide-react';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import { toast } from 'sonner';
+
+interface ScheduleCallbackFormProps {
+  contactId: string;
+  callId?: string | null;
+  onScheduled: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Default to "30 minutes from now, rounded to the next 15-min slot" so the
+ * picker lands on a sensible value rather than midnight.
+ */
+function defaultCallbackTime(): Date {
+  const now = addMinutes(new Date(), 30);
+  const rounded = setSeconds(now, 0);
+  const minutes = rounded.getMinutes();
+  const bump = (15 - (minutes % 15)) % 15;
+  return setMinutes(rounded, minutes + bump);
+}
+
+export function ScheduleCallbackForm({
+  contactId,
+  callId,
+  onScheduled,
+  onCancel
+}: ScheduleCallbackFormProps) {
+  const t = useTranslations('calls.callbacks.form');
+  const api = useApi();
+
+  const initial = defaultCallbackTime();
+  const [weekStart, setWeekStart] = useState(startOfToday());
+  const [selectedDate, setSelectedDate] = useState<Date>(initial);
+  const [time, setTime] = useState<string>(format(initial, 'HH:mm'));
+  const [note, setNote] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  const buildScheduledAt = (): Date | null => {
+    const [hours, minutes] = time.split(':').map(Number);
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null;
+    return setSeconds(setMinutes(setHours(selectedDate, hours), minutes), 0);
+  };
+
+  const handleSubmit = async () => {
+    const scheduledAt = buildScheduledAt();
+    if (!scheduledAt) {
+      toast.error(t('errors.invalidTime'));
+      return;
+    }
+    if (scheduledAt.getTime() <= Date.now()) {
+      toast.error(t('errors.mustBeFuture'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await api.post('/callbacks', {
+        contactId,
+        callId: callId || undefined,
+        scheduledAt: scheduledAt.toISOString(),
+        note: note.trim() || undefined
+      });
+      toast.success(
+        t('success', {
+          date: format(scheduledAt, 'EEE, MMM d'),
+          time: format(scheduledAt, 'h:mm a')
+        })
+      );
+      onScheduled();
+    } catch {
+      toast.error(t('errors.saveFailed'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const prevWeek = () => setWeekStart((d) => addDays(d, -7));
+  const nextWeek = () => setWeekStart((d) => addDays(d, 7));
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {/* Day strip */}
+      <div className='flex items-center gap-1'>
+        <button
+          onClick={prevWeek}
+          className='text-muted-foreground hover:text-foreground flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors'
+          disabled={isSameDay(weekStart, startOfToday())}
+          type='button'
+        >
+          <ChevronLeft className='h-4 w-4' />
+        </button>
+
+        <div className='flex flex-1 gap-1'>
+          {days.map((day) => {
+            const isSelected = isSameDay(day, selectedDate);
+            const isPast = day < startOfToday();
+            return (
+              <button
+                key={day.toISOString()}
+                disabled={isPast}
+                onClick={() => setSelectedDate(day)}
+                type='button'
+                className={cn(
+                  'flex flex-1 flex-col items-center rounded-lg py-1.5 text-[10px] font-medium transition-all',
+                  isPast && 'cursor-not-allowed opacity-30',
+                  isSelected
+                    ? 'bg-primary text-primary-foreground shadow-sm'
+                    : 'hover:bg-muted/60'
+                )}
+              >
+                <span className='uppercase'>{format(day, 'EEE')}</span>
+                <span className='text-xs font-semibold'>{format(day, 'd')}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <button
+          onClick={nextWeek}
+          className='text-muted-foreground hover:text-foreground flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors'
+          type='button'
+        >
+          <ChevronRight className='h-4 w-4' />
+        </button>
+      </div>
+
+      {/* Time */}
+      <div className='space-y-1.5'>
+        <label className='text-muted-foreground block text-[10px] font-medium uppercase tracking-wider'>
+          {t('timeLabel')}
+        </label>
+        <Input
+          type='time'
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+          className='border-border/80 h-9 text-sm'
+        />
+      </div>
+
+      {/* Note */}
+      <div className='space-y-1.5'>
+        <label className='text-muted-foreground block text-[10px] font-medium uppercase tracking-wider'>
+          {t('noteLabel')}
+        </label>
+        <Textarea
+          placeholder={t('notePlaceholder')}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={2}
+          className='min-h-[48px] resize-none text-sm'
+        />
+      </div>
+
+      {/* Reminder hint */}
+      <p className='text-muted-foreground text-[11px] leading-snug'>
+        {t('reminderHint')}
+      </p>
+
+      {/* Actions */}
+      <div className='mt-1 flex gap-2'>
+        <Button
+          variant='ghost'
+          size='sm'
+          onClick={onCancel}
+          className='flex-1'
+          type='button'
+        >
+          {t('cancel')}
+        </Button>
+        <Button
+          size='sm'
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+          className='flex-1 bg-amber-600 text-white hover:bg-amber-700'
+          type='button'
+        >
+          {isSubmitting ? (
+            <Loader2 className='h-3.5 w-3.5 animate-spin' />
+          ) : (
+            <>
+              <PhoneCall className='mr-1.5 h-3.5 w-3.5' />
+              {t('confirm')}
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/calls/store/call.store.ts
+++ b/apps/frontend/src/features/calls/store/call.store.ts
@@ -7,6 +7,7 @@ export type CallOutcome =
   | 'sale'
   | 'interested'
   | 'follow_up'
+  | 'callback_scheduled'
   | 'not_interested'
   | 'no_answer'
   | 'voicemail'
@@ -25,6 +26,7 @@ interface CallState {
   outcome: CallOutcome | null;
   outcomeNote: string;
   meetingBooked: boolean;
+  callbackScheduled: boolean;
   callDuration: number;
   callContactName: string | null;
   callContactId: string | null;
@@ -55,6 +57,7 @@ interface CallState {
   setOutcome: (outcome: CallOutcome | null) => void;
   setOutcomeNote: (note: string) => void;
   setMeetingBooked: (booked: boolean) => void;
+  setCallbackScheduled: (scheduled: boolean) => void;
   setBookingPanelOpen: (open: boolean) => void;
   reset: () => void;
 }
@@ -68,6 +71,7 @@ const initialState = {
   outcome: null,
   outcomeNote: '',
   meetingBooked: false,
+  callbackScheduled: false,
   callDuration: 0,
   callContactName: null,
   callContactId: null,
@@ -105,6 +109,11 @@ export const useCallStore = create<CallState>((set) => ({
     set({
       meetingBooked: booked,
       outcome: booked ? 'meeting_booked' : null
+    }),
+  setCallbackScheduled: (scheduled) =>
+    set({
+      callbackScheduled: scheduled,
+      outcome: scheduled ? 'callback_scheduled' : null
     }),
   setBookingPanelOpen: (open) => set({ bookingPanelOpen: open }),
   reset: () => set(initialState)

--- a/apps/frontend/src/i18n/locales/de/calls.json
+++ b/apps/frontend/src/i18n/locales/de/calls.json
@@ -98,7 +98,23 @@
     "title": "Rückrufe",
     "description": "Geplante Rückrufe aus Dialer-Sitzungen einsehen und verwalten",
     "metaTitle": "Rückrufe | Ringee",
-    "metaDescription": "Geplante Rückrufaufgaben einsehen und verwalten."
+    "metaDescription": "Geplante Rückrufaufgaben einsehen und verwalten.",
+    "disposition": "Rückruf planen",
+    "badge": "Rückruf während des Gesprächs geplant",
+    "form": {
+      "timeLabel": "Uhrzeit",
+      "noteLabel": "Notiz (optional)",
+      "notePlaceholder": "Was haben Sie vereinbart?",
+      "reminderHint": "Wir senden Ihnen 15 und 5 Minuten vorher eine Erinnerung per E-Mail.",
+      "cancel": "Abbrechen",
+      "confirm": "Rückruf planen",
+      "success": "Rückruf geplant — {date} um {time}",
+      "errors": {
+        "invalidTime": "Wählen Sie eine gültige Uhrzeit",
+        "mustBeFuture": "Wählen Sie eine Uhrzeit in der Zukunft",
+        "saveFailed": "Rückruf konnte nicht geplant werden"
+      }
+    }
   },
   "dnc": {
     "title": "Nicht anrufen",

--- a/apps/frontend/src/i18n/locales/de/dialer.json
+++ b/apps/frontend/src/i18n/locales/de/dialer.json
@@ -22,5 +22,14 @@
     "title": "Dialer-Sitzung",
     "remaining": "{count} verbleibend",
     "completed": "{count} abgeschlossen"
+  },
+  "dnc": {
+    "title": "Diese Nummer steht auf Ihrer Nicht-anrufen-Liste",
+    "description": "Dieser Kontakt wurde zuvor als „Nicht anrufen“ markiert. Diesen Anruf zu tätigen, könnte gegen Compliance-Regeln und die Richtlinie Ihrer Organisation verstoßen.",
+    "reasonLabel": "Grund",
+    "addedLabel": "Hinzugefügt am",
+    "compliance": "Rufen Sie nur an, wenn Sie einen legitimen Grund und die Zustimmung des Empfängers haben.",
+    "doNotCall": "Nicht anrufen",
+    "callAnyway": "Trotzdem anrufen"
   }
 }

--- a/apps/frontend/src/i18n/locales/en/calls.json
+++ b/apps/frontend/src/i18n/locales/en/calls.json
@@ -108,7 +108,23 @@
     "title": "Callbacks",
     "description": "View and manage scheduled callbacks from dialer sessions",
     "metaTitle": "Callbacks | Ringee",
-    "metaDescription": "View and manage scheduled callback tasks."
+    "metaDescription": "View and manage scheduled callback tasks.",
+    "disposition": "Schedule Callback",
+    "badge": "Callback scheduled during call",
+    "form": {
+      "timeLabel": "Time",
+      "noteLabel": "Note (optional)",
+      "notePlaceholder": "What did you agree on?",
+      "reminderHint": "We'll email you a reminder 15 and 5 minutes before.",
+      "cancel": "Cancel",
+      "confirm": "Schedule callback",
+      "success": "Callback scheduled — {date} at {time}",
+      "errors": {
+        "invalidTime": "Please pick a valid time",
+        "mustBeFuture": "Pick a time in the future",
+        "saveFailed": "Couldn't schedule callback"
+      }
+    }
   },
   "dnc": {
     "title": "Do Not Call",

--- a/apps/frontend/src/i18n/locales/en/dialer.json
+++ b/apps/frontend/src/i18n/locales/en/dialer.json
@@ -22,5 +22,14 @@
     "title": "Dialer session",
     "remaining": "{count} remaining",
     "completed": "{count} completed"
+  },
+  "dnc": {
+    "title": "This number is on your Do Not Call list",
+    "description": "This contact was previously marked as Do Not Call. Placing this call could breach compliance rules and your organization's policy.",
+    "reasonLabel": "Reason",
+    "addedLabel": "Added on",
+    "compliance": "Only call if you have a legitimate reason and the recipient's consent.",
+    "doNotCall": "Don't call",
+    "callAnyway": "Call anyway"
   }
 }

--- a/apps/frontend/src/i18n/locales/es/calls.json
+++ b/apps/frontend/src/i18n/locales/es/calls.json
@@ -108,7 +108,23 @@
     "title": "Devoluciones de llamada",
     "description": "Consulta y gestiona las devoluciones programadas desde el marcador",
     "metaTitle": "Devoluciones | Ringee",
-    "metaDescription": "Consulta y gestiona las tareas de devolución de llamada programadas."
+    "metaDescription": "Consulta y gestiona las tareas de devolución de llamada programadas.",
+    "disposition": "Agendar devolución",
+    "badge": "Devolución agendada durante la llamada",
+    "form": {
+      "timeLabel": "Hora",
+      "noteLabel": "Nota (opcional)",
+      "notePlaceholder": "¿En qué quedaron?",
+      "reminderHint": "Te enviaremos un recordatorio por email 15 y 5 minutos antes.",
+      "cancel": "Cancelar",
+      "confirm": "Agendar devolución",
+      "success": "Devolución agendada — {date} a las {time}",
+      "errors": {
+        "invalidTime": "Elige una hora válida",
+        "mustBeFuture": "Elige una hora en el futuro",
+        "saveFailed": "No se pudo agendar la devolución"
+      }
+    }
   },
   "dnc": {
     "title": "No llamar",

--- a/apps/frontend/src/i18n/locales/es/dialer.json
+++ b/apps/frontend/src/i18n/locales/es/dialer.json
@@ -22,5 +22,14 @@
     "title": "Sesión del marcador",
     "remaining": "{count} pendientes",
     "completed": "{count} completados"
+  },
+  "dnc": {
+    "title": "Este número está en tu lista de No Llamar",
+    "description": "Este contacto fue marcado anteriormente como No Llamar. Continuar con esta llamada podría infringir las reglas de cumplimiento y la política de tu organización.",
+    "reasonLabel": "Motivo",
+    "addedLabel": "Añadido el",
+    "compliance": "Llama únicamente si tienes un motivo legítimo y el consentimiento del destinatario.",
+    "doNotCall": "No llamar",
+    "callAnyway": "Llamar de todos modos"
   }
 }

--- a/apps/frontend/src/i18n/locales/fr/calls.json
+++ b/apps/frontend/src/i18n/locales/fr/calls.json
@@ -98,7 +98,23 @@
     "title": "Rappels",
     "description": "Consultez et gérez les rappels planifiés depuis le composeur",
     "metaTitle": "Rappels | Ringee",
-    "metaDescription": "Consultez et gérez les tâches de rappel planifiées."
+    "metaDescription": "Consultez et gérez les tâches de rappel planifiées.",
+    "disposition": "Planifier un rappel",
+    "badge": "Rappel planifié pendant l'appel",
+    "form": {
+      "timeLabel": "Heure",
+      "noteLabel": "Note (facultative)",
+      "notePlaceholder": "Qu'avez-vous convenu ?",
+      "reminderHint": "Nous vous enverrons un rappel par e-mail 15 et 5 minutes avant.",
+      "cancel": "Annuler",
+      "confirm": "Planifier le rappel",
+      "success": "Rappel planifié — {date} à {time}",
+      "errors": {
+        "invalidTime": "Choisissez une heure valide",
+        "mustBeFuture": "Choisissez une heure dans le futur",
+        "saveFailed": "Impossible de planifier le rappel"
+      }
+    }
   },
   "dnc": {
     "title": "Ne pas appeler",

--- a/apps/frontend/src/i18n/locales/fr/dialer.json
+++ b/apps/frontend/src/i18n/locales/fr/dialer.json
@@ -22,5 +22,14 @@
     "title": "Session du composeur",
     "remaining": "{count} restants",
     "completed": "{count} terminés"
+  },
+  "dnc": {
+    "title": "Ce numéro figure sur votre liste « Ne pas appeler »",
+    "description": "Ce contact a déjà été marqué comme « Ne pas appeler ». Poursuivre cet appel pourrait enfreindre les règles de conformité et la politique de votre organisation.",
+    "reasonLabel": "Motif",
+    "addedLabel": "Ajouté le",
+    "compliance": "N'appelez que si vous avez un motif légitime et le consentement du destinataire.",
+    "doNotCall": "Ne pas appeler",
+    "callAnyway": "Appeler quand même"
   }
 }

--- a/apps/frontend/src/i18n/locales/it/calls.json
+++ b/apps/frontend/src/i18n/locales/it/calls.json
@@ -98,7 +98,23 @@
     "title": "Richiami",
     "description": "Visualizza e gestisci i richiami pianificati dal dialer",
     "metaTitle": "Richiami | Ringee",
-    "metaDescription": "Visualizza e gestisci le attività di richiamo pianificate."
+    "metaDescription": "Visualizza e gestisci le attività di richiamo pianificate.",
+    "disposition": "Pianifica richiamo",
+    "badge": "Richiamo pianificato durante la chiamata",
+    "form": {
+      "timeLabel": "Ora",
+      "noteLabel": "Nota (facoltativa)",
+      "notePlaceholder": "Cosa avete concordato?",
+      "reminderHint": "Ti invieremo un promemoria via email 15 e 5 minuti prima.",
+      "cancel": "Annulla",
+      "confirm": "Pianifica richiamo",
+      "success": "Richiamo pianificato — {date} alle {time}",
+      "errors": {
+        "invalidTime": "Scegli un orario valido",
+        "mustBeFuture": "Scegli un orario nel futuro",
+        "saveFailed": "Impossibile pianificare il richiamo"
+      }
+    }
   },
   "dnc": {
     "title": "Non chiamare",

--- a/apps/frontend/src/i18n/locales/it/dialer.json
+++ b/apps/frontend/src/i18n/locales/it/dialer.json
@@ -22,5 +22,14 @@
     "title": "Sessione dialer",
     "remaining": "{count} rimanenti",
     "completed": "{count} completati"
+  },
+  "dnc": {
+    "title": "Questo numero è nella tua lista Non Chiamare",
+    "description": "Questo contatto è stato precedentemente contrassegnato come Non Chiamare. Effettuare questa chiamata potrebbe violare le regole di conformità e la politica della tua organizzazione.",
+    "reasonLabel": "Motivo",
+    "addedLabel": "Aggiunto il",
+    "compliance": "Chiama solo se hai un motivo legittimo e il consenso del destinatario.",
+    "doNotCall": "Non chiamare",
+    "callAnyway": "Chiama comunque"
   }
 }

--- a/apps/frontend/src/i18n/locales/nl/calls.json
+++ b/apps/frontend/src/i18n/locales/nl/calls.json
@@ -98,7 +98,23 @@
     "title": "Terugbelverzoeken",
     "description": "Bekijk en beheer geplande terugbelverzoeken vanuit dialer-sessies",
     "metaTitle": "Terugbelverzoeken | Ringee",
-    "metaDescription": "Bekijk en beheer geplande terugbeltaken."
+    "metaDescription": "Bekijk en beheer geplande terugbeltaken.",
+    "disposition": "Terugbelverzoek plannen",
+    "badge": "Terugbelverzoek tijdens gesprek gepland",
+    "form": {
+      "timeLabel": "Tijd",
+      "noteLabel": "Notitie (optioneel)",
+      "notePlaceholder": "Wat hebben jullie afgesproken?",
+      "reminderHint": "We sturen je 15 en 5 minuten van tevoren een herinnering per e-mail.",
+      "cancel": "Annuleren",
+      "confirm": "Terugbelverzoek plannen",
+      "success": "Terugbelverzoek gepland — {date} om {time}",
+      "errors": {
+        "invalidTime": "Kies een geldige tijd",
+        "mustBeFuture": "Kies een tijd in de toekomst",
+        "saveFailed": "Terugbelverzoek kon niet worden gepland"
+      }
+    }
   },
   "dnc": {
     "title": "Niet bellen",

--- a/apps/frontend/src/i18n/locales/nl/dialer.json
+++ b/apps/frontend/src/i18n/locales/nl/dialer.json
@@ -22,5 +22,14 @@
     "title": "Dialer-sessie",
     "remaining": "{count} resterend",
     "completed": "{count} voltooid"
+  },
+  "dnc": {
+    "title": "Dit nummer staat op je Niet-bellen-lijst",
+    "description": "Dit contact is eerder gemarkeerd als Niet bellen. Doorgaan met dit gesprek kan in strijd zijn met compliance-regels en het beleid van je organisatie.",
+    "reasonLabel": "Reden",
+    "addedLabel": "Toegevoegd op",
+    "compliance": "Bel alleen als je een legitieme reden en de toestemming van de ontvanger hebt.",
+    "doNotCall": "Niet bellen",
+    "callAnyway": "Toch bellen"
   }
 }

--- a/apps/frontend/src/i18n/locales/pt/calls.json
+++ b/apps/frontend/src/i18n/locales/pt/calls.json
@@ -98,7 +98,23 @@
     "title": "Retornos de chamada",
     "description": "Consulte e gira retornos agendados a partir das sessões do marcador",
     "metaTitle": "Retornos de chamada | Ringee",
-    "metaDescription": "Consulte e gira tarefas de retorno de chamada agendadas."
+    "metaDescription": "Consulte e gira tarefas de retorno de chamada agendadas.",
+    "disposition": "Agendar retorno",
+    "badge": "Retorno agendado durante a chamada",
+    "form": {
+      "timeLabel": "Hora",
+      "noteLabel": "Nota (opcional)",
+      "notePlaceholder": "O que combinaram?",
+      "reminderHint": "Enviaremos um lembrete por e-mail 15 e 5 minutos antes.",
+      "cancel": "Cancelar",
+      "confirm": "Agendar retorno",
+      "success": "Retorno agendado — {date} às {time}",
+      "errors": {
+        "invalidTime": "Escolha uma hora válida",
+        "mustBeFuture": "Escolha uma hora no futuro",
+        "saveFailed": "Não foi possível agendar o retorno"
+      }
+    }
   },
   "dnc": {
     "title": "Não ligar",

--- a/apps/frontend/src/i18n/locales/pt/dialer.json
+++ b/apps/frontend/src/i18n/locales/pt/dialer.json
@@ -22,5 +22,14 @@
     "title": "Sessão do marcador",
     "remaining": "{count} em falta",
     "completed": "{count} concluídos"
+  },
+  "dnc": {
+    "title": "Este número está na sua lista Não Ligar",
+    "description": "Este contacto foi marcado anteriormente como Não Ligar. Prosseguir com esta chamada pode violar as regras de conformidade e a política da sua organização.",
+    "reasonLabel": "Motivo",
+    "addedLabel": "Adicionado em",
+    "compliance": "Ligue apenas se tiver um motivo legítimo e o consentimento do destinatário.",
+    "doNotCall": "Não ligar",
+    "callAnyway": "Ligar mesmo assim"
   }
 }

--- a/apps/worker/src/woorker.service.ts
+++ b/apps/worker/src/woorker.service.ts
@@ -15,6 +15,7 @@ import {
   CrmCallLogService,
   CrmRecordingUploadService,
   EnrichmentDrainService,
+  ReminderService,
 } from "@ringee/services";
 import {
   UserRepository,
@@ -33,6 +34,7 @@ const CRM_DRAIN_BATCH_SIZE = 25;
 const CRM_BULK_SYNC_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const ENRICHMENT_DRAIN_INTERVAL_MS = 5_000; // 5 seconds
 const ENRICHMENT_DRAIN_BATCH_SIZE = 25;
+const REMINDER_INTERVAL_MS = 30_000; // 30 seconds
 
 @Injectable()
 export class WorkerService implements OnModuleInit, OnModuleDestroy {
@@ -58,6 +60,7 @@ export class WorkerService implements OnModuleInit, OnModuleDestroy {
     private readonly publicRecordingRepo: PublicRecordingRepository,
     private readonly enrichmentDrainService: EnrichmentDrainService,
     private readonly crmRecordingUpload: CrmRecordingUploadService,
+    private readonly reminderService: ReminderService,
   ) { }
 
   onModuleInit() {
@@ -77,6 +80,7 @@ export class WorkerService implements OnModuleInit, OnModuleDestroy {
       setInterval(() => this.runCrmDrain(), CRM_DRAIN_INTERVAL_MS),
       setInterval(() => this.crmBulkSyncService.syncAllActiveConnections(), CRM_BULK_SYNC_INTERVAL_MS),
       setInterval(() => this.runEnrichmentDrain(), ENRICHMENT_DRAIN_INTERVAL_MS),
+      setInterval(() => this.runReminderScheduler(), REMINDER_INTERVAL_MS),
     );
     this.logger.log("Outbound schedulers started");
   }
@@ -153,6 +157,23 @@ export class WorkerService implements OnModuleInit, OnModuleDestroy {
       this.logger.error("EnrichmentDrain error:", err);
     } finally {
       this.enrichmentDrainInFlight = false;
+    }
+  }
+
+  private reminderInFlight = false;
+
+  private async runReminderScheduler() {
+    if (this.reminderInFlight) return;
+    this.reminderInFlight = true;
+    try {
+      const count = await this.reminderService.processDuePending();
+      if (count > 0) {
+        this.logger.debug(`ReminderScheduler: ${count} reminders dispatched`);
+      }
+    } catch (err) {
+      this.logger.error("ReminderScheduler error:", err);
+    } finally {
+      this.reminderInFlight = false;
     }
   }
 

--- a/packages/database/prisma/migrations-pending/20260513000000_callback_freelancer/migration.sql
+++ b/packages/database/prisma/migrations-pending/20260513000000_callback_freelancer/migration.sql
@@ -1,0 +1,50 @@
+-- CallbackTask: freelancer support
+-- Decouples callbacks from campaigns so they can be created from any contact/call,
+-- in either freelancer (organizationId NULL) or organization context.
+
+-- 1. New columns (nullable for backfill)
+ALTER TABLE "CallbackTask"
+  ADD COLUMN "userId"         UUID,
+  ADD COLUMN "organizationId" UUID,
+  ADD COLUMN "contactId"      UUID,
+  ADD COLUMN "callId"         UUID;
+
+-- 2. Backfill: userId = agentUserId; contactId/organizationId from CampaignLead -> Campaign
+UPDATE "CallbackTask" SET "userId" = "agentUserId";
+
+UPDATE "CallbackTask" cb
+SET "contactId"      = cl."contactId",
+    "organizationId" = c."organizationId"
+FROM "CampaignLead" cl
+JOIN "Campaign" c ON c."id" = cl."campaignId"
+WHERE cb."campaignLeadId" = cl."id";
+
+-- 3. Enforce NOT NULL on userId / contactId (every legacy row must have been backfilled)
+ALTER TABLE "CallbackTask"
+  ALTER COLUMN "userId"    SET NOT NULL,
+  ALTER COLUMN "contactId" SET NOT NULL;
+
+-- 4. campaignLeadId becomes nullable for standalone callbacks
+ALTER TABLE "CallbackTask"
+  ALTER COLUMN "campaignLeadId" DROP NOT NULL;
+
+-- 5. Drop legacy column
+ALTER TABLE "CallbackTask" DROP COLUMN "agentUserId";
+
+-- 6. New FK constraints
+ALTER TABLE "CallbackTask"
+  ADD CONSTRAINT "CallbackTask_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE,
+  ADD CONSTRAINT "CallbackTask_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL,
+  ADD CONSTRAINT "CallbackTask_contactId_fkey"
+    FOREIGN KEY ("contactId") REFERENCES "Contact"("id") ON DELETE CASCADE,
+  ADD CONSTRAINT "CallbackTask_callId_fkey"
+    FOREIGN KEY ("callId") REFERENCES "Call"("id") ON DELETE SET NULL;
+
+-- 7. Indexes
+DROP INDEX IF EXISTS "CallbackTask_agentUserId_idx";
+CREATE INDEX "CallbackTask_userId_idx"         ON "CallbackTask"("userId");
+CREATE INDEX "CallbackTask_organizationId_idx" ON "CallbackTask"("organizationId");
+CREATE INDEX "CallbackTask_contactId_idx"      ON "CallbackTask"("contactId");
+CREATE INDEX "CallbackTask_callId_idx"         ON "CallbackTask"("callId");

--- a/packages/database/prisma/migrations-pending/20260513000100_dnc_freelancer/migration.sql
+++ b/packages/database/prisma/migrations-pending/20260513000100_dnc_freelancer/migration.sql
@@ -1,0 +1,56 @@
+-- DNCEntry: freelancer support
+-- Allows DNC entries to belong either to an organization (shared across the org)
+-- or to a single user (personal/freelancer scope). The validation rule lives in
+-- ComplianceService: the active call context decides which list to check —
+-- the two scopes are never mixed implicitly.
+
+-- 1. Add userId (nullable for backfill)
+ALTER TABLE "DNCEntry" ADD COLUMN "userId" UUID;
+
+-- 2. Backfill userId from addedByUserId where available; for rows missing both
+--    we fall back to the organization's creator. This is a best-effort backfill
+--    so the column can be marked NOT NULL — every legacy DNC row has an org.
+UPDATE "DNCEntry" d
+SET "userId" = COALESCE(
+  d."addedByUserId",
+  (SELECT om."userId"
+     FROM "OrganizationMembership" om
+    WHERE om."organizationId" = d."organizationId"
+      AND om."userId" IS NOT NULL
+    ORDER BY om."createdAt" ASC
+    LIMIT 1)
+)
+WHERE d."userId" IS NULL;
+
+-- Any row still null after backfill (no addedBy, no org member) cannot exist in
+-- a valid state. Delete defensively.
+DELETE FROM "DNCEntry" WHERE "userId" IS NULL;
+
+-- 3. Enforce NOT NULL on userId
+ALTER TABLE "DNCEntry" ALTER COLUMN "userId" SET NOT NULL;
+
+-- 4. organizationId becomes nullable to allow personal DNC entries
+ALTER TABLE "DNCEntry" ALTER COLUMN "organizationId" DROP NOT NULL;
+
+-- 5. Drop the old org-scoped unique constraint
+ALTER TABLE "DNCEntry" DROP CONSTRAINT IF EXISTS "DNCEntry_organizationId_phoneNumber_key";
+DROP INDEX IF EXISTS "DNCEntry_organizationId_phoneNumber_key";
+
+-- 6. Re-create uniqueness as partial indexes:
+--    organization DNC: dedupe within the org
+CREATE UNIQUE INDEX "DNCEntry_org_phone_unique"
+  ON "DNCEntry" ("organizationId", "phoneNumber")
+  WHERE "organizationId" IS NOT NULL;
+
+--    personal DNC: dedupe per user, ONLY for entries with no org
+CREATE UNIQUE INDEX "DNCEntry_user_phone_unique"
+  ON "DNCEntry" ("userId", "phoneNumber")
+  WHERE "organizationId" IS NULL;
+
+-- 7. FK on userId
+ALTER TABLE "DNCEntry"
+  ADD CONSTRAINT "DNCEntry_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE;
+
+-- 8. Index already declared via Prisma — add the new one for userId lookups
+CREATE INDEX IF NOT EXISTS "DNCEntry_userId_idx" ON "DNCEntry"("userId");

--- a/packages/database/prisma/migrations-pending/20260513000200_reminders/migration.sql
+++ b/packages/database/prisma/migrations-pending/20260513000200_reminders/migration.sql
@@ -1,0 +1,44 @@
+-- Reminders: scheduled notifications for callbacks, meetings, and follow-ups.
+-- Source of truth lives in this table; the worker polls pending rows whose
+-- fireAt has elapsed and dispatches them through the configured channels.
+
+-- CreateEnum
+CREATE TYPE "ReminderSubjectType" AS ENUM ('callback', 'meeting', 'followup');
+
+-- CreateEnum
+CREATE TYPE "ReminderStatus" AS ENUM ('pending', 'sent', 'failed', 'cancelled', 'snoozed');
+
+-- CreateTable
+CREATE TABLE "Reminder" (
+    "id"             UUID                  NOT NULL,
+    "userId"         UUID                  NOT NULL,
+    "organizationId" UUID,
+    "subjectType"    "ReminderSubjectType" NOT NULL,
+    "subjectId"      UUID                  NOT NULL,
+    "fireAt"         TIMESTAMP(3)          NOT NULL,
+    "channels"       TEXT[]                NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "status"         "ReminderStatus"      NOT NULL DEFAULT 'pending',
+    "attemptCount"   INTEGER               NOT NULL DEFAULT 0,
+    "lastError"      TEXT,
+    "sentAt"         TIMESTAMP(3),
+    "snoozedUntil"   TIMESTAMP(3),
+    "dedupeKey"      TEXT                  NOT NULL,
+    "createdAt"      TIMESTAMP(3)          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"      TIMESTAMP(3)          NOT NULL,
+
+    CONSTRAINT "Reminder_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "Reminder_dedupeKey_key"          ON "Reminder"("dedupeKey");
+CREATE INDEX        "Reminder_status_fireAt_idx"      ON "Reminder"("status", "fireAt");
+CREATE INDEX        "Reminder_userId_idx"             ON "Reminder"("userId");
+CREATE INDEX        "Reminder_organizationId_idx"     ON "Reminder"("organizationId");
+CREATE INDEX        "Reminder_subjectType_subjectId_idx" ON "Reminder"("subjectType", "subjectId");
+
+-- FKs
+ALTER TABLE "Reminder"
+  ADD CONSTRAINT "Reminder_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE,
+  ADD CONSTRAINT "Reminder_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL;

--- a/packages/database/prisma/migrations-pending/20260513000300_callback_outcome/migration.sql
+++ b/packages/database/prisma/migrations-pending/20260513000300_callback_outcome/migration.sql
@@ -1,0 +1,5 @@
+-- Add `callback_scheduled` to CallOutcome enum.
+-- Distinct from `follow_up` (qualitative) — this fires when the agent
+-- schedules an explicit callback time, mirroring the campaign dialer flow.
+
+ALTER TYPE "CallOutcome" ADD VALUE IF NOT EXISTS 'callback_scheduled';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -27,6 +27,7 @@ enum CallOutcome {
   sale
   interested
   follow_up
+  callback_scheduled
   not_interested
   no_answer
   voicemail

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -4,7 +4,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = "postgresql://ringee-user:ringee-password@localhost:5432/ringee-db-local?schema=public"
 }
 
 enum EmailStatus {
@@ -44,6 +44,20 @@ enum MeetingStatus {
   completed
   cancelled
   rescheduled
+}
+
+enum ReminderSubjectType {
+  callback
+  meeting
+  followup
+}
+
+enum ReminderStatus {
+  pending
+  sent
+  failed
+  cancelled
+  snoozed
 }
 
 enum SubscriptionStatus {
@@ -293,6 +307,9 @@ model User {
   enrichmentJobs          EnrichmentJob[]
   leadSearchJobs          LeadSearchJob[]
   callScripts             CallScript[]
+  callbacks               CallbackTask[]
+  dncEntries              DNCEntry[]
+  reminders               Reminder[]
 
   @@index([clerkId])
 }
@@ -330,6 +347,9 @@ model Organization {
   leadSearchJobs         LeadSearchJob[]
   callScripts            CallScript[]
   customFieldDefinitions CustomFieldDefinition[]
+  callbacks              CallbackTask[]
+  dncEntries             DNCEntry[]
+  reminders              Reminder[]
 
   @@index([clerkId])
 }
@@ -459,6 +479,7 @@ model Call {
   callAttempts     CallAttempt[]
   crmSyncs         CrmCallSync[]
   inboxEvents      InboxEvent[]
+  callbacks        CallbackTask[]
 
   @@index([userId])
   @@index([organizationId])
@@ -667,6 +688,7 @@ model Contact {
   enrichmentJobs    EnrichmentJob[]
   inboxThreads      InboxThread[]
   messages          Message[]
+  callbacks         CallbackTask[]
 
   @@unique([userId, phoneNumber, deletedAt])
   @@index([userId])
@@ -1280,8 +1302,11 @@ model RetryRule {
 
 model CallbackTask {
   id             String         @id @default(uuid()) @db.Uuid
-  campaignLeadId String         @db.Uuid
-  agentUserId    String         @db.Uuid
+  userId         String         @db.Uuid
+  organizationId String?        @db.Uuid
+  contactId      String         @db.Uuid
+  callId         String?        @db.Uuid
+  campaignLeadId String?        @db.Uuid
   scheduledAt    DateTime
   note           String?        @db.Text
   status         CallbackStatus @default(scheduled)
@@ -1290,9 +1315,16 @@ model CallbackTask {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  campaignLead CampaignLead @relation(fields: [campaignLeadId], references: [id], onDelete: Cascade)
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  contact      Contact       @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  call         Call?         @relation(fields: [callId], references: [id], onDelete: SetNull)
+  campaignLead CampaignLead? @relation(fields: [campaignLeadId], references: [id], onDelete: Cascade)
 
-  @@index([agentUserId])
+  @@index([userId])
+  @@index([organizationId])
+  @@index([contactId])
+  @@index([callId])
   @@index([status, scheduledAt])
   @@index([campaignLeadId])
 }
@@ -1300,16 +1332,60 @@ model CallbackTask {
 model DNCEntry {
   id             String  @id @default(uuid()) @db.Uuid
   phoneNumber    String  @db.VarChar(20)
-  organizationId String  @db.Uuid
+  userId         String  @db.Uuid
+  organizationId String? @db.Uuid
   reason         String?
   source         String? // "manual", "disposition", "import"
   addedByUserId  String? @db.Uuid
 
   createdAt DateTime @default(now())
 
-  @@unique([organizationId, phoneNumber])
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  // Uniqueness is enforced by partial indexes in SQL:
+  //   - (organizationId, phoneNumber) WHERE organizationId IS NOT NULL → org-wide DNC
+  //   - (userId, phoneNumber)        WHERE organizationId IS NULL     → personal/freelancer DNC
+  // Prisma can't express WHERE clauses on @@unique, so see migration SQL.
   @@index([phoneNumber])
   @@index([organizationId])
+  @@index([userId])
+}
+
+// Reminders fire scheduled notifications for callbacks, meetings and follow-ups.
+// The Reminder row is the source of truth; the worker polls pending rows whose
+// fireAt has passed and dispatches them through the configured channels.
+// Cancellation/reschedule of the subject (callback or meeting) updates the
+// related reminder rows to keep state consistent.
+model Reminder {
+  id             String              @id @default(uuid()) @db.Uuid
+  userId         String              @db.Uuid
+  organizationId String?             @db.Uuid
+  subjectType    ReminderSubjectType
+  subjectId      String              @db.Uuid
+  fireAt         DateTime
+  channels       String[]            @default([]) // ["email"] today; "in_app" | "sms" | "whatsapp" later
+  status         ReminderStatus      @default(pending)
+  attemptCount   Int                 @default(0)
+  lastError      String?             @db.Text
+  sentAt         DateTime?
+  snoozedUntil   DateTime?
+
+  // Stable dedupe key per (subjectType, subjectId, offsetTag), e.g.
+  // "callback:<uuid>:T-15m". Lets us upsert without duplicating rows when
+  // a subject is re-scheduled to the same time.
+  dedupeKey String @unique
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  @@index([status, fireAt])
+  @@index([userId])
+  @@index([organizationId])
+  @@index([subjectType, subjectId])
 }
 
 model VoicemailDropAsset {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -4,7 +4,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://ringee-user:ringee-password@localhost:5432/ringee-db-local?schema=public"
+  url      = env("DATABASE_URL")
 }
 
 enum EmailStatus {

--- a/packages/database/src/database/database.module.ts
+++ b/packages/database/src/database/database.module.ts
@@ -27,6 +27,7 @@ import { DispositionRepository } from "./repositories/disposition.repository";
 import { RetryRuleRepository } from "./repositories/retry-rule.repository";
 import { CallbackTaskRepository } from "./repositories/callback-task.repository";
 import { DNCEntryRepository } from "./repositories/dnc-entry.repository";
+import { ReminderRepository } from "./repositories/reminder.repository";
 import { VoicemailDropAssetRepository } from "./repositories/voicemail-drop-asset.repository";
 import { AgentSessionRepository } from "./repositories/agent-session.repository";
 import { OutboundAnalyticsRepository } from "./repositories/outbound-analytics.repository";
@@ -86,6 +87,7 @@ const databaseProviders = [
   RetryRuleRepository,
   CallbackTaskRepository,
   DNCEntryRepository,
+  ReminderRepository,
   VoicemailDropAssetRepository,
   AgentSessionRepository,
   OutboundAnalyticsRepository,

--- a/packages/database/src/database/repositories/callback-task.repository.ts
+++ b/packages/database/src/database/repositories/callback-task.repository.ts
@@ -1,18 +1,26 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
-import { CallbackTask, CallbackStatus } from "@prisma/client";
+import { CallbackTask, CallbackStatus, Prisma } from "@prisma/client";
 
-export interface CallbackTaskWithLead extends CallbackTask {
-  campaignLead: {
+export interface CallbackTaskWithContext extends CallbackTask {
+  contact: {
     id: string;
-    campaignId: string;
-    contact: {
-      id: string;
-      name: string | null;
-      phoneNumber: string;
-      company: string | null;
-    };
+    name: string | null;
+    phoneNumber: string;
+    company: string | null;
   };
+  campaignLead:
+    | {
+        id: string;
+        campaignId: string;
+        campaign: { id: string; name: string };
+      }
+    | null;
+}
+
+export interface CallbackOwnerFilter {
+  userId: string;
+  organizationId?: string | null;
 }
 
 @Injectable()
@@ -20,29 +28,49 @@ export class CallbackTaskRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(data: {
-    campaignLeadId: string;
-    agentUserId: string;
+    userId: string;
+    organizationId?: string | null;
+    contactId: string;
+    callId?: string | null;
+    campaignLeadId?: string | null;
     scheduledAt: Date;
     note?: string;
   }): Promise<CallbackTask> {
-    return this.prisma.callbackTask.create({ data });
+    return this.prisma.callbackTask.create({
+      data: {
+        userId: data.userId,
+        organizationId: data.organizationId ?? null,
+        contactId: data.contactId,
+        callId: data.callId ?? null,
+        campaignLeadId: data.campaignLeadId ?? null,
+        scheduledAt: data.scheduledAt,
+        note: data.note,
+      },
+    });
   }
 
   async findById(id: string): Promise<CallbackTask | null> {
     return this.prisma.callbackTask.findUnique({ where: { id } });
   }
 
-  async findByAgent(
-    agentUserId: string,
+  /**
+   * List callbacks visible to the given owner context.
+   * - Org context: returns every callback in the organization.
+   * - Freelancer context: returns the user's personal callbacks (organizationId IS NULL).
+   */
+  async listForOwner(
+    owner: CallbackOwnerFilter,
     options?: { status?: CallbackStatus; page?: number; limit?: number }
   ): Promise<{
-    data: CallbackTaskWithLead[];
+    data: CallbackTaskWithContext[];
     meta: { total: number; page: number; limit: number; totalPages: number };
   }> {
     const { status, page = 1, limit = 20 } = options || {};
 
-    const where = {
-      agentUserId,
+    const where: Prisma.CallbackTaskWhereInput = {
+      ...(owner.organizationId
+        ? { organizationId: owner.organizationId }
+        : { userId: owner.userId, organizationId: null }),
       ...(status ? { status } : {}),
     };
 
@@ -50,16 +78,19 @@ export class CallbackTaskRepository {
     const data = await this.prisma.callbackTask.findMany({
       where,
       include: {
+        contact: {
+          select: {
+            id: true,
+            name: true,
+            phoneNumber: true,
+            company: true,
+          },
+        },
         campaignLead: {
-          include: {
-            contact: {
-              select: {
-                id: true,
-                name: true,
-                phoneNumber: true,
-                company: true,
-              },
-            },
+          select: {
+            id: true,
+            campaignId: true,
+            campaign: { select: { id: true, name: true } },
           },
         },
       },
@@ -69,7 +100,7 @@ export class CallbackTaskRepository {
     });
 
     return {
-      data: data as CallbackTaskWithLead[],
+      data: data as CallbackTaskWithContext[],
       meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
     };
   }
@@ -105,6 +136,13 @@ export class CallbackTaskRepository {
   async findByCampaignLead(campaignLeadId: string): Promise<CallbackTask[]> {
     return this.prisma.callbackTask.findMany({
       where: { campaignLeadId },
+      orderBy: { scheduledAt: "desc" },
+    });
+  }
+
+  async findByContact(contactId: string): Promise<CallbackTask[]> {
+    return this.prisma.callbackTask.findMany({
+      where: { contactId },
       orderBy: { scheduledAt: "desc" },
     });
   }

--- a/packages/database/src/database/repositories/dnc-entry.repository.ts
+++ b/packages/database/src/database/repositories/dnc-entry.repository.ts
@@ -1,56 +1,85 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
-import { DNCEntry } from "@prisma/client";
+import { DNCEntry, Prisma } from "@prisma/client";
+
+export interface DNCOwnerScope {
+  userId: string;
+  organizationId?: string | null;
+}
+
+export interface DNCCreateInput {
+  phoneNumber: string;
+  userId: string;
+  organizationId?: string | null;
+  reason?: string;
+  source?: string;
+  addedByUserId?: string;
+}
 
 @Injectable()
 export class DNCEntryRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(data: {
-    phoneNumber: string;
-    organizationId: string;
-    reason?: string;
-    source?: string;
-    addedByUserId?: string;
-  }): Promise<DNCEntry> {
-    return this.prisma.dNCEntry.create({ data });
+  /**
+   * Build the WHERE clause for the owner's DNC list. Org context queries the
+   * org list only; freelancer context queries the user's personal list only.
+   * The two are never mixed.
+   */
+  private ownerWhere(owner: DNCOwnerScope): Prisma.DNCEntryWhereInput {
+    return owner.organizationId
+      ? { organizationId: owner.organizationId }
+      : { userId: owner.userId, organizationId: null };
   }
 
-  async createMany(
-    entries: {
-      phoneNumber: string;
-      organizationId: string;
-      reason?: string;
-      source?: string;
-      addedByUserId?: string;
-    }[]
-  ): Promise<number> {
+  async create(data: DNCCreateInput): Promise<DNCEntry> {
+    return this.prisma.dNCEntry.create({
+      data: {
+        phoneNumber: data.phoneNumber,
+        userId: data.userId,
+        organizationId: data.organizationId ?? null,
+        reason: data.reason,
+        source: data.source,
+        addedByUserId: data.addedByUserId,
+      },
+    });
+  }
+
+  async createMany(entries: DNCCreateInput[]): Promise<number> {
     const result = await this.prisma.dNCEntry.createMany({
-      data: entries,
+      data: entries.map((e) => ({
+        phoneNumber: e.phoneNumber,
+        userId: e.userId,
+        organizationId: e.organizationId ?? null,
+        reason: e.reason,
+        source: e.source,
+        addedByUserId: e.addedByUserId,
+      })),
       skipDuplicates: true,
     });
     return result.count;
   }
 
   async findByPhone(
-    organizationId: string,
+    owner: DNCOwnerScope,
     phoneNumber: string
   ): Promise<DNCEntry | null> {
-    return this.prisma.dNCEntry.findUnique({
-      where: { organizationId_phoneNumber: { organizationId, phoneNumber } },
+    return this.prisma.dNCEntry.findFirst({
+      where: { ...this.ownerWhere(owner), phoneNumber },
     });
   }
 
   async isOnDNC(
-    organizationId: string,
+    owner: DNCOwnerScope,
     phoneNumber: string
   ): Promise<boolean> {
-    const entry = await this.findByPhone(organizationId, phoneNumber);
-    return entry !== null;
+    const count = await this.prisma.dNCEntry.count({
+      where: { ...this.ownerWhere(owner), phoneNumber },
+    });
+    return count > 0;
   }
 
-  async listByOrganization(
-    organizationId: string,
+  async listForOwner(
+    owner: DNCOwnerScope,
     options?: { search?: string; page?: number; limit?: number }
   ): Promise<{
     data: DNCEntry[];
@@ -58,8 +87,8 @@ export class DNCEntryRepository {
   }> {
     const { search, page = 1, limit = 20 } = options || {};
 
-    const where = {
-      organizationId,
+    const where: Prisma.DNCEntryWhereInput = {
+      ...this.ownerWhere(owner),
       ...(search ? { phoneNumber: { contains: search } } : {}),
     };
 
@@ -82,11 +111,12 @@ export class DNCEntryRepository {
   }
 
   async deleteByPhone(
-    organizationId: string,
+    owner: DNCOwnerScope,
     phoneNumber: string
-  ): Promise<DNCEntry> {
-    return this.prisma.dNCEntry.delete({
-      where: { organizationId_phoneNumber: { organizationId, phoneNumber } },
+  ): Promise<number> {
+    const result = await this.prisma.dNCEntry.deleteMany({
+      where: { ...this.ownerWhere(owner), phoneNumber },
     });
+    return result.count;
   }
 }

--- a/packages/database/src/database/repositories/index.ts
+++ b/packages/database/src/database/repositories/index.ts
@@ -25,6 +25,7 @@ export * from "./disposition.repository";
 export * from "./retry-rule.repository";
 export * from "./callback-task.repository";
 export * from "./dnc-entry.repository";
+export * from "./reminder.repository";
 export * from "./voicemail-drop-asset.repository";
 export * from "./agent-session.repository";
 export * from "./outbound-analytics.repository";

--- a/packages/database/src/database/repositories/reminder.repository.ts
+++ b/packages/database/src/database/repositories/reminder.repository.ts
@@ -1,0 +1,193 @@
+import { Injectable } from "@nestjs/common";
+import { PrismaService } from "../prisma.service";
+import {
+  Reminder,
+  ReminderStatus,
+  ReminderSubjectType,
+  Prisma,
+} from "@prisma/client";
+
+export interface ReminderOwnerScope {
+  userId: string;
+  organizationId?: string | null;
+}
+
+export interface ReminderUpsertInput {
+  userId: string;
+  organizationId?: string | null;
+  subjectType: ReminderSubjectType;
+  subjectId: string;
+  fireAt: Date;
+  channels: string[];
+  dedupeKey: string;
+}
+
+@Injectable()
+export class ReminderRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Idempotent schedule. If a reminder with the same dedupeKey already exists
+   * and is still actionable (pending/snoozed), update its fireAt/channels.
+   * If it was sent/failed/cancelled, leave it alone — we don't resurrect a
+   * past delivery.
+   */
+  async upsertPending(input: ReminderUpsertInput): Promise<Reminder | null> {
+    if (input.fireAt.getTime() <= Date.now()) {
+      // Backfill / past-event safety: never schedule a reminder for an event
+      // whose fire time has already passed.
+      return null;
+    }
+
+    const existing = await this.prisma.reminder.findUnique({
+      where: { dedupeKey: input.dedupeKey },
+    });
+
+    if (existing) {
+      if (
+        existing.status === ReminderStatus.sent ||
+        existing.status === ReminderStatus.failed ||
+        existing.status === ReminderStatus.cancelled
+      ) {
+        return existing;
+      }
+      return this.prisma.reminder.update({
+        where: { id: existing.id },
+        data: {
+          fireAt: input.fireAt,
+          channels: input.channels,
+          status: ReminderStatus.pending,
+          snoozedUntil: null,
+        },
+      });
+    }
+
+    return this.prisma.reminder.create({
+      data: {
+        userId: input.userId,
+        organizationId: input.organizationId ?? null,
+        subjectType: input.subjectType,
+        subjectId: input.subjectId,
+        fireAt: input.fireAt,
+        channels: input.channels,
+        dedupeKey: input.dedupeKey,
+      },
+    });
+  }
+
+  async findById(id: string): Promise<Reminder | null> {
+    return this.prisma.reminder.findUnique({ where: { id } });
+  }
+
+  async findDuePending(limit = 50): Promise<Reminder[]> {
+    return this.prisma.reminder.findMany({
+      where: {
+        status: ReminderStatus.pending,
+        fireAt: { lte: new Date() },
+      },
+      orderBy: { fireAt: "asc" },
+      take: limit,
+    });
+  }
+
+  async markSent(id: string): Promise<Reminder> {
+    return this.prisma.reminder.update({
+      where: { id },
+      data: { status: ReminderStatus.sent, sentAt: new Date() },
+    });
+  }
+
+  async markFailed(id: string, error: string): Promise<Reminder> {
+    return this.prisma.reminder.update({
+      where: { id },
+      data: {
+        status: ReminderStatus.failed,
+        attemptCount: { increment: 1 },
+        lastError: error.slice(0, 1000),
+      },
+    });
+  }
+
+  async incrementAttempt(id: string): Promise<Reminder> {
+    return this.prisma.reminder.update({
+      where: { id },
+      data: { attemptCount: { increment: 1 } },
+    });
+  }
+
+  async snooze(id: string, until: Date): Promise<Reminder> {
+    return this.prisma.reminder.update({
+      where: { id },
+      data: {
+        status: ReminderStatus.snoozed,
+        snoozedUntil: until,
+        fireAt: until,
+      },
+    });
+  }
+
+  async unsnoozeDue(): Promise<number> {
+    const result = await this.prisma.reminder.updateMany({
+      where: {
+        status: ReminderStatus.snoozed,
+        snoozedUntil: { lte: new Date() },
+      },
+      data: { status: ReminderStatus.pending },
+    });
+    return result.count;
+  }
+
+  /**
+   * Cancel every actionable reminder belonging to a subject. Used when the
+   * underlying callback/meeting is cancelled or completed.
+   */
+  async cancelForSubject(
+    subjectType: ReminderSubjectType,
+    subjectId: string
+  ): Promise<number> {
+    const result = await this.prisma.reminder.updateMany({
+      where: {
+        subjectType,
+        subjectId,
+        status: { in: [ReminderStatus.pending, ReminderStatus.snoozed] },
+      },
+      data: { status: ReminderStatus.cancelled },
+    });
+    return result.count;
+  }
+
+  async listUpcomingForOwner(
+    owner: ReminderOwnerScope,
+    options?: {
+      subjectType?: ReminderSubjectType;
+      page?: number;
+      limit?: number;
+    }
+  ): Promise<{
+    data: Reminder[];
+    meta: { total: number; page: number; limit: number; totalPages: number };
+  }> {
+    const { subjectType, page = 1, limit = 20 } = options || {};
+
+    const where: Prisma.ReminderWhereInput = {
+      ...(owner.organizationId
+        ? { organizationId: owner.organizationId }
+        : { userId: owner.userId, organizationId: null }),
+      ...(subjectType ? { subjectType } : {}),
+      status: { in: [ReminderStatus.pending, ReminderStatus.snoozed] },
+    };
+
+    const total = await this.prisma.reminder.count({ where });
+    const data = await this.prisma.reminder.findMany({
+      where,
+      orderBy: { fireAt: "asc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return {
+      data,
+      meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
+    };
+  }
+}

--- a/packages/services/src/services/index.ts
+++ b/packages/services/src/services/index.ts
@@ -24,3 +24,4 @@ export * from "./crm";
 export * from "./enrichment";
 export * from "./attio-app.service";
 export * from "./inbox";
+export * from "./reminders";

--- a/packages/services/src/services/meeting.service.ts
+++ b/packages/services/src/services/meeting.service.ts
@@ -1,4 +1,6 @@
 import {
+  forwardRef,
+  Inject,
   Injectable,
   ForbiddenException,
   NotFoundException,
@@ -11,10 +13,12 @@ import {
   MeetingStatus,
   CallOutcome,
   Call,
+  ReminderSubjectType,
 } from "@ringee/database";
 import { OwnershipContext } from "@ringee/platform";
 import { CalendarService } from "./calendar.service";
 import { CrmMeetingSyncService } from "./crm/crm-meeting-sync.service";
+import { ReminderService } from "./reminders/reminder.service";
 
 @Injectable()
 export class MeetingService {
@@ -25,6 +29,8 @@ export class MeetingService {
     private readonly callRepo: CallRepository,
     private readonly calendarService: CalendarService,
     private readonly crmMeetingSync: CrmMeetingSyncService,
+    @Inject(forwardRef(() => ReminderService))
+    private readonly reminderService: ReminderService,
   ) {}
 
   private ensureOrganization(ctx: OwnershipContext): void {
@@ -100,6 +106,21 @@ export class MeetingService {
       );
     }
 
+    // Best-effort: schedule reminders (-15min, -5min email by default)
+    try {
+      await this.reminderService.scheduleForSubject({
+        subjectType: ReminderSubjectType.meeting,
+        subjectId: meeting.id,
+        userId: meeting.userId,
+        organizationId: meeting.organizationId,
+        fireAt: meeting.scheduledAt,
+      });
+    } catch (err) {
+      this.logger.debug(
+        `Skipped reminder scheduling for meeting ${meeting.id}: ${(err as Error).message}`,
+      );
+    }
+
     return meeting;
   }
 
@@ -147,22 +168,53 @@ export class MeetingService {
   ): Promise<Meeting> {
     const meeting = await this.getMeetingById(ctx, id);
 
-    return this.meetingRepo.update(meeting.id, {
+    const updated = await this.meetingRepo.update(meeting.id, {
       title: dto.title,
       scheduledAt: dto.scheduledAt ? new Date(dto.scheduledAt) : undefined,
       duration: dto.duration,
       location: dto.location,
       notes: dto.notes,
     });
+
+    if (dto.scheduledAt) {
+      try {
+        await this.reminderService.rescheduleForSubject({
+          subjectType: ReminderSubjectType.meeting,
+          subjectId: meeting.id,
+          userId: meeting.userId,
+          organizationId: meeting.organizationId,
+          fireAt: new Date(dto.scheduledAt),
+        });
+      } catch (err) {
+        this.logger.debug(
+          `Skipped reminder reschedule for meeting ${meeting.id}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    return updated;
   }
 
   async cancelMeeting(ctx: OwnershipContext, id: string): Promise<Meeting> {
     const meeting = await this.getMeetingById(ctx, id);
 
-    return this.meetingRepo.update(meeting.id, {
+    const updated = await this.meetingRepo.update(meeting.id, {
       status: MeetingStatus.cancelled,
       cancelledAt: new Date(),
     });
+
+    try {
+      await this.reminderService.cancelForSubject(
+        ReminderSubjectType.meeting,
+        meeting.id,
+      );
+    } catch (err) {
+      this.logger.debug(
+        `Skipped reminder cancel for meeting ${meeting.id}: ${(err as Error).message}`,
+      );
+    }
+
+    return updated;
   }
 
   async findCallBySessionId(sessionId: string): Promise<Call | null> {

--- a/packages/services/src/services/outbound/call-attempt.service.ts
+++ b/packages/services/src/services/outbound/call-attempt.service.ts
@@ -230,9 +230,11 @@ export class CallAttemptService {
       if (leadData) {
         await this.complianceService.addToDNC({
           phoneNumber: leadData.campaignLead.contact.phoneNumber,
+          userId: attempt.agentUserId,
           organizationId: data.organizationId,
           reason: `Disposition: ${disposition.label}`,
           source: "disposition",
+          addedByUserId: attempt.agentUserId,
         });
       }
       action = "dnc";
@@ -240,9 +242,9 @@ export class CallAttemptService {
       disposition.triggersCallback &&
       data.callback?.scheduledAt
     ) {
-      await this.callbackService.schedule({
+      await this.callbackService.scheduleFromCampaign({
         campaignLeadId: attempt.campaignLeadId,
-        agentUserId: attempt.agentUserId,
+        userId: attempt.agentUserId,
         scheduledAt: data.callback.scheduledAt,
         note: data.callback.note,
       });

--- a/packages/services/src/services/outbound/callback.service.ts
+++ b/packages/services/src/services/outbound/callback.service.ts
@@ -1,10 +1,13 @@
-import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import {
   CallbackTaskRepository,
   CampaignLeadRepository,
+  CampaignRepository,
   CallbackStatus,
   CampaignLeadStatus,
+  ReminderSubjectType,
 } from "@ringee/database";
+import { ReminderService } from "../reminders/reminder.service";
 
 @Injectable()
 export class CallbackService {
@@ -12,58 +15,208 @@ export class CallbackService {
 
   constructor(
     private readonly callbackRepo: CallbackTaskRepository,
-    private readonly campaignLeadRepo: CampaignLeadRepository
+    private readonly campaignLeadRepo: CampaignLeadRepository,
+    private readonly campaignRepo: CampaignRepository,
+    @Inject(forwardRef(() => ReminderService))
+    private readonly reminderService: ReminderService
   ) {}
 
-  async schedule(data: {
+  /**
+   * Best-effort reminder scheduling. Never blocks callback creation if
+   * the reminder subsystem misbehaves.
+   */
+  private async scheduleReminders(
+    userId: string,
+    organizationId: string | null,
+    callbackId: string,
+    scheduledAt: Date
+  ) {
+    try {
+      await this.reminderService.scheduleForSubject({
+        subjectType: ReminderSubjectType.callback,
+        subjectId: callbackId,
+        userId,
+        organizationId,
+        fireAt: scheduledAt,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to schedule reminders for callback ${callbackId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  /**
+   * Schedule a callback originating from a campaign lead. Transitions the
+   * lead to `scheduled` so the dialer skips it until the callback fires.
+   * Use this from CallAttempt disposition handlers.
+   */
+  async scheduleFromCampaign(data: {
     campaignLeadId: string;
-    agentUserId: string;
+    userId: string;
     scheduledAt: Date;
     note?: string;
   }) {
-    const callback = await this.callbackRepo.create(data);
+    const lead = await this.campaignLeadRepo.findByIdWithContact(
+      data.campaignLeadId
+    );
+    if (!lead) throw new NotFoundException("Campaign lead not found");
 
-    // Transition lead to scheduled status
+    const campaign = await this.campaignRepo.findById(lead.campaignId);
+
+    const callback = await this.callbackRepo.create({
+      userId: data.userId,
+      organizationId: campaign?.organizationId ?? null,
+      contactId: lead.contactId,
+      campaignLeadId: data.campaignLeadId,
+      scheduledAt: data.scheduledAt,
+      note: data.note,
+    });
+
     await this.campaignLeadRepo.updateStatus(
       data.campaignLeadId,
       CampaignLeadStatus.scheduled,
       { lockedBy: null, lockedAt: null }
     );
 
+    await this.scheduleReminders(
+      data.userId,
+      campaign?.organizationId ?? null,
+      callback.id,
+      data.scheduledAt
+    );
+
     this.logger.debug(
-      `Callback scheduled for lead ${data.campaignLeadId} at ${data.scheduledAt.toISOString()}`
+      `Campaign callback scheduled for lead ${data.campaignLeadId} at ${data.scheduledAt.toISOString()}`
     );
 
     return callback;
   }
 
-  async listByAgent(
-    agentUserId: string,
+  /**
+   * Schedule a callback directly against a contact, optionally linked to a
+   * call (e.g. from the post-call flow). Works in freelancer and org modes.
+   * Does NOT touch CampaignLead state — this path is independent of campaigns.
+   */
+  async scheduleFromContact(data: {
+    userId: string;
+    organizationId?: string | null;
+    contactId: string;
+    callId?: string | null;
+    scheduledAt: Date;
+    note?: string;
+  }) {
+    const callback = await this.callbackRepo.create({
+      userId: data.userId,
+      organizationId: data.organizationId ?? null,
+      contactId: data.contactId,
+      callId: data.callId ?? null,
+      scheduledAt: data.scheduledAt,
+      note: data.note,
+    });
+
+    await this.scheduleReminders(
+      data.userId,
+      data.organizationId ?? null,
+      callback.id,
+      data.scheduledAt
+    );
+
+    this.logger.debug(
+      `Standalone callback ${callback.id} scheduled for contact ${data.contactId} at ${data.scheduledAt.toISOString()}`
+    );
+
+    return callback;
+  }
+
+  async listForOwner(
+    owner: { userId: string; organizationId?: string | null },
     options?: { status?: CallbackStatus; page?: number; limit?: number }
   ) {
-    return this.callbackRepo.findByAgent(agentUserId, options);
+    return this.callbackRepo.listForOwner(owner, options);
+  }
+
+  /**
+   * Find a callback by id but only if it's visible to the given owner.
+   * Throws NotFoundException otherwise (used by controllers for authz).
+   */
+  async findOwnedById(
+    id: string,
+    owner: { userId: string; organizationId?: string | null }
+  ) {
+    const callback = await this.callbackRepo.findById(id);
+    if (!callback) throw new NotFoundException("Callback not found");
+
+    const visible = owner.organizationId
+      ? callback.organizationId === owner.organizationId
+      : callback.organizationId === null && callback.userId === owner.userId;
+
+    if (!visible) throw new NotFoundException("Callback not found");
+    return callback;
   }
 
   async cancel(id: string) {
     const callback = await this.callbackRepo.findById(id);
     if (!callback) throw new NotFoundException("Callback not found");
 
-    return this.callbackRepo.updateStatus(id, CallbackStatus.cancelled);
+    const updated = await this.callbackRepo.updateStatus(
+      id,
+      CallbackStatus.cancelled
+    );
+    await this.silentlyCancelReminders(id);
+    return updated;
   }
 
   async reschedule(id: string, scheduledAt: Date) {
     const callback = await this.callbackRepo.findById(id);
     if (!callback) throw new NotFoundException("Callback not found");
 
-    return this.callbackRepo.update(id, {
+    const updated = await this.callbackRepo.update(id, {
       scheduledAt,
       status: CallbackStatus.scheduled,
     });
+
+    try {
+      await this.reminderService.rescheduleForSubject({
+        subjectType: ReminderSubjectType.callback,
+        subjectId: id,
+        userId: callback.userId,
+        organizationId: callback.organizationId,
+        fireAt: scheduledAt,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to reschedule reminders for callback ${id}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    return updated;
+  }
+
+  private async silentlyCancelReminders(callbackId: string) {
+    try {
+      await this.reminderService.cancelForSubject(
+        ReminderSubjectType.callback,
+        callbackId
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to cancel reminders for callback ${callbackId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   /**
-   * Process callbacks that are due. Called by the CallbackScheduler background job.
-   * Transitions leads to queued with high priority.
+   * Process callbacks that are due. Called by the CallbackScheduler worker.
+   * For campaign-bound callbacks, transitions the lead back to queued with
+   * high priority so the dialer picks it up. Standalone callbacks just flip
+   * to `due` — the user is notified via reminder.
    */
   async processDueCallbacks(): Promise<number> {
     const dueCallbacks = await this.callbackRepo.findDue();
@@ -72,12 +225,13 @@ export class CallbackService {
     for (const callback of dueCallbacks) {
       await this.callbackRepo.updateStatus(callback.id, CallbackStatus.due);
 
-      // Transition lead to queued with high priority
-      await this.campaignLeadRepo.updateStatus(
-        callback.campaignLeadId,
-        CampaignLeadStatus.queued,
-        { priority: 10, lockedBy: null, lockedAt: null }
-      );
+      if (callback.campaignLeadId) {
+        await this.campaignLeadRepo.updateStatus(
+          callback.campaignLeadId,
+          CampaignLeadStatus.queued,
+          { priority: 10, lockedBy: null, lockedAt: null }
+        );
+      }
 
       count++;
       this.logger.debug(`Callback ${callback.id} is now due`);
@@ -87,10 +241,12 @@ export class CallbackService {
   }
 
   async markCompleted(id: string) {
-    return this.callbackRepo.updateStatus(
+    const updated = await this.callbackRepo.updateStatus(
       id,
       CallbackStatus.completed,
       new Date()
     );
+    await this.silentlyCancelReminders(id);
+    return updated;
   }
 }

--- a/packages/services/src/services/outbound/compliance.service.ts
+++ b/packages/services/src/services/outbound/compliance.service.ts
@@ -1,51 +1,55 @@
 import { Injectable } from "@nestjs/common";
-import { DNCEntryRepository } from "@ringee/database";
+import {
+  DNCEntryRepository,
+  DNCOwnerScope,
+  DNCCreateInput,
+} from "@ringee/database";
 
 @Injectable()
 export class ComplianceService {
   constructor(private readonly dncRepo: DNCEntryRepository) {}
 
+  /**
+   * Check whether a phone number is on the caller's applicable DNC list.
+   * The owner scope decides which list — personal lists and org lists are
+   * never queried together. A freelancer placing a call only consults their
+   * personal DNC; an org member only consults the org DNC.
+   */
   async isOnDNC(
-    organizationId: string,
+    owner: DNCOwnerScope,
     phoneNumber: string
   ): Promise<boolean> {
-    return this.dncRepo.isOnDNC(organizationId, phoneNumber);
+    return this.dncRepo.isOnDNC(owner, phoneNumber);
   }
 
-  async addToDNC(data: {
-    phoneNumber: string;
-    organizationId: string;
-    reason?: string;
-    source?: string;
-    addedByUserId?: string;
-  }) {
+  /**
+   * Same scope rules as `isOnDNC` but returns the matching entry so callers
+   * can show the reason / source / addedAt to the user.
+   */
+  async findOnDNC(owner: DNCOwnerScope, phoneNumber: string) {
+    return this.dncRepo.findByPhone(owner, phoneNumber);
+  }
+
+  async addToDNC(data: DNCCreateInput) {
     return this.dncRepo.create(data);
   }
 
-  async bulkAddToDNC(
-    entries: {
-      phoneNumber: string;
-      organizationId: string;
-      reason?: string;
-      source?: string;
-      addedByUserId?: string;
-    }[]
-  ) {
+  async bulkAddToDNC(entries: DNCCreateInput[]) {
     return this.dncRepo.createMany(entries);
   }
 
-  async removeFromDNC(organizationId: string, phoneNumber: string) {
-    return this.dncRepo.deleteByPhone(organizationId, phoneNumber);
+  async removeFromDNCByPhone(owner: DNCOwnerScope, phoneNumber: string) {
+    return this.dncRepo.deleteByPhone(owner, phoneNumber);
   }
 
   async listDNC(
-    organizationId: string,
+    owner: DNCOwnerScope,
     options?: { search?: string; page?: number; limit?: number }
   ) {
-    return this.dncRepo.listByOrganization(organizationId, options);
+    return this.dncRepo.listForOwner(owner, options);
   }
 
-  async checkDNCById(id: string) {
+  async deleteDNCById(id: string) {
     return this.dncRepo.delete(id);
   }
 
@@ -60,7 +64,6 @@ export class ComplianceService {
   }): boolean {
     const now = new Date();
 
-    // Get current time in campaign timezone
     const formatter = new Intl.DateTimeFormat("en-US", {
       timeZone: campaign.timezone,
       hour: "numeric",

--- a/packages/services/src/services/reminders/email-reminder.channel.ts
+++ b/packages/services/src/services/reminders/email-reminder.channel.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ResendProvider } from "@ringee/platform";
+import {
+  ReminderChannel,
+  ReminderChannelKind,
+  ReminderContent,
+  ReminderRecipient,
+} from "./reminder-channel.interface";
+
+@Injectable()
+export class EmailReminderChannel implements ReminderChannel {
+  readonly kind: ReminderChannelKind = "email";
+  private readonly logger = new Logger(EmailReminderChannel.name);
+  private readonly provider = new ResendProvider();
+
+  async send(recipient: ReminderRecipient, content: ReminderContent) {
+    if (!recipient.email) {
+      throw new Error(
+        `EmailReminderChannel: recipient ${recipient.userId} has no email`
+      );
+    }
+
+    const result = await this.provider.sendEmail(
+      recipient.email,
+      content.subject,
+      content.bodyHtml
+    );
+
+    this.logger.debug(
+      `Reminder email dispatched to ${recipient.email}: ${content.subject}`
+    );
+
+    // ResendProvider swallows errors and returns { sent: false }; surface that
+    // so the orchestrator records a failure rather than a phantom success.
+    if (
+      result &&
+      typeof result === "object" &&
+      "sent" in result &&
+      result.sent === false
+    ) {
+      throw new Error("Resend provider reported send failure");
+    }
+  }
+}

--- a/packages/services/src/services/reminders/index.ts
+++ b/packages/services/src/services/reminders/index.ts
@@ -1,0 +1,3 @@
+export * from "./reminder-channel.interface";
+export * from "./email-reminder.channel";
+export * from "./reminder.service";

--- a/packages/services/src/services/reminders/reminder-channel.interface.ts
+++ b/packages/services/src/services/reminders/reminder-channel.interface.ts
@@ -1,0 +1,32 @@
+/**
+ * Delivery channel abstraction. Initially only `email` is implemented; new
+ * channels (in_app, sms, whatsapp) plug in by implementing this interface and
+ * registering with `REMINDER_CHANNELS` in the services module.
+ *
+ * The orchestration (loading subject data, building content, recording
+ * delivery state) lives in ReminderService. Channels only know *how* to
+ * send a pre-built message to a recipient.
+ */
+export type ReminderChannelKind = "email" | "in_app" | "sms" | "whatsapp";
+
+export interface ReminderRecipient {
+  userId: string;
+  email?: string | null;
+  name?: string | null;
+  phoneNumber?: string | null;
+}
+
+export interface ReminderContent {
+  subject: string;
+  bodyHtml: string;
+  bodyText: string;
+  /** Deep-link the user can follow to open the reminder's subject in-app. */
+  deepLinkUrl?: string;
+}
+
+export interface ReminderChannel {
+  readonly kind: ReminderChannelKind;
+  send(recipient: ReminderRecipient, content: ReminderContent): Promise<void>;
+}
+
+export const REMINDER_CHANNELS = Symbol("REMINDER_CHANNELS");

--- a/packages/services/src/services/reminders/reminder.service.ts
+++ b/packages/services/src/services/reminders/reminder.service.ts
@@ -196,6 +196,7 @@ export class ReminderService {
     note?: string | null;
     contact?: { name: string | null; phoneNumber: string };
     title?: string | null;
+    location?: string | null;
   } | null> {
     if (subjectType === ReminderSubjectType.callback) {
       const callback = await this.callbackRepo.findById(subjectId);
@@ -231,6 +232,7 @@ export class ReminderService {
         scheduledAt: meeting.scheduledAt,
         note: meeting.notes,
         title: meeting.title,
+        location: meeting.location,
         contact: contact
           ? { name: contact.name ?? null, phoneNumber: contact.phoneNumber }
           : undefined,
@@ -238,6 +240,11 @@ export class ReminderService {
     }
 
     return null;
+  }
+
+  private isLikelyUrl(value: string | null | undefined): boolean {
+    if (!value) return false;
+    return /^https?:\/\//i.test(value.trim());
   }
 
   private async resolveRecipient(userId: string): Promise<ReminderRecipient> {
@@ -275,19 +282,22 @@ export class ReminderService {
     if (subjectType === ReminderSubjectType.meeting) {
       const title = subjectCtx.title?.trim() || "Upcoming meeting";
       const subject = `Reminder: ${title} at ${when}`;
+      const linkLine = this.isLikelyUrl(subjectCtx.location)
+        ? `Join: ${subjectCtx.location}`
+        : subjectCtx.location
+          ? `Where: ${subjectCtx.location}`
+          : "";
       const bodyText = [
         `${title}`,
         `When: ${when}`,
         `With: ${contactLine}`,
+        linkLine,
         subjectCtx.note ? `\nNotes:\n${subjectCtx.note}` : "",
       ]
         .filter(Boolean)
         .join("\n");
-      return {
-        subject,
-        bodyText,
-        bodyHtml: bodyText.replace(/\n/g, "<br>"),
-      };
+      const bodyHtml = this.toHtml(bodyText, subjectCtx.location);
+      return { subject, bodyText, bodyHtml };
     }
 
     // callback / followup
@@ -307,5 +317,15 @@ export class ReminderService {
       bodyText,
       bodyHtml: bodyText.replace(/\n/g, "<br>"),
     };
+  }
+
+  private toHtml(text: string, maybeUrl?: string | null): string {
+    const escaped = text.replace(/\n/g, "<br>");
+    if (!this.isLikelyUrl(maybeUrl)) return escaped;
+    const url = (maybeUrl as string).trim();
+    return escaped.replace(
+      url,
+      `<a href="${url}">${url}</a>`
+    );
   }
 }

--- a/packages/services/src/services/reminders/reminder.service.ts
+++ b/packages/services/src/services/reminders/reminder.service.ts
@@ -1,0 +1,311 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import {
+  CallbackStatus,
+  CallbackTaskRepository,
+  MeetingRepository,
+  MeetingStatus,
+  ReminderRepository,
+  ReminderStatus,
+  ReminderSubjectType,
+  UserRepository,
+  ContactRepository,
+} from "@ringee/database";
+import {
+  REMINDER_CHANNELS,
+  ReminderChannel,
+  ReminderChannelKind,
+  ReminderContent,
+  ReminderRecipient,
+} from "./reminder-channel.interface";
+
+const DEFAULT_OFFSETS_MIN = [15, 5] as const;
+const DEFAULT_CHANNELS: ReminderChannelKind[] = ["email"];
+
+interface ScheduleSubjectInput {
+  subjectType: ReminderSubjectType;
+  subjectId: string;
+  userId: string;
+  organizationId?: string | null;
+  fireAt: Date;
+  channels?: ReminderChannelKind[];
+  offsetsMinutes?: readonly number[];
+}
+
+@Injectable()
+export class ReminderService {
+  private readonly logger = new Logger(ReminderService.name);
+
+  constructor(
+    private readonly reminderRepo: ReminderRepository,
+    private readonly userRepo: UserRepository,
+    private readonly callbackRepo: CallbackTaskRepository,
+    private readonly meetingRepo: MeetingRepository,
+    private readonly contactRepo: ContactRepository,
+    @Inject(REMINDER_CHANNELS)
+    private readonly channels: ReminderChannel[]
+  ) {}
+
+  /**
+   * Schedule the default reminder set (-15min, -5min) for a subject.
+   * Idempotent per (subjectType, subjectId, offset) — re-running with the
+   * same fireAt won't duplicate rows.
+   *
+   * Past-event safety: offsets that fall before `now()` are skipped, so
+   * backfills and migrations never enqueue email for events already passed.
+   */
+  async scheduleForSubject(input: ScheduleSubjectInput) {
+    const offsets = input.offsetsMinutes ?? DEFAULT_OFFSETS_MIN;
+    const channels = input.channels ?? DEFAULT_CHANNELS;
+
+    const created = [];
+    for (const offsetMin of offsets) {
+      const fireAt = new Date(input.fireAt.getTime() - offsetMin * 60_000);
+      const dedupeKey = `${input.subjectType}:${input.subjectId}:T-${offsetMin}m`;
+
+      const reminder = await this.reminderRepo.upsertPending({
+        userId: input.userId,
+        organizationId: input.organizationId ?? null,
+        subjectType: input.subjectType,
+        subjectId: input.subjectId,
+        fireAt,
+        channels,
+        dedupeKey,
+      });
+
+      if (reminder) created.push(reminder);
+    }
+    return created;
+  }
+
+  /**
+   * Cancel every pending/snoozed reminder for a subject. Called when the
+   * subject is cancelled or completed (callback completed, meeting cancelled).
+   */
+  async cancelForSubject(
+    subjectType: ReminderSubjectType,
+    subjectId: string
+  ) {
+    return this.reminderRepo.cancelForSubject(subjectType, subjectId);
+  }
+
+  /**
+   * Re-schedule by cancelling existing reminders and creating fresh ones.
+   * Used when a callback or meeting is rescheduled to a new time.
+   */
+  async rescheduleForSubject(input: ScheduleSubjectInput) {
+    await this.cancelForSubject(input.subjectType, input.subjectId);
+    return this.scheduleForSubject(input);
+  }
+
+  async snooze(id: string, minutes: number) {
+    const reminder = await this.reminderRepo.findById(id);
+    if (!reminder) throw new NotFoundException("Reminder not found");
+    const until = new Date(Date.now() + minutes * 60_000);
+    return this.reminderRepo.snooze(id, until);
+  }
+
+  async listUpcomingForOwner(
+    owner: { userId: string; organizationId?: string | null },
+    options?: {
+      subjectType?: ReminderSubjectType;
+      page?: number;
+      limit?: number;
+    }
+  ) {
+    return this.reminderRepo.listUpcomingForOwner(owner, options);
+  }
+
+  /**
+   * Worker entry point. Unsnooze anything whose snooze window elapsed, then
+   * process every pending reminder whose fireAt has passed.
+   *
+   * Behavior is best-effort and idempotent:
+   * - If the underlying subject is gone or no longer actionable
+   *   (callback cancelled/completed, meeting cancelled), mark the reminder
+   *   cancelled without sending.
+   * - If any channel throws, the reminder is marked failed with the error
+   *   captured. We deliberately don't auto-retry yet — retries can come
+   *   later by re-flipping failed → pending with backoff.
+   */
+  async processDuePending(): Promise<number> {
+    await this.reminderRepo.unsnoozeDue();
+    const due = await this.reminderRepo.findDuePending();
+
+    let dispatched = 0;
+    for (const reminder of due) {
+      try {
+        const subjectCtx = await this.loadSubjectContext(
+          reminder.subjectType,
+          reminder.subjectId
+        );
+
+        if (!subjectCtx) {
+          await this.reminderRepo.cancelForSubject(
+            reminder.subjectType,
+            reminder.subjectId
+          );
+          continue;
+        }
+
+        const recipient = await this.resolveRecipient(reminder.userId);
+        if (!recipient.email) {
+          await this.reminderRepo.markFailed(
+            reminder.id,
+            "recipient has no email on file"
+          );
+          continue;
+        }
+
+        const content = this.buildContent(
+          reminder.subjectType,
+          subjectCtx
+        );
+
+        for (const channelKind of reminder.channels) {
+          const channel = this.channels.find((c) => c.kind === channelKind);
+          if (!channel) {
+            throw new Error(`No channel registered for kind ${channelKind}`);
+          }
+          await channel.send(recipient, content);
+        }
+
+        await this.reminderRepo.markSent(reminder.id);
+        dispatched++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `Reminder ${reminder.id} delivery failed: ${message}`
+        );
+        await this.reminderRepo.markFailed(reminder.id, message);
+      }
+    }
+
+    return dispatched;
+  }
+
+  private async loadSubjectContext(
+    subjectType: ReminderSubjectType,
+    subjectId: string
+  ): Promise<{
+    scheduledAt: Date;
+    note?: string | null;
+    contact?: { name: string | null; phoneNumber: string };
+    title?: string | null;
+  } | null> {
+    if (subjectType === ReminderSubjectType.callback) {
+      const callback = await this.callbackRepo.findById(subjectId);
+      if (!callback) return null;
+      if (
+        callback.status === CallbackStatus.completed ||
+        callback.status === CallbackStatus.cancelled ||
+        callback.status === CallbackStatus.missed
+      ) {
+        return null;
+      }
+      const contact = await this.contactRepo.findById(callback.contactId);
+      return {
+        scheduledAt: callback.scheduledAt,
+        note: callback.note,
+        contact: contact
+          ? { name: contact.name ?? null, phoneNumber: contact.phoneNumber }
+          : undefined,
+      };
+    }
+
+    if (subjectType === ReminderSubjectType.meeting) {
+      const meeting = await this.meetingRepo.findById(subjectId);
+      if (!meeting) return null;
+      if (
+        meeting.status === MeetingStatus.completed ||
+        meeting.status === MeetingStatus.cancelled
+      ) {
+        return null;
+      }
+      const contact = await this.contactRepo.findById(meeting.contactId);
+      return {
+        scheduledAt: meeting.scheduledAt,
+        note: meeting.notes,
+        title: meeting.title,
+        contact: contact
+          ? { name: contact.name ?? null, phoneNumber: contact.phoneNumber }
+          : undefined,
+      };
+    }
+
+    return null;
+  }
+
+  private async resolveRecipient(userId: string): Promise<ReminderRecipient> {
+    const user = await this.userRepo.findById(userId);
+    if (!user) {
+      return { userId };
+    }
+    type UserWithEmails = typeof user & {
+      emails?: Array<{ email: string; isPrimary: boolean }>;
+    };
+    const withEmails = user as UserWithEmails;
+    const emails = withEmails.emails ?? [];
+    const primary =
+      emails.find((e) => e.isPrimary)?.email ?? emails[0]?.email ?? null;
+    const name =
+      [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
+      null;
+    return { userId, email: primary, name };
+  }
+
+  private buildContent(
+    subjectType: ReminderSubjectType,
+    subjectCtx: NonNullable<
+      Awaited<ReturnType<ReminderService["loadSubjectContext"]>>
+    >
+  ): ReminderContent {
+    const when = subjectCtx.scheduledAt.toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+    const contactLine = subjectCtx.contact
+      ? `${subjectCtx.contact.name ?? "Unknown"} (${subjectCtx.contact.phoneNumber})`
+      : "Unknown contact";
+
+    if (subjectType === ReminderSubjectType.meeting) {
+      const title = subjectCtx.title?.trim() || "Upcoming meeting";
+      const subject = `Reminder: ${title} at ${when}`;
+      const bodyText = [
+        `${title}`,
+        `When: ${when}`,
+        `With: ${contactLine}`,
+        subjectCtx.note ? `\nNotes:\n${subjectCtx.note}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+      return {
+        subject,
+        bodyText,
+        bodyHtml: bodyText.replace(/\n/g, "<br>"),
+      };
+    }
+
+    // callback / followup
+    const subject = `Reminder: callback with ${
+      subjectCtx.contact?.name ?? "your lead"
+    } at ${when}`;
+    const bodyText = [
+      `You have a scheduled callback.`,
+      `When: ${when}`,
+      `Contact: ${contactLine}`,
+      subjectCtx.note ? `\nNotes:\n${subjectCtx.note}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    return {
+      subject,
+      bodyText,
+      bodyHtml: bodyText.replace(/\n/g, "<br>"),
+    };
+  }
+}

--- a/packages/services/src/services/services.module.ts
+++ b/packages/services/src/services/services.module.ts
@@ -1,4 +1,4 @@
-import { Global, Module } from "@nestjs/common";
+import { Global, Module, Provider } from "@nestjs/common";
 import { UserService } from "./user.service";
 import {
   AuthModule,
@@ -71,6 +71,11 @@ import {
   CustomFieldsService,
 } from "./enrichment";
 import { InboxTimelineService, MessageService } from "./inbox";
+import {
+  EmailReminderChannel,
+  REMINDER_CHANNELS,
+  ReminderService,
+} from "./reminders";
 
 const servicesProviders = [
   UserService,
@@ -135,12 +140,26 @@ const servicesProviders = [
   // Inbox / messaging
   InboxTimelineService,
   MessageService,
+  // Reminders
+  ReminderService,
+  EmailReminderChannel,
+];
+
+const reminderChannelsProvider: Provider = {
+  provide: REMINDER_CHANNELS,
+  useFactory: (email: EmailReminderChannel) => [email],
+  inject: [EmailReminderChannel],
+};
+
+const allProviders: Provider[] = [
+  ...servicesProviders,
+  reminderChannelsProvider,
 ];
 
 @Global()
 @Module({
   imports: [AuthModule, NotificationModule, TelephonyModule, StripeModule, CrmModule, EnrichmentModule, RedisModule, CryptoModule],
-  providers: servicesProviders,
-  exports: servicesProviders,
+  providers: allProviders,
+  exports: allProviders,
 })
 export class ServicesModule { }


### PR DESCRIPTION
- Added ReminderService to handle scheduling, processing, and managing reminders.
- Introduced EmailReminderChannel for sending email notifications.
- Created ReminderController for managing reminder-related API endpoints.
- Updated ComplianceService to support personal and organizational DNC entries.
- Enhanced DNCEntry model to allow entries to belong to either users or organizations.
- Added database migrations for reminders and DNC entries.
- Implemented reminder listing and snoozing functionality.
- Introduced reminder content building and recipient resolution logic.
- Added validation for reminder subject types and handling of reminder statuses.