### PR TITLE
feat: add number verification workflow and implement document submission process

### DIFF
--- a/apps/backend/src/api/routes/stripe.controller.ts
+++ b/apps/backend/src/api/routes/stripe.controller.ts
@@ -331,10 +331,19 @@ export class StripeController {
                 upfrontCost: upfrontCostUsd,
               },
             );
-            await this.triggerLoop.phoneNumberAssigned(
-              userId,
-              purchased.phoneNumber,
-            );
+
+            // Numbers awaiting document verification are persisted as `pending`
+            // and are not yet usable, so don't announce them as assigned.
+            if (purchased.status === "pending") {
+              console.log(
+                `🪪 ${purchased.phoneNumber} ordered but pending regulatory verification for ${userId}`,
+              );
+            } else {
+              await this.triggerLoop.phoneNumberAssigned(
+                userId,
+                purchased.phoneNumber,
+              );
+            }
           } else if (metadata.type === "organization" && userId) {
             // Organization subscription
             console.log(

--- a/apps/backend/src/api/routes/telephony.controller.ts
+++ b/apps/backend/src/api/routes/telephony.controller.ts
@@ -8,7 +8,10 @@ import {
   Post,
   Query,
   ParseIntPipe,
+  UseInterceptors,
+  UploadedFile,
 } from "@nestjs/common";
+import { FileInterceptor } from "@nestjs/platform-express";
 import {
   AvailableNumber,
   CurrentUser,
@@ -21,6 +24,7 @@ import { TelephonyCountryRate } from "@ringee/platform";
 import { CallerIdService, NumberPurchasedService } from "@ringee/services";
 import {
   RequestCallerIdVerificationDto,
+  SubmitRequirementsDto,
   VerifyCallerIdDto,
 } from "@ringee/platform";
 import {
@@ -85,6 +89,25 @@ export class TelephonyController {
     });
   }
 
+  @Public()
+  @Get("numbers/requirements/:country")
+  async getNumberRequirements(
+    @Param("country") country: string,
+    @Query("numberType")
+    numberType?: "local" | "toll_free" | "mobile" | "national",
+    @Query("action") action?: "ordering" | "porting",
+  ) {
+    if (!country) {
+      throw new BadRequestException("Country is required");
+    }
+
+    return this.telephonyService.getRegulatoryRequirements({
+      countryCode: country,
+      phoneNumberType: numberType,
+      action,
+    });
+  }
+
   @Get("caller-ids")
   async getCallerIds(@CurrentUser() user: CurrentUserData) {
     const ctx = createOwnershipContext(user);
@@ -124,6 +147,66 @@ export class TelephonyController {
   @Post("phone-numbers/:id/refresh-messaging")
   async refreshMessaging(@Param("id") id: string) {
     return this.numberPurchasedService.refreshMessagingCapabilities(id);
+  }
+
+  @Get("phone-numbers/:id/requirements")
+  async getPendingNumberRequirements(@Param("id") id: string) {
+    return this.numberPurchasedService.getNumberRequirements(id);
+  }
+
+  @Post("phone-numbers/:id/requirements/documents")
+  @UseInterceptors(
+    FileInterceptor("file", {
+      // Telnyx caps documents at 20 MB.
+      limits: { fileSize: 20 * 1024 * 1024 },
+      fileFilter: (_req, file, cb) => {
+        const allowed = [
+          "application/pdf",
+          "image/png",
+          "image/jpeg",
+          "image/jpg",
+          "image/webp",
+          "image/heic",
+        ];
+        if (allowed.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(
+            new BadRequestException(
+              "Only PDF or image files (PNG, JPG, WEBP, HEIC) are allowed",
+            ),
+            false,
+          );
+        }
+      },
+    }),
+  )
+  async uploadRequirementDocument(
+    @Param("id") id: string,
+    @UploadedFile()
+    file: { buffer: Buffer; originalname: string; mimetype: string },
+  ) {
+    if (!file) {
+      throw new BadRequestException("No file uploaded");
+    }
+
+    void id;
+    return this.numberPurchasedService.uploadRequirementDocument({
+      buffer: file.buffer,
+      filename: file.originalname,
+      contentType: file.mimetype,
+    });
+  }
+
+  @Post("phone-numbers/:id/requirements/submit")
+  async submitNumberRequirements(
+    @Param("id") id: string,
+    @Body() body: SubmitRequirementsDto,
+  ) {
+    return this.numberPurchasedService.submitNumberRequirements(
+      id,
+      body.requirements,
+    );
   }
 
   @Get("calls")

--- a/apps/frontend/src/features/number/components/tables/my.number.columns.tsx
+++ b/apps/frontend/src/features/number/components/tables/my.number.columns.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { format } from 'date-fns';
 import { cn } from '@ringee/frontend-shared/lib/utils';
 import { useTranslations } from 'next-intl';
+import { VerifyNumberCell } from './verify.number.cell';
 
 export type NumberPurchased = {
   id: string;
@@ -74,11 +75,19 @@ export const columns: ColumnDef<NumberPurchased>[] = [
       const variants: Record<string, string> = {
         assigned: 'default',
         inactive: 'secondary',
-        pending: 'default'
+        pending: 'default',
+        rejected: 'destructive',
+        expired: 'destructive'
       };
 
       const variant = variants[status] as any;
-      const knownStatuses = ['assigned', 'inactive', 'pending'];
+      const knownStatuses = [
+        'assigned',
+        'inactive',
+        'pending',
+        'rejected',
+        'expired'
+      ];
       const label = status
         ? knownStatuses.includes(status)
           ? tStatus(status as any)
@@ -87,7 +96,11 @@ export const columns: ColumnDef<NumberPurchased>[] = [
 
       return (
         <Badge
-          className={cn(status == 'pending' && 'bg-orange-500 text-white')}
+          className={cn(
+            status == 'pending' && 'bg-orange-500 text-white',
+            (status == 'rejected' || status == 'expired') &&
+              'bg-red-500 text-white'
+          )}
           variant={variant}
         >
           {label}
@@ -135,5 +148,13 @@ export const columns: ColumnDef<NumberPurchased>[] = [
       const val = cell.getValue<number | null>();
       return val ? `$${val.toFixed(2)}` : '-';
     }
+  },
+  {
+    id: 'verify',
+    header: () => {
+      const t = useTranslations('settings.numbers.my.table');
+      return <>{t('actions')}</>;
+    },
+    cell: ({ row }) => <VerifyNumberCell data={row.original} />
   }
 ];

--- a/apps/frontend/src/features/number/components/tables/verify.number.cell.tsx
+++ b/apps/frontend/src/features/number/components/tables/verify.number.cell.tsx
@@ -1,0 +1,553 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { IconFileCheck, IconLoader2, IconUpload } from '@tabler/icons-react';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { Badge } from '@ringee/frontend-shared/components/ui/badge';
+import { Input } from '@ringee/frontend-shared/components/ui/input';
+import { Label } from '@ringee/frontend-shared/components/ui/label';
+import { Textarea } from '@ringee/frontend-shared/components/ui/textarea';
+import { ScrollArea } from '@ringee/frontend-shared/components/ui/scroll-area';
+import { Separator } from '@ringee/frontend-shared/components/ui/separator';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@ringee/frontend-shared/components/ui/dialog';
+import { NumberPurchased } from './my.number.columns';
+
+type RequirementFieldType = 'textual' | 'document' | 'address' | string;
+
+interface RequirementItem {
+  id: string;
+  name: string;
+  description?: string;
+  fieldType: RequirementFieldType;
+  acceptanceCriteria?: Record<string, unknown> | null;
+  example?: string | null;
+  status?: string | null;
+  reason?: string | null;
+  fieldValue?: string | null;
+}
+
+function isRejectedStatus(status?: string | null): boolean {
+  return /reject|declin|fail/i.test(status ?? '');
+}
+
+interface NumberRequirements {
+  numberOrderPhoneNumberId: string;
+  phoneNumber: string;
+  countryCode: string;
+  phoneNumberType: string;
+  requirementsStatus: string;
+  requirementsMet: boolean;
+  requirements: RequirementItem[];
+}
+
+interface AddressForm {
+  businessName: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string;
+  streetAddress: string;
+  extendedAddress: string;
+  locality: string;
+  administrativeArea: string;
+  postalCode: string;
+  countryCode: string;
+}
+
+interface RequirementValueState {
+  text: string;
+  documentId?: string;
+  filename?: string;
+  uploading?: boolean;
+  address: AddressForm;
+}
+
+function emptyAddress(countryCode: string): AddressForm {
+  return {
+    businessName: '',
+    firstName: '',
+    lastName: '',
+    phoneNumber: '',
+    streetAddress: '',
+    extendedAddress: '',
+    locality: '',
+    administrativeArea: '',
+    postalCode: '',
+    countryCode: countryCode || ''
+  };
+}
+
+export function VerifyNumberCell({ data }: { data: NumberPurchased }) {
+  const t = useTranslations('settings.numbers.verify');
+  const [open, setOpen] = useState(false);
+
+  const status = (data.status || '').toLowerCase();
+  const actionable = ['pending', 'rejected', 'expired'].includes(status);
+
+  if (!actionable) {
+    return <span className='text-muted-foreground'>-</span>;
+  }
+
+  const needsFix = status === 'rejected' || status === 'expired';
+
+  return (
+    <>
+      <Button
+        size='sm'
+        variant='default'
+        className={
+          needsFix
+            ? 'cursor-pointer bg-red-500 hover:bg-red-600'
+            : 'cursor-pointer bg-orange-500 hover:bg-orange-600'
+        }
+        onClick={() => setOpen(true)}
+      >
+        {needsFix ? t('ctaFix') : t('cta')}
+      </Button>
+      {open && (
+        <VerifyNumberDialog data={data} open={open} onOpenChange={setOpen} />
+      )}
+    </>
+  );
+}
+
+function VerifyNumberDialog({
+  data,
+  open,
+  onOpenChange
+}: {
+  data: NumberPurchased;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useTranslations('settings.numbers.verify');
+  const api = useApi();
+  const router = useRouter();
+
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [reqs, setReqs] = useState<NumberRequirements | null>(null);
+  const [values, setValues] = useState<Record<string, RequirementValueState>>(
+    {}
+  );
+
+  const load = async () => {
+    try {
+      setLoading(true);
+      const res = await api.get<NumberRequirements>(
+        `/telephony/phone-numbers/${data.id}/requirements`
+      );
+      setReqs(res);
+      const initial: Record<string, RequirementValueState> = {};
+      for (const r of res.requirements) {
+        initial[r.id] = {
+          text: r.fieldType === 'textual' ? (r.fieldValue ?? '') : '',
+          address: emptyAddress(res.countryCode || data.isoCountry)
+        };
+      }
+      setValues(initial);
+    } catch {
+      toast.error(t('loadError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Load requirements once when the dialog mounts.
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const setValue = (id: string, patch: Partial<RequirementValueState>) =>
+    setValues((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
+
+  const setAddress = (id: string, patch: Partial<AddressForm>) =>
+    setValues((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], address: { ...prev[id].address, ...patch } }
+    }));
+
+  const uploadDocument = async (id: string, file: File) => {
+    setValue(id, { uploading: true });
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await api.upload<{ documentId: string; filename: string }>(
+        `/telephony/phone-numbers/${data.id}/requirements/documents`,
+        fd
+      );
+      setValue(id, {
+        documentId: res.documentId,
+        filename: res.filename,
+        uploading: false
+      });
+      toast.success(t('uploadOk'));
+    } catch {
+      setValue(id, { uploading: false });
+      toast.error(t('uploadError'));
+    }
+  };
+
+  const isComplete = (r: RequirementItem): boolean => {
+    const v = values[r.id];
+    if (!v) return false;
+    if (r.fieldType === 'document') return !!v.documentId;
+    if (r.fieldType === 'address') {
+      const a = v.address;
+      const hasName = !!a.businessName || (!!a.firstName && !!a.lastName);
+      return !!a.streetAddress && !!a.locality && !!a.countryCode && hasName;
+    }
+    return !!v.text.trim();
+  };
+
+  const canSubmit =
+    !!reqs &&
+    reqs.requirements.length > 0 &&
+    reqs.requirements.every(isComplete);
+
+  const submit = async () => {
+    if (!reqs) return;
+    setSubmitting(true);
+    try {
+      const payload = {
+        requirements: reqs.requirements.map((r) => {
+          const v = values[r.id];
+          if (r.fieldType === 'document') {
+            return {
+              requirementId: r.id,
+              fieldType: 'document',
+              documentId: v.documentId
+            };
+          }
+          if (r.fieldType === 'address') {
+            const a = v.address;
+            return {
+              requirementId: r.id,
+              fieldType: 'address',
+              address: {
+                businessName: a.businessName || undefined,
+                firstName: a.firstName || undefined,
+                lastName: a.lastName || undefined,
+                phoneNumber: a.phoneNumber || undefined,
+                streetAddress: a.streetAddress,
+                extendedAddress: a.extendedAddress || undefined,
+                locality: a.locality,
+                administrativeArea: a.administrativeArea || undefined,
+                postalCode: a.postalCode || undefined,
+                countryCode: a.countryCode
+              }
+            };
+          }
+          return {
+            requirementId: r.id,
+            fieldType: 'textual',
+            textValue: v.text.trim()
+          };
+        })
+      };
+
+      await api.post(
+        `/telephony/phone-numbers/${data.id}/requirements/submit`,
+        payload
+      );
+      toast.success(t('submitOk'));
+      onOpenChange(false);
+      router.refresh();
+    } catch {
+      toast.error(t('submitError'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-h-[90vh] max-w-2xl overflow-hidden'>
+        <DialogHeader>
+          <DialogTitle>{t('title', { phone: data.phoneNumber })}</DialogTitle>
+          <DialogDescription>{t('subtitle')}</DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className='flex items-center justify-center py-10'>
+            <IconLoader2 className='text-muted-foreground h-6 w-6 animate-spin' />
+          </div>
+        ) : !reqs || reqs.requirements.length === 0 ? (
+          <p className='text-muted-foreground py-6 text-sm'>{t('none')}</p>
+        ) : (
+          <div className='space-y-3'>
+            <StatusBanner reqs={reqs} />
+            <ScrollArea className='max-h-[50vh] pr-3'>
+              <div className='space-y-5'>
+                {reqs.requirements.map((r) => (
+                  <RequirementRow
+                    key={r.id}
+                    req={r}
+                    value={values[r.id]}
+                    onText={(text) => setValue(r.id, { text })}
+                    onAddress={(patch) => setAddress(r.id, patch)}
+                    onUpload={(file) => uploadDocument(r.id, file)}
+                  />
+                ))}
+              </div>
+            </ScrollArea>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant='outline'
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            {t('cancel')}
+          </Button>
+          <Button onClick={submit} disabled={!canSubmit || submitting}>
+            {submitting && (
+              <IconLoader2 className='mr-2 h-4 w-4 animate-spin' />
+            )}
+            {t('submit')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StatusBanner({ reqs }: { reqs: NumberRequirements }) {
+  const t = useTranslations('settings.numbers.verify');
+
+  const hasRejected =
+    reqs.requirements.some((r) => isRejectedStatus(r.status)) ||
+    isRejectedStatus(reqs.requirementsStatus);
+  const underReview = /review/i.test(reqs.requirementsStatus || '');
+
+  if (hasRejected) {
+    return (
+      <div className='rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950/20'>
+        {t('rejectedBanner')}
+      </div>
+    );
+  }
+
+  if (underReview) {
+    return (
+      <div className='rounded-md border border-blue-300 bg-blue-50 p-3 text-sm text-blue-700 dark:bg-blue-950/20'>
+        {t('underReview')}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function RequirementRow({
+  req,
+  value,
+  onText,
+  onAddress,
+  onUpload
+}: {
+  req: RequirementItem;
+  value: RequirementValueState;
+  onText: (text: string) => void;
+  onAddress: (patch: Partial<AddressForm>) => void;
+  onUpload: (file: File) => void;
+}) {
+  const t = useTranslations('settings.numbers.verify');
+  const rejected = isRejectedStatus(req.status);
+
+  return (
+    <div
+      className={
+        rejected
+          ? 'rounded-lg border border-red-300 bg-red-50 p-4 dark:bg-red-950/20'
+          : 'rounded-lg border p-4'
+      }
+    >
+      <div className='mb-1 flex items-center justify-between gap-2'>
+        <h4 className='text-sm font-semibold'>{req.name}</h4>
+        <div className='flex items-center gap-2'>
+          <Badge variant='outline' className='capitalize'>
+            {t(`fieldType.${req.fieldType}` as any)}
+          </Badge>
+          {req.status && (
+            <Badge
+              variant={rejected ? 'destructive' : 'outline'}
+              className='capitalize'
+              title={t('statusHint')}
+            >
+              {req.status}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {rejected && (
+        <p className='mb-2 text-xs font-medium text-red-600'>
+          {t('rejectedReason')}: {req.reason || t('rejectedGeneric')}
+        </p>
+      )}
+
+      {req.description && (
+        <p className='text-muted-foreground mb-2 text-xs'>{req.description}</p>
+      )}
+
+      <CriteriaHint criteria={req.acceptanceCriteria} example={req.example} />
+
+      <div className='mt-3'>
+        {req.fieldType === 'document' ? (
+          <DocumentField value={value} onUpload={onUpload} />
+        ) : req.fieldType === 'address' ? (
+          <AddressFields address={value.address} onChange={onAddress} />
+        ) : (
+          <Textarea
+            value={value.text}
+            placeholder={req.example ?? t('valuePlaceholder')}
+            onChange={(e) => onText(e.target.value)}
+            rows={2}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CriteriaHint({
+  criteria,
+  example
+}: {
+  criteria?: Record<string, unknown> | null;
+  example?: string | null;
+}) {
+  const t = useTranslations('settings.numbers.verify');
+  const entries =
+    criteria && typeof criteria === 'object'
+      ? Object.entries(criteria).filter(
+          ([, v]) => v !== null && v !== undefined && v !== ''
+        )
+      : [];
+
+  if (entries.length === 0 && !example) return null;
+
+  return (
+    <div className='bg-muted/50 rounded-md p-2 text-xs'>
+      {entries.length > 0 && (
+        <ul className='text-muted-foreground space-y-0.5'>
+          {entries.map(([k, v]) => (
+            <li key={k}>
+              <span className='font-medium capitalize'>
+                {k.replace(/_/g, ' ')}:
+              </span>{' '}
+              {Array.isArray(v) ? v.join(', ') : String(v)}
+            </li>
+          ))}
+        </ul>
+      )}
+      {example && (
+        <p className='text-muted-foreground mt-1'>
+          <span className='font-medium'>{t('example')}:</span> {example}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DocumentField({
+  value,
+  onUpload
+}: {
+  value: RequirementValueState;
+  onUpload: (file: File) => void;
+}) {
+  const t = useTranslations('settings.numbers.verify');
+
+  if (value.documentId) {
+    return (
+      <div className='flex items-center gap-2 text-sm text-green-600'>
+        <IconFileCheck className='h-4 w-4' />
+        <span className='truncate'>{value.filename ?? t('uploaded')}</span>
+      </div>
+    );
+  }
+
+  return (
+    <label className='border-muted-foreground/30 hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded-md border border-dashed px-3 py-3 text-sm'>
+      {value.uploading ? (
+        <IconLoader2 className='h-4 w-4 animate-spin' />
+      ) : (
+        <IconUpload className='h-4 w-4' />
+      )}
+      <span className='text-muted-foreground'>
+        {value.uploading ? t('uploading') : t('chooseFile')}
+      </span>
+      <input
+        type='file'
+        className='hidden'
+        accept='.pdf,.png,.jpg,.jpeg,.webp,.heic'
+        disabled={value.uploading}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onUpload(file);
+        }}
+      />
+    </label>
+  );
+}
+
+function AddressFields({
+  address,
+  onChange
+}: {
+  address: AddressForm;
+  onChange: (patch: Partial<AddressForm>) => void;
+}) {
+  const t = useTranslations('settings.numbers.verify.address');
+
+  const field = (key: keyof AddressForm, label: string, required = false) => (
+    <div className='space-y-1'>
+      <Label className='text-xs'>
+        {label}
+        {required && <span className='text-red-500'> *</span>}
+      </Label>
+      <Input
+        value={address[key]}
+        onChange={(e) =>
+          onChange({ [key]: e.target.value } as Partial<AddressForm>)
+        }
+      />
+    </div>
+  );
+
+  return (
+    <div className='space-y-3'>
+      <p className='text-muted-foreground text-xs'>{t('hint')}</p>
+      <div className='grid grid-cols-2 gap-3'>
+        {field('businessName', t('businessName'))}
+        {field('phoneNumber', t('phoneNumber'))}
+        {field('firstName', t('firstName'))}
+        {field('lastName', t('lastName'))}
+      </div>
+      <Separator />
+      {field('streetAddress', t('streetAddress'), true)}
+      {field('extendedAddress', t('extendedAddress'))}
+      <div className='grid grid-cols-2 gap-3'>
+        {field('locality', t('locality'), true)}
+        {field('administrativeArea', t('administrativeArea'))}
+        {field('postalCode', t('postalCode'))}
+        {field('countryCode', t('countryCode'), true)}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/i18n/locales/de/settings.json
+++ b/apps/frontend/src/i18n/locales/de/settings.json
@@ -65,12 +65,57 @@
         "monthlyCost": "Monatliche Kosten",
         "upfrontCost": "Einmalige Kosten",
         "unknown": "Unbekannt",
-        "na": "k.A."
+        "na": "k.A.",
+        "actions": "Aktionen"
       },
       "status": {
         "assigned": "zugewiesen",
         "inactive": "inaktiv",
-        "pending": "ausstehend"
+        "pending": "ausstehend",
+        "rejected": "abgelehnt",
+        "expired": "abgelaufen"
+      }
+    },
+    "verify": {
+      "cta": "Verifizierung abschließen",
+      "ctaFix": "Korrigieren & erneut senden",
+      "title": "{phone} verifizieren",
+      "subtitle": "Das Land dieser Nummer erfordert eine Dokumentenprüfung. Geben Sie die folgenden Angaben an, und wir übermitteln sie dem Anbieter zur Prüfung.",
+      "underReview": "Ihre Dokumente wurden übermittelt und werden vom Anbieter geprüft. Dies dauert in der Regel einige Werktage.",
+      "rejectedBanner": "Der Anbieter hat einige Angaben nicht akzeptiert. Korrigieren Sie die unten rot markierten Punkte und senden Sie sie erneut.",
+      "rejectedReason": "Grund",
+      "rejectedGeneric": "Dieser Punkt wurde nicht akzeptiert – bitte korrigieren und erneut senden.",
+      "none": "Für diese Nummer sind keine Anforderungen offen.",
+      "loadError": "Die Verifizierungsanforderungen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+      "cancel": "Abbrechen",
+      "submit": "Zur Verifizierung senden",
+      "submitOk": "Dokumente übermittelt – der Anbieter prüft sie nun. Sie erhalten eine Bestätigungs-E-Mail.",
+      "submitError": "Die Dokumente konnten nicht übermittelt werden. Bitte prüfen Sie die Angaben und versuchen Sie es erneut.",
+      "chooseFile": "Datei auswählen (PDF oder Bild)",
+      "uploading": "Wird hochgeladen…",
+      "uploaded": "Dokument hochgeladen",
+      "uploadOk": "Dokument hochgeladen",
+      "uploadError": "Das Dokument konnte nicht hochgeladen werden. Bitte versuchen Sie es erneut.",
+      "valuePlaceholder": "Geforderten Wert eingeben",
+      "example": "Beispiel",
+      "statusHint": "Aktueller Prüfstatus des Anbieters",
+      "fieldType": {
+        "textual": "Text",
+        "document": "Dokument",
+        "address": "Adresse"
+      },
+      "address": {
+        "hint": "Geben Sie eine vollständige, zustellbare Adresse genau wie in offiziellen Unterlagen an. Der Anbieter prüft sie streng.",
+        "businessName": "Firmenname",
+        "firstName": "Vorname",
+        "lastName": "Nachname",
+        "phoneNumber": "Telefonnummer",
+        "streetAddress": "Straße und Hausnummer",
+        "extendedAddress": "Wohnung / Etage",
+        "locality": "Stadt",
+        "administrativeArea": "Bundesland / Region",
+        "postalCode": "Postleitzahl",
+        "countryCode": "Ländercode (ISO, z. B. GB)"
       }
     }
   },

--- a/apps/frontend/src/i18n/locales/en/settings.json
+++ b/apps/frontend/src/i18n/locales/en/settings.json
@@ -65,12 +65,57 @@
         "monthlyCost": "Monthly Cost",
         "upfrontCost": "Upfront Cost",
         "unknown": "unknown",
-        "na": "N/A"
+        "na": "N/A",
+        "actions": "Actions"
       },
       "status": {
         "assigned": "assigned",
         "inactive": "inactive",
-        "pending": "pending"
+        "pending": "pending",
+        "rejected": "rejected",
+        "expired": "expired"
+      }
+    },
+    "verify": {
+      "cta": "Complete verification",
+      "ctaFix": "Fix & resubmit",
+      "title": "Verify {phone}",
+      "subtitle": "This number's country requires document verification. Provide the items below and we'll submit them to the carrier for review.",
+      "underReview": "Your documents have been submitted and are being reviewed by the carrier. This usually takes a couple of business days.",
+      "rejectedBanner": "The carrier did not approve some items. Fix the ones marked in red below and resubmit.",
+      "rejectedReason": "Reason",
+      "rejectedGeneric": "This item was not accepted — please correct it and resubmit.",
+      "none": "No outstanding requirements for this number.",
+      "loadError": "Could not load the verification requirements. Please try again.",
+      "cancel": "Cancel",
+      "submit": "Submit for verification",
+      "submitOk": "Documents submitted — the carrier is now reviewing them. You'll get a confirmation email.",
+      "submitError": "Could not submit the documents. Please check the values and try again.",
+      "chooseFile": "Choose a file (PDF or image)",
+      "uploading": "Uploading…",
+      "uploaded": "Document uploaded",
+      "uploadOk": "Document uploaded",
+      "uploadError": "Could not upload the document. Please try again.",
+      "valuePlaceholder": "Enter the requested value",
+      "example": "Example",
+      "statusHint": "Current review status from the carrier",
+      "fieldType": {
+        "textual": "Text",
+        "document": "Document",
+        "address": "Address"
+      },
+      "address": {
+        "hint": "Enter a complete, deliverable address exactly as it appears on official records. The carrier validates it strictly.",
+        "businessName": "Business name",
+        "firstName": "First name",
+        "lastName": "Last name",
+        "phoneNumber": "Phone number",
+        "streetAddress": "Street address",
+        "extendedAddress": "Apt / suite / floor",
+        "locality": "City",
+        "administrativeArea": "State / province / region",
+        "postalCode": "Postal code",
+        "countryCode": "Country code (ISO, e.g. GB)"
       }
     }
   },

--- a/apps/frontend/src/i18n/locales/es/settings.json
+++ b/apps/frontend/src/i18n/locales/es/settings.json
@@ -65,12 +65,57 @@
         "monthlyCost": "Coste mensual",
         "upfrontCost": "Coste inicial",
         "unknown": "Desconocido",
-        "na": "N/D"
+        "na": "N/D",
+        "actions": "Acciones"
       },
       "status": {
         "assigned": "asignado",
         "inactive": "inactivo",
-        "pending": "pendiente"
+        "pending": "pendiente",
+        "rejected": "rechazado",
+        "expired": "expirado"
+      }
+    },
+    "verify": {
+      "cta": "Completar verificación",
+      "ctaFix": "Corregir y reenviar",
+      "title": "Verificar {phone}",
+      "subtitle": "El país de este número requiere verificación de documentos. Proporciona los elementos siguientes y los enviaremos al operador para su revisión.",
+      "underReview": "Tus documentos se han enviado y el operador los está revisando. Esto suele tardar un par de días hábiles.",
+      "rejectedBanner": "El operador no aprobó algunos elementos. Corrige los marcados en rojo abajo y vuelve a enviarlos.",
+      "rejectedReason": "Motivo",
+      "rejectedGeneric": "Este elemento no fue aceptado — corrígelo y vuelve a enviarlo.",
+      "none": "No hay requisitos pendientes para este número.",
+      "loadError": "No se pudieron cargar los requisitos de verificación. Inténtalo de nuevo.",
+      "cancel": "Cancelar",
+      "submit": "Enviar para verificación",
+      "submitOk": "Documentos enviados — el operador los está revisando. Recibirás un correo de confirmación.",
+      "submitError": "No se pudieron enviar los documentos. Revisa los valores e inténtalo de nuevo.",
+      "chooseFile": "Elige un archivo (PDF o imagen)",
+      "uploading": "Subiendo…",
+      "uploaded": "Documento subido",
+      "uploadOk": "Documento subido",
+      "uploadError": "No se pudo subir el documento. Inténtalo de nuevo.",
+      "valuePlaceholder": "Introduce el valor solicitado",
+      "example": "Ejemplo",
+      "statusHint": "Estado de revisión actual del operador",
+      "fieldType": {
+        "textual": "Texto",
+        "document": "Documento",
+        "address": "Dirección"
+      },
+      "address": {
+        "hint": "Introduce una dirección completa y válida tal como aparece en los registros oficiales. El operador la valida de forma estricta.",
+        "businessName": "Nombre de empresa",
+        "firstName": "Nombre",
+        "lastName": "Apellidos",
+        "phoneNumber": "Teléfono",
+        "streetAddress": "Dirección (calle y número)",
+        "extendedAddress": "Apto / piso / planta",
+        "locality": "Ciudad",
+        "administrativeArea": "Estado / provincia / región",
+        "postalCode": "Código postal",
+        "countryCode": "Código de país (ISO, p. ej. GB)"
       }
     }
   },

--- a/apps/frontend/src/i18n/locales/fr/settings.json
+++ b/apps/frontend/src/i18n/locales/fr/settings.json
@@ -65,12 +65,57 @@
         "monthlyCost": "Coût mensuel",
         "upfrontCost": "Coût initial",
         "unknown": "Inconnu",
-        "na": "N/D"
+        "na": "N/D",
+        "actions": "Actions"
       },
       "status": {
         "assigned": "attribué",
         "inactive": "inactif",
-        "pending": "en attente"
+        "pending": "en attente",
+        "rejected": "rejeté",
+        "expired": "expiré"
+      }
+    },
+    "verify": {
+      "cta": "Compléter la vérification",
+      "ctaFix": "Corriger et renvoyer",
+      "title": "Vérifier {phone}",
+      "subtitle": "Le pays de ce numéro exige une vérification de documents. Fournissez les éléments ci-dessous et nous les soumettrons à l'opérateur pour examen.",
+      "underReview": "Vos documents ont été soumis et sont en cours d'examen par l'opérateur. Cela prend généralement quelques jours ouvrés.",
+      "rejectedBanner": "L'opérateur n'a pas approuvé certains éléments. Corrigez ceux marqués en rouge ci-dessous et renvoyez-les.",
+      "rejectedReason": "Motif",
+      "rejectedGeneric": "Cet élément n'a pas été accepté — veuillez le corriger et le renvoyer.",
+      "none": "Aucune exigence en attente pour ce numéro.",
+      "loadError": "Impossible de charger les exigences de vérification. Veuillez réessayer.",
+      "cancel": "Annuler",
+      "submit": "Soumettre pour vérification",
+      "submitOk": "Documents soumis — l'opérateur les examine. Vous recevrez un e-mail de confirmation.",
+      "submitError": "Impossible de soumettre les documents. Veuillez vérifier les valeurs et réessayer.",
+      "chooseFile": "Choisir un fichier (PDF ou image)",
+      "uploading": "Téléversement…",
+      "uploaded": "Document téléversé",
+      "uploadOk": "Document téléversé",
+      "uploadError": "Impossible de téléverser le document. Veuillez réessayer.",
+      "valuePlaceholder": "Saisissez la valeur demandée",
+      "example": "Exemple",
+      "statusHint": "Statut d'examen actuel de l'opérateur",
+      "fieldType": {
+        "textual": "Texte",
+        "document": "Document",
+        "address": "Adresse"
+      },
+      "address": {
+        "hint": "Saisissez une adresse complète et distribuable, exactement telle qu'elle figure sur les documents officiels. L'opérateur la valide strictement.",
+        "businessName": "Nom de l'entreprise",
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "phoneNumber": "Téléphone",
+        "streetAddress": "Adresse (rue et numéro)",
+        "extendedAddress": "Appartement / étage",
+        "locality": "Ville",
+        "administrativeArea": "État / région",
+        "postalCode": "Code postal",
+        "countryCode": "Code pays (ISO, p. ex. GB)"
       }
     }
   },

--- a/apps/frontend/src/i18n/locales/it/settings.json
+++ b/apps/frontend/src/i18n/locales/it/settings.json
@@ -65,12 +65,57 @@
         "monthlyCost": "Costo mensile",
         "upfrontCost": "Costo iniziale",
         "unknown": "Sconosciuto",
-        "na": "N/D"
+        "na": "N/D",
+        "actions": "Azioni"
       },
       "status": {
         "assigned": "assegnato",
         "inactive": "inattivo",
-        "pending": "in attesa"
+        "pending": "in attesa",
+        "rejected": "rifiutato",
+        "expired": "scaduto"
+      }
+    },
+    "verify": {
+      "cta": "Completa la verifica",
+      "ctaFix": "Correggi e invia di nuovo",
+      "title": "Verifica {phone}",
+      "subtitle": "Il paese di questo numero richiede la verifica dei documenti. Fornisci gli elementi sottostanti e li invieremo all'operatore per la revisione.",
+      "underReview": "I tuoi documenti sono stati inviati e sono in fase di revisione da parte dell'operatore. Di solito richiede un paio di giorni lavorativi.",
+      "rejectedBanner": "L'operatore non ha approvato alcuni elementi. Correggi quelli evidenziati in rosso qui sotto e inviali di nuovo.",
+      "rejectedReason": "Motivo",
+      "rejectedGeneric": "Questo elemento non è stato accettato — correggilo e invialo di nuovo.",
+      "none": "Nessun requisito in sospeso per questo numero.",
+      "loadError": "Impossibile caricare i requisiti di verifica. Riprova.",
+      "cancel": "Annulla",
+      "submit": "Invia per la verifica",
+      "submitOk": "Documenti inviati — l'operatore li sta esaminando. Riceverai un'email di conferma.",
+      "submitError": "Impossibile inviare i documenti. Controlla i valori e riprova.",
+      "chooseFile": "Scegli un file (PDF o immagine)",
+      "uploading": "Caricamento…",
+      "uploaded": "Documento caricato",
+      "uploadOk": "Documento caricato",
+      "uploadError": "Impossibile caricare il documento. Riprova.",
+      "valuePlaceholder": "Inserisci il valore richiesto",
+      "example": "Esempio",
+      "statusHint": "Stato di revisione attuale dell'operatore",
+      "fieldType": {
+        "textual": "Testo",
+        "document": "Documento",
+        "address": "Indirizzo"
+      },
+      "address": {
+        "hint": "Inserisci un indirizzo completo e recapitabile, esattamente come appare nei documenti ufficiali. L'operatore lo verifica in modo rigoroso.",
+        "businessName": "Nome dell'azienda",
+        "firstName": "Nome",
+        "lastName": "Cognome",
+        "phoneNumber": "Telefono",
+        "streetAddress": "Indirizzo (via e numero)",
+        "extendedAddress": "Interno / piano",
+        "locality": "Città",
+        "administrativeArea": "Stato / regione",
+        "postalCode": "Codice postale",
+        "countryCode": "Codice paese (ISO, es. GB)"
       }
     }
   },

--- a/apps/frontend/src/i18n/locales/nl/settings.json
+++ b/apps/frontend/src/i18n/locales/nl/settings.json
@@ -65,12 +65,57 @@
         "monthlyCost": "Maandelijkse kosten",
         "upfrontCost": "Eenmalige kosten",
         "unknown": "Onbekend",
-        "na": "N.v.t."
+        "na": "N.v.t.",
+        "actions": "Acties"
       },
       "status": {
         "assigned": "toegewezen",
         "inactive": "inactief",
-        "pending": "in afwachting"
+        "pending": "in afwachting",
+        "rejected": "afgewezen",
+        "expired": "verlopen"
+      }
+    },
+    "verify": {
+      "cta": "Verificatie voltooien",
+      "ctaFix": "Corrigeren en opnieuw indienen",
+      "title": "{phone} verifiëren",
+      "subtitle": "Het land van dit nummer vereist documentverificatie. Lever de onderstaande gegevens aan en wij dienen ze ter beoordeling in bij de provider.",
+      "underReview": "Uw documenten zijn ingediend en worden door de provider beoordeeld. Dit duurt meestal enkele werkdagen.",
+      "rejectedBanner": "De provider heeft sommige items niet goedgekeurd. Corrigeer de hieronder rood gemarkeerde items en dien ze opnieuw in.",
+      "rejectedReason": "Reden",
+      "rejectedGeneric": "Dit item is niet geaccepteerd — corrigeer het en dien het opnieuw in.",
+      "none": "Geen openstaande vereisten voor dit nummer.",
+      "loadError": "Kon de verificatievereisten niet laden. Probeer het opnieuw.",
+      "cancel": "Annuleren",
+      "submit": "Indienen voor verificatie",
+      "submitOk": "Documenten ingediend — de provider beoordeelt ze nu. U ontvangt een bevestigingsmail.",
+      "submitError": "Kon de documenten niet indienen. Controleer de waarden en probeer het opnieuw.",
+      "chooseFile": "Kies een bestand (PDF of afbeelding)",
+      "uploading": "Uploaden…",
+      "uploaded": "Document geüpload",
+      "uploadOk": "Document geüpload",
+      "uploadError": "Kon het document niet uploaden. Probeer het opnieuw.",
+      "valuePlaceholder": "Voer de gevraagde waarde in",
+      "example": "Voorbeeld",
+      "statusHint": "Huidige beoordelingsstatus van de provider",
+      "fieldType": {
+        "textual": "Tekst",
+        "document": "Document",
+        "address": "Adres"
+      },
+      "address": {
+        "hint": "Voer een volledig, bezorgbaar adres in, precies zoals het op officiële documenten staat. De provider valideert het streng.",
+        "businessName": "Bedrijfsnaam",
+        "firstName": "Voornaam",
+        "lastName": "Achternaam",
+        "phoneNumber": "Telefoonnummer",
+        "streetAddress": "Straat en huisnummer",
+        "extendedAddress": "Appartement / verdieping",
+        "locality": "Plaats",
+        "administrativeArea": "Provincie / regio",
+        "postalCode": "Postcode",
+        "countryCode": "Landcode (ISO, bijv. GB)"
       }
     }
   },

--- a/apps/frontend/src/i18n/locales/pt/settings.json
+++ b/apps/frontend/src/i18n/locales/pt/settings.json
@@ -65,12 +65,57 @@
         "monthlyCost": "Custo mensal",
         "upfrontCost": "Custo inicial",
         "unknown": "Desconhecido",
-        "na": "N/D"
+        "na": "N/D",
+        "actions": "Ações"
       },
       "status": {
         "assigned": "atribuído",
         "inactive": "inativo",
-        "pending": "pendente"
+        "pending": "pendente",
+        "rejected": "rejeitado",
+        "expired": "expirado"
+      }
+    },
+    "verify": {
+      "cta": "Concluir verificação",
+      "ctaFix": "Corrigir e reenviar",
+      "title": "Verificar {phone}",
+      "subtitle": "O país deste número exige verificação de documentos. Forneça os itens abaixo e nós os enviaremos à operadora para análise.",
+      "underReview": "Os seus documentos foram enviados e estão a ser analisados pela operadora. Normalmente demora alguns dias úteis.",
+      "rejectedBanner": "A operadora não aprovou alguns itens. Corrija os marcados a vermelho abaixo e reenvie.",
+      "rejectedReason": "Motivo",
+      "rejectedGeneric": "Este item não foi aceite — corrija-o e reenvie.",
+      "none": "Não há requisitos pendentes para este número.",
+      "loadError": "Não foi possível carregar os requisitos de verificação. Tente novamente.",
+      "cancel": "Cancelar",
+      "submit": "Enviar para verificação",
+      "submitOk": "Documentos enviados — a operadora está a analisá-los. Receberá um e-mail de confirmação.",
+      "submitError": "Não foi possível enviar os documentos. Verifique os valores e tente novamente.",
+      "chooseFile": "Escolher um ficheiro (PDF ou imagem)",
+      "uploading": "A enviar…",
+      "uploaded": "Documento enviado",
+      "uploadOk": "Documento enviado",
+      "uploadError": "Não foi possível enviar o documento. Tente novamente.",
+      "valuePlaceholder": "Introduza o valor solicitado",
+      "example": "Exemplo",
+      "statusHint": "Estado de análise atual da operadora",
+      "fieldType": {
+        "textual": "Texto",
+        "document": "Documento",
+        "address": "Endereço"
+      },
+      "address": {
+        "hint": "Introduza um endereço completo e entregável, exatamente como aparece nos registos oficiais. A operadora valida-o de forma rigorosa.",
+        "businessName": "Nome da empresa",
+        "firstName": "Nome",
+        "lastName": "Apelido",
+        "phoneNumber": "Telefone",
+        "streetAddress": "Morada (rua e número)",
+        "extendedAddress": "Apartamento / andar",
+        "locality": "Cidade",
+        "administrativeArea": "Distrito / região",
+        "postalCode": "Código postal",
+        "countryCode": "Código do país (ISO, p. ex. GB)"
       }
     }
   },

--- a/apps/orchestrator/src/temporal/activities.ts
+++ b/apps/orchestrator/src/temporal/activities.ts
@@ -6,6 +6,7 @@ import {
   CrmSyncService,
   CustomIntegrationDeliveryService,
   EnrichmentDrainService,
+  NumberPurchasedService,
   RecordingProcessingService,
   ReminderService,
   RetryEngine,
@@ -42,6 +43,7 @@ export function createActivities(app: INestApplicationContext) {
   const enrichmentDrainService = app.get(EnrichmentDrainService);
   const reminderService = app.get(ReminderService);
   const customIntegrationsDelivery = app.get(CustomIntegrationDeliveryService);
+  const numberPurchasedService = app.get(NumberPurchasedService);
 
   return {
     // ── Event-driven jobs (started by the backend via OrchestratorService) ──
@@ -122,6 +124,13 @@ export function createActivities(app: INestApplicationContext) {
       );
       if (count > 0)
         logger.debug(`CustomIntegrationsDrain: ${count} deliveries processed`);
+    },
+
+    async reconcileNumberVerifications() {
+      const count =
+        await numberPurchasedService.reconcilePendingVerifications();
+      if (count > 0)
+        logger.debug(`NumberVerification: ${count} numbers transitioned`);
     },
   };
 }

--- a/apps/orchestrator/src/temporal/schedules.ts
+++ b/apps/orchestrator/src/temporal/schedules.ts
@@ -81,6 +81,14 @@ const SCHEDULES: ScheduleDef[] = [
     every: "15s",
     catchupWindow: "1m",
   },
+  {
+    // Carriers review regulatory documents over hours/days, so a slow cadence
+    // is plenty; this reconciles pending number orders → approved/rejected.
+    id: "ringee.number-verification-check",
+    workflow: WORKFLOW_NAMES.numberVerificationCheck,
+    every: "5m",
+    catchupWindow: "30m",
+  },
 ];
 
 /**

--- a/apps/orchestrator/src/temporal/workflows.ts
+++ b/apps/orchestrator/src/temporal/workflows.ts
@@ -103,3 +103,7 @@ export async function reminderSchedulerWorkflow(): Promise<void> {
 export async function customIntegrationsDrainWorkflow(): Promise<void> {
   await periodicJobs.drainCustomIntegrations();
 }
+
+export async function numberVerificationCheckWorkflow(): Promise<void> {
+  await periodicJobs.reconcileNumberVerifications();
+}

--- a/packages/database/src/database/repositories/number.purchased.repository.ts
+++ b/packages/database/src/database/repositories/number.purchased.repository.ts
@@ -185,4 +185,37 @@ export class NumberPurchasedRepository {
       data,
     });
   }
+
+  /**
+   * Pending numbers awaiting regulatory approval that still have a provider
+   * order to reconcile against. Used by the orchestrator poller.
+   */
+  async findPendingProviderOrders(): Promise<NumberPurchased[]> {
+    return this.prisma.numberPurchased.findMany({
+      where: {
+        status: "pending",
+        providerNumberId: { not: null },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  /**
+   * Enables the UserNumber rows for a number once its order is provisioned, so
+   * it becomes usable (callable) for the owner.
+   */
+  async enableUserNumbersOnProvision(
+    numberId: string,
+    isPrimary: boolean,
+  ): Promise<void> {
+    await this.prisma.userNumber.updateMany({
+      where: { numberId },
+      data: {
+        enabled: true,
+        canCall: true,
+        canReceive: true,
+        isPrimary,
+      },
+    });
+  }
 }

--- a/packages/platform/src/dtos/telephony.dto.ts
+++ b/packages/platform/src/dtos/telephony.dto.ts
@@ -1,4 +1,13 @@
-import { IsString, IsNotEmpty, IsOptional, IsIn } from "class-validator";
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsIn,
+  IsArray,
+  ArrayNotEmpty,
+  ValidateNested,
+} from "class-validator";
+import { Type } from "class-transformer";
 
 export class RequestCallerIdVerificationDto {
   @IsString()
@@ -19,4 +28,91 @@ export class VerifyCallerIdDto {
   @IsString()
   @IsNotEmpty()
   verificationCode!: string;
+}
+
+/**
+ * A postal address submitted for an "address" regulatory requirement. Telnyx
+ * validates these strictly, so streetAddress, locality and countryCode are
+ * mandatory and a name (business or person) is required by the provider.
+ */
+export class TelnyxAddressDto {
+  @IsString()
+  @IsOptional()
+  businessName?: string;
+
+  @IsString()
+  @IsOptional()
+  firstName?: string;
+
+  @IsString()
+  @IsOptional()
+  lastName?: string;
+
+  @IsString()
+  @IsOptional()
+  phoneNumber?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  streetAddress!: string;
+
+  @IsString()
+  @IsOptional()
+  extendedAddress?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  locality!: string;
+
+  @IsString()
+  @IsOptional()
+  administrativeArea?: string;
+
+  @IsString()
+  @IsOptional()
+  neighborhood?: string;
+
+  @IsString()
+  @IsOptional()
+  borough?: string;
+
+  @IsString()
+  @IsOptional()
+  postalCode?: string;
+
+  /** ISO 3166-1 alpha-2 country code (e.g. "GB"). */
+  @IsString()
+  @IsNotEmpty()
+  countryCode!: string;
+}
+
+export class SubmitRequirementItemDto {
+  @IsString()
+  @IsNotEmpty()
+  requirementId!: string;
+
+  @IsString()
+  @IsIn(["textual", "document", "address"])
+  fieldType!: "textual" | "document" | "address";
+
+  @IsString()
+  @IsOptional()
+  textValue?: string;
+
+  @IsString()
+  @IsOptional()
+  documentId?: string;
+
+  @ValidateNested()
+  @Type(() => TelnyxAddressDto)
+  @IsOptional()
+  address?: TelnyxAddressDto;
+}
+
+export class SubmitRequirementsDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => SubmitRequirementItemDto)
+  requirements!: SubmitRequirementItemDto[];
 }

--- a/packages/platform/src/email/email.interface.ts
+++ b/packages/platform/src/email/email.interface.ts
@@ -8,5 +8,6 @@ export interface EmailInterface {
     emailFromName?: string,
     emailFromAddress?: string,
     replyTo?: string,
+    cc?: string | string[],
   ): Promise<any>;
 }

--- a/packages/platform/src/email/resend.provider.ts
+++ b/packages/platform/src/email/resend.provider.ts
@@ -15,6 +15,7 @@ export class ResendProvider implements EmailInterface {
     emailFromAddress?: string,
     // @ts-ignore
     replyTo?: string,
+    cc?: string | string[],
   ) {
     try {
       const sendReplyEmail = !emailFromAddress?.includes("no-reply")
@@ -26,6 +27,7 @@ export class ResendProvider implements EmailInterface {
         to,
         subject,
         html,
+        ...(cc ? { cc } : {}),
         ...(sendReplyEmail && sendReplyEmail),
       });
 

--- a/packages/platform/src/telephony/interfaces/available.number.ts
+++ b/packages/platform/src/telephony/interfaces/available.number.ts
@@ -51,10 +51,143 @@ export interface PurchaseNumbers {
     countryCode: string;
     requirementsStatus: string;
     requirementsMet: boolean;
+    /**
+     * Regulatory requirements attached to this number by the provider. Present
+     * (and `requirementsMet === false`) when the country/number type needs
+     * document verification before the number can be activated.
+     */
+    regulatoryRequirements: RegulatoryRequirement[];
     connectionId: string;
     connectionName: string;
     billingGroupId: string;
   }[];
+}
+
+/** Kind of value the provider expects for a regulatory requirement. */
+export type RequirementFieldType =
+  | "textual"
+  | "document"
+  | "address"
+  | "action"
+  | string;
+
+/**
+ * A single regulatory requirement that must be fulfilled before a number can
+ * be activated (e.g. a proof-of-address document, a local business address, or
+ * a textual field). `id` is the provider's requirement identifier that values
+ * are submitted against.
+ */
+export interface RegulatoryRequirement {
+  id: string;
+  name: string;
+  description?: string;
+  fieldType: RequirementFieldType;
+  /** Provider validation rules for the value (shape varies by requirement). */
+  acceptanceCriteria?: Record<string, unknown> | null;
+  example?: string | null;
+}
+
+export interface RegulatoryRequirementsQuery {
+  countryCode: string; // ISO (eg. "GB")
+  phoneNumberType?: "local" | "toll_free" | "mobile" | "national";
+  action?: "ordering" | "porting";
+}
+
+export interface RegulatoryRequirementsResult {
+  countryCode: string;
+  phoneNumberType: string;
+  action: string;
+  /** true when no documentation is required for this combination. */
+  requirementsMet: boolean;
+  requirements: RegulatoryRequirement[];
+}
+
+/**
+ * The regulatory requirements attached to one specific number within an order,
+ * enriched with the human-readable details (name/description/criteria/example)
+ * needed to guide the user, plus the live fulfilment status for each one.
+ */
+export interface NumberOrderRequirements {
+  /** Telnyx number_order_phone_number id (PATCH target). */
+  numberOrderPhoneNumberId: string;
+  phoneNumber: string;
+  countryCode: string;
+  phoneNumberType: string;
+  /** Provider-level status of the order line ("pending" | "requirement-info-pending" | ...). */
+  requirementsStatus: string;
+  requirementsMet: boolean;
+  requirements: NumberOrderRequirementItem[];
+}
+
+export interface NumberOrderRequirementItem extends RegulatoryRequirement {
+  /** Per-requirement fulfilment status ("approved" | "pending" | "declined" | ...). */
+  status?: string | null;
+  /** Provider-supplied reason when a requirement was declined/rejected. */
+  reason?: string | null;
+  /** Value already submitted for this requirement, if any. */
+  fieldValue?: string | null;
+}
+
+/** Coarse outcome of reconciling a pending order line against the provider. */
+export type NumberVerificationOutcome =
+  | "approved"
+  | "rejected"
+  | "pending"
+  | "expired";
+
+/**
+ * Input for Telnyx POST /addresses. Telnyx validates these strictly, so the
+ * caller must supply a complete, deliverable postal address. Field names mirror
+ * Telnyx's (camelCase here, mapped to snake_case when sent).
+ */
+export interface TelnyxAddressInput {
+  /** Business name OR firstName+lastName is required by Telnyx. */
+  businessName?: string;
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+  /** Required. Street + house number. */
+  streetAddress: string;
+  /** Apartment / suite / floor. */
+  extendedAddress?: string;
+  /** Required. City / town. */
+  locality: string;
+  /** State / province / region — required in many countries. */
+  administrativeArea?: string;
+  neighborhood?: string;
+  borough?: string;
+  /** Postal / ZIP code — required in most countries. */
+  postalCode?: string;
+  /** Required. ISO 3166-1 alpha-2 (e.g. "GB", "DE"). */
+  countryCode: string;
+}
+
+export interface UploadedDocument {
+  documentId: string;
+  filename: string;
+}
+
+/** A single regulatory requirement value the user is submitting. */
+export interface RegulatoryRequirementValue {
+  requirementId: string;
+  /** Resolved value: address id, document id, or the textual value. */
+  fieldValue: string;
+}
+
+/**
+ * What the user submits for one requirement before it is resolved into a
+ * provider field_value. Exactly one of textValue / documentId / address is
+ * expected, matching `fieldType`.
+ */
+export interface SubmitRegulatoryRequirementInput {
+  requirementId: string;
+  fieldType: RequirementFieldType;
+  /** For `textual` requirements. */
+  textValue?: string;
+  /** For `document` requirements — an already-uploaded document id. */
+  documentId?: string;
+  /** For `address` requirements — created with the provider then referenced. */
+  address?: TelnyxAddressInput;
 }
 
 export type NumberFeature =

--- a/packages/platform/src/telephony/interfaces/telephony.numbers.service.ts
+++ b/packages/platform/src/telephony/interfaces/telephony.numbers.service.ts
@@ -1,8 +1,14 @@
 import {
   AssignedNumber,
   AvailableNumber,
+  NumberOrderRequirements,
   PurchaseNumbers,
+  RegulatoryRequirementsQuery,
+  RegulatoryRequirementsResult,
+  RegulatoryRequirementValue,
   SearchAvailableParams,
+  TelnyxAddressInput,
+  UploadedDocument,
 } from "./available.number";
 
 export interface TelephonyNumbersService {
@@ -14,4 +20,43 @@ export interface TelephonyNumbersService {
     phoneNumber: string,
     connectionId?: string,
   ): Promise<AssignedNumber>;
+  /**
+   * Lists the regulatory requirements (documents / fields) that must be
+   * fulfilled to order a number for a given country + number type, so the UI
+   * can tell the user what they'll need to provide.
+   */
+  getRegulatoryRequirements(
+    query: RegulatoryRequirementsQuery,
+  ): Promise<RegulatoryRequirementsResult>;
+
+  /**
+   * Reads the regulatory requirements attached to a specific number within an
+   * order, enriched with descriptions/criteria/examples and the live status of
+   * each requirement.
+   */
+  getNumberOrderRequirements(
+    numberOrderPhoneNumberId: string,
+  ): Promise<NumberOrderRequirements>;
+
+  /** Uploads a document to the provider and returns its id. */
+  uploadDocument(file: {
+    buffer: Buffer;
+    filename: string;
+    contentType: string;
+  }): Promise<UploadedDocument>;
+
+  /**
+   * Creates a validated address with the provider and returns its id, to be
+   * used as the field_value of an "address" regulatory requirement.
+   */
+  createAddress(input: TelnyxAddressInput): Promise<{ addressId: string }>;
+
+  /**
+   * Submits regulatory requirement values for a number within an order. Returns
+   * the refreshed requirement state.
+   */
+  submitNumberOrderRequirements(
+    numberOrderPhoneNumberId: string,
+    requirements: RegulatoryRequirementValue[],
+  ): Promise<NumberOrderRequirements>;
 }

--- a/packages/platform/src/telephony/telephony.service.ts
+++ b/packages/platform/src/telephony/telephony.service.ts
@@ -7,6 +7,12 @@ import {
   PurchaseNumbers,
   AssignedNumber,
   AvailableNumber,
+  NumberOrderRequirements,
+  RegulatoryRequirementsQuery,
+  RegulatoryRequirementsResult,
+  RegulatoryRequirementValue,
+  TelnyxAddressInput,
+  UploadedDocument,
 } from "./interfaces/available.number";
 
 @Injectable()
@@ -67,6 +73,42 @@ export class TelephonyService implements TelephonyServiceInterface {
     return this.getServiceProvider().assignNumberToConnection(
       phoneNumber,
       connectionId,
+    );
+  }
+
+  getRegulatoryRequirements(
+    query: RegulatoryRequirementsQuery,
+  ): Promise<RegulatoryRequirementsResult> {
+    return this.getServiceProvider().getRegulatoryRequirements(query);
+  }
+
+  getNumberOrderRequirements(
+    numberOrderPhoneNumberId: string,
+  ): Promise<NumberOrderRequirements> {
+    return this.getServiceProvider().getNumberOrderRequirements(
+      numberOrderPhoneNumberId,
+    );
+  }
+
+  uploadDocument(file: {
+    buffer: Buffer;
+    filename: string;
+    contentType: string;
+  }): Promise<UploadedDocument> {
+    return this.getServiceProvider().uploadDocument(file);
+  }
+
+  createAddress(input: TelnyxAddressInput): Promise<{ addressId: string }> {
+    return this.getServiceProvider().createAddress(input);
+  }
+
+  submitNumberOrderRequirements(
+    numberOrderPhoneNumberId: string,
+    requirements: RegulatoryRequirementValue[],
+  ): Promise<NumberOrderRequirements> {
+    return this.getServiceProvider().submitNumberOrderRequirements(
+      numberOrderPhoneNumberId,
+      requirements,
     );
   }
 

--- a/packages/platform/src/telephony/telnyx/telnyx.client.ts
+++ b/packages/platform/src/telephony/telnyx/telnyx.client.ts
@@ -51,6 +51,49 @@ export class TelnyxClient {
     }
   }
 
+  /**
+   * Uploads a file as multipart/form-data. The shared axios instance forces
+   * `Content-Type: application/json`, so this uses fetch with a native FormData
+   * boundary instead.
+   */
+  async uploadFile<T = any>(
+    path: string,
+    file: { buffer: Buffer; filename: string; contentType: string },
+    fields: Record<string, string> = {},
+  ): Promise<T> {
+    const form = new FormData();
+    for (const [key, value] of Object.entries(fields)) {
+      form.append(key, value);
+    }
+    form.append(
+      "file",
+      new Blob([new Uint8Array(file.buffer)], { type: file.contentType }),
+      file.filename,
+    );
+
+    const res = await fetch(`https://api.telnyx.com/v2${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiConfiguration.TELNYX_API_KEY}`,
+      },
+      body: form,
+    });
+
+    const text = await res.text();
+    let json: any;
+    try {
+      json = text ? JSON.parse(text) : {};
+    } catch {
+      json = { raw: text };
+    }
+
+    if (!res.ok) {
+      throw new HttpException(json, res.status || HttpStatus.BAD_GATEWAY);
+    }
+
+    return json;
+  }
+
   async download(path: string): Promise<ArrayBuffer> {
     try {
       const fetchResponse = await fetch(path);

--- a/packages/platform/src/telephony/telnyx/telnyx.service.ts
+++ b/packages/platform/src/telephony/telnyx/telnyx.service.ts
@@ -4,8 +4,16 @@ import { TelnyxClient } from "./telnyx.client";
 import {
   AssignedNumber,
   AvailableNumber,
+  NumberOrderRequirementItem,
+  NumberOrderRequirements,
   PurchaseNumbers,
+  RegulatoryRequirement,
+  RegulatoryRequirementsQuery,
+  RegulatoryRequirementsResult,
+  RegulatoryRequirementValue,
   SearchAvailableParams,
+  TelnyxAddressInput,
+  UploadedDocument,
 } from "../interfaces/available.number";
 import { apiConfiguration } from "@ringee/configuration";
 import { TelephonyService } from "../interfaces/telephony.service";
@@ -192,7 +200,7 @@ export class TelnyxService implements TelephonyService {
 
     const { data } = await this.telnyxClient.post("/number_orders", payload);
 
-    const response = {
+    const response: PurchaseNumbers = {
       billingGroupId: data.billing_group_id,
       orderId: data.id,
       phoneNumbersCount: data.phone_numbers_count,
@@ -206,6 +214,9 @@ export class TelnyxService implements TelephonyService {
         countryCode: number.country_code,
         requirementsStatus: number.requirements_status,
         requirementsMet: number.requirements_met,
+        regulatoryRequirements: this.mapRegulatoryRequirements(
+          number.regulatory_requirements,
+        ),
         connectionId: "",
         connectionName: "",
         billingGroupId: data.billing_group_id,
@@ -213,6 +224,19 @@ export class TelnyxService implements TelephonyService {
     };
 
     for (const phoneNumber of response.phoneNumbers) {
+      // Numbers from countries that require document verification come back
+      // with `requirements_met === false` and stay in a pending order until the
+      // documents are submitted and approved. They are NOT yet provisioned, so
+      // assigning them to a connection (PATCH /phone_numbers/{number}) would
+      // 404. Skip assignment for those; the caller persists them as `pending`.
+      if (phoneNumber.requirementsMet === false) {
+        this.logger.warn(
+          `Number ${phoneNumber.phoneNumber} (order ${response.orderId}) requires regulatory verification ` +
+            `(${phoneNumber.regulatoryRequirements.length} requirement(s)); leaving unassigned until requirements are met.`,
+        );
+        continue;
+      }
+
       const assignedNumber = await this.assignNumberToConnection(
         phoneNumber.phoneNumber,
       );
@@ -222,6 +246,225 @@ export class TelnyxService implements TelephonyService {
     }
 
     return response;
+  }
+
+  private mapRegulatoryRequirements(raw: any): RegulatoryRequirement[] {
+    if (!Array.isArray(raw)) return [];
+    return raw.map((req: any) => ({
+      id: req?.requirement_id ?? req?.id,
+      name: req?.name ?? req?.requirement_id ?? req?.id ?? "Requirement",
+      description: req?.description,
+      fieldType: req?.field_type ?? req?.type ?? "textual",
+      acceptanceCriteria: req?.acceptance_criteria ?? null,
+      example: req?.example ?? null,
+    }));
+  }
+
+  async getRegulatoryRequirements(
+    query: RegulatoryRequirementsQuery,
+  ): Promise<RegulatoryRequirementsResult> {
+    const phoneNumberType = query.phoneNumberType ?? "local";
+    const action = query.action ?? "ordering";
+
+    const params = new URLSearchParams({
+      "filter[country_code]": query.countryCode,
+      "filter[phone_number_type]": phoneNumberType,
+      "filter[action]": action,
+    });
+
+    try {
+      const { data } = await this.telnyxClient.get(
+        `/requirements?${params.toString()}`,
+      );
+
+      const records: any[] = Array.isArray(data) ? data : [];
+      const requirements: RegulatoryRequirement[] = [];
+      const seen = new Set<string>();
+
+      for (const record of records) {
+        const types: any[] = Array.isArray(record?.requirement_types)
+          ? record.requirement_types
+          : [];
+
+        for (const type of types) {
+          // Entries may be full objects or bare requirement-type id strings.
+          const id = typeof type === "string" ? type : (type?.id ?? type?.uuid);
+          if (!id || seen.has(id)) continue;
+          seen.add(id);
+
+          requirements.push({
+            id,
+            name: typeof type === "string" ? id : (type?.name ?? id),
+            description:
+              typeof type === "string" ? undefined : type?.description,
+            fieldType:
+              typeof type === "string"
+                ? "textual"
+                : (type?.type ?? type?.field_type ?? "textual"),
+            acceptanceCriteria:
+              typeof type === "string"
+                ? null
+                : (type?.acceptance_criteria ?? null),
+            example: typeof type === "string" ? null : (type?.example ?? null),
+          });
+        }
+      }
+
+      return {
+        countryCode: query.countryCode,
+        phoneNumberType,
+        action,
+        requirementsMet: requirements.length === 0,
+        requirements,
+      };
+    } catch (error: any) {
+      this.logger.error(
+        `Failed to fetch regulatory requirements for ${query.countryCode}/${phoneNumberType}: ${error?.message}`,
+      );
+      throw error;
+    }
+  }
+
+  async getNumberOrderRequirements(
+    numberOrderPhoneNumberId: string,
+  ): Promise<NumberOrderRequirements> {
+    const { data } = await this.telnyxClient.get(
+      `/number_order_phone_numbers/${numberOrderPhoneNumberId}`,
+    );
+
+    const countryCode: string = data?.country_code ?? "";
+    const phoneNumberType: string = data?.phone_number_type ?? "local";
+
+    // Enrich the bare requirement ids attached to this number with the
+    // human-readable details for the country/type combination so the UI can be
+    // descriptive about what each document/field is.
+    const details = new Map<string, RegulatoryRequirement>();
+    if (countryCode) {
+      try {
+        const catalog = await this.getRegulatoryRequirements({
+          countryCode,
+          phoneNumberType:
+            phoneNumberType as RegulatoryRequirementsQuery["phoneNumberType"],
+          action: "ordering",
+        });
+        for (const req of catalog.requirements) details.set(req.id, req);
+      } catch (err: any) {
+        this.logger.warn(
+          `Could not enrich requirement details for ${countryCode}/${phoneNumberType}: ${err?.message}`,
+        );
+      }
+    }
+
+    const rawReqs: any[] = Array.isArray(data?.regulatory_requirements)
+      ? data.regulatory_requirements
+      : [];
+
+    const requirements: NumberOrderRequirementItem[] = rawReqs.map((req) => {
+      const id: string = req?.requirement_id ?? req?.field_type ?? "";
+      const detail = details.get(id);
+      return {
+        id,
+        name: detail?.name ?? req?.name ?? id,
+        description: detail?.description,
+        fieldType: detail?.fieldType ?? req?.field_type ?? "textual",
+        acceptanceCriteria: detail?.acceptanceCriteria ?? null,
+        example: detail?.example ?? null,
+        status: req?.status ?? null,
+        reason:
+          req?.reason ??
+          req?.declined_reason ??
+          req?.rejection_reason ??
+          req?.requirement_status_reason ??
+          null,
+        fieldValue: req?.field_value ?? null,
+      };
+    });
+
+    return {
+      numberOrderPhoneNumberId: data?.id ?? numberOrderPhoneNumberId,
+      phoneNumber: data?.phone_number ?? "",
+      countryCode,
+      phoneNumberType,
+      requirementsStatus: data?.requirements_status ?? "pending",
+      requirementsMet: !!data?.requirements_met,
+      requirements,
+    };
+  }
+
+  async uploadDocument(file: {
+    buffer: Buffer;
+    filename: string;
+    contentType: string;
+  }): Promise<UploadedDocument> {
+    const data = await this.telnyxClient.uploadFile("/documents", file);
+    const documentId: string = data?.data?.id ?? data?.id;
+
+    if (!documentId) {
+      throw new HttpException("Telnyx did not return a document id", 502);
+    }
+
+    return { documentId, filename: file.filename };
+  }
+
+  async createAddress(
+    input: TelnyxAddressInput,
+  ): Promise<{ addressId: string }> {
+    if (!input.businessName && !(input.firstName && input.lastName)) {
+      throw new HttpException(
+        "An address needs either a business name or a first and last name",
+        422,
+      );
+    }
+
+    const payload: Record<string, unknown> = {
+      business_name: input.businessName,
+      first_name: input.firstName,
+      last_name: input.lastName,
+      phone_number: input.phoneNumber,
+      street_address: input.streetAddress,
+      extended_address: input.extendedAddress,
+      locality: input.locality,
+      administrative_area: input.administrativeArea,
+      neighborhood: input.neighborhood,
+      borough: input.borough,
+      postal_code: input.postalCode,
+      country_code: input.countryCode,
+      // Telnyx is strict about regulatory addresses: ask it to validate so a
+      // bad address fails here instead of silently blocking the order.
+      validate_address: true,
+    };
+
+    for (const key of Object.keys(payload)) {
+      if (payload[key] === undefined || payload[key] === "") {
+        delete payload[key];
+      }
+    }
+
+    const { data } = await this.telnyxClient.post("/addresses", payload);
+    const addressId: string = data?.id;
+
+    if (!addressId) {
+      throw new HttpException("Telnyx did not return an address id", 502);
+    }
+
+    return { addressId };
+  }
+
+  async submitNumberOrderRequirements(
+    numberOrderPhoneNumberId: string,
+    requirements: RegulatoryRequirementValue[],
+  ): Promise<NumberOrderRequirements> {
+    await this.telnyxClient.patch(
+      `/number_order_phone_numbers/${numberOrderPhoneNumberId}`,
+      {
+        regulatory_requirements: requirements.map((req) => ({
+          requirement_id: req.requirementId,
+          field_value: req.fieldValue,
+        })),
+      },
+    );
+
+    return this.getNumberOrderRequirements(numberOrderPhoneNumberId);
   }
 
   async assignNumberToConnection(

--- a/packages/platform/src/temporal/contracts.ts
+++ b/packages/platform/src/temporal/contracts.ts
@@ -40,6 +40,7 @@ export const WORKFLOW_NAMES = {
   enrichmentDrain: "enrichmentDrainWorkflow",
   reminderScheduler: "reminderSchedulerWorkflow",
   customIntegrationsDrain: "customIntegrationsDrainWorkflow",
+  numberVerificationCheck: "numberVerificationCheckWorkflow",
 } as const;
 
 export type WorkflowName = (typeof WORKFLOW_NAMES)[keyof typeof WORKFLOW_NAMES];

--- a/packages/services/src/services/number.purchased.service.ts
+++ b/packages/services/src/services/number.purchased.service.ts
@@ -1,19 +1,41 @@
-import { Injectable, Logger, NotFoundException } from "@nestjs/common";
-import { NumberPurchased, NumberPurchasedRepository } from "@ringee/database";
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import {
+  NumberPurchased,
+  NumberPurchasedRepository,
+  UserRepository,
+} from "@ringee/database";
 import {
   TelephonyService,
   CostInformation,
   OwnershipContext,
+  PurchaseNumbers,
+  NumberOrderRequirements,
+  NumberVerificationOutcome,
+  RegulatoryRequirementValue,
+  ResendProvider,
+  SubmitRegulatoryRequirementInput,
+  UploadedDocument,
 } from "@ringee/platform";
 import { apiConfiguration } from "@ringee/configuration";
+
+/** Internal address copied on every regulatory-submission follow-up email. */
+const REGULATORY_FOLLOWUP_CC = "edisonpadilla.dev@gmail.com";
 
 @Injectable()
 export class NumberPurchasedService {
   private readonly logger = new Logger(NumberPurchasedService.name);
 
+  private readonly email = new ResendProvider();
+
   constructor(
     private readonly numberPurchasedRepository: NumberPurchasedRepository,
     private telephonyService: TelephonyService,
+    private readonly userRepository: UserRepository,
   ) {}
 
   release(id: string): Promise<NumberPurchased> {
@@ -141,6 +163,24 @@ export class NumberPurchasedService {
     const purchase = await this.telephonyService.purchaseNumbers([numberId]);
     const phoneNumber = purchase.phoneNumbers[0]!;
 
+    // Countries that require document verification come back with the order in
+    // a `pending` state and the number not yet provisioned (no connection, no
+    // readable features). Persist it as `pending` instead of throwing so the
+    // user's payment is recorded and the platform can prompt them to upload the
+    // required documents. See getRegulatoryRequirements for the document list.
+    if (phoneNumber.requirementsMet === false) {
+      this.logger.warn(
+        `Number ${phoneNumber.phoneNumber} requires regulatory verification ` +
+          `(order ${purchase.orderId}); saving as pending.`,
+      );
+      return this.createPendingNumber(
+        ctx,
+        phoneNumber,
+        purchase,
+        costInformation,
+      );
+    }
+
     const numbers = await this.numberPurchasedRepository.findByOwner(ctx);
 
     const foundPrimaryNumber = numbers.find((number) => {
@@ -238,4 +278,563 @@ export class NumberPurchasedService {
 
     return created;
   }
+
+  /**
+   * Persists a freshly ordered number whose regulatory requirements are not yet
+   * met. The number is NOT assigned to a connection and has no `assignedDate`,
+   * so it cannot be used to place calls until verification completes. The
+   * UserNumber is created disabled so it shows up in "My numbers" as pending
+   * without being selectable as a caller ID.
+   */
+  private createPendingNumber(
+    ctx: OwnershipContext,
+    phoneNumber: PurchaseNumbers["phoneNumbers"][number],
+    purchase: PurchaseNumbers,
+    costInformation: CostInformation,
+  ): Promise<NumberPurchased> {
+    return this.numberPurchasedRepository.create(ctx, {
+      userNumbers: {
+        create: {
+          userId: ctx.userId,
+          organizationId: ctx.organizationId ?? null,
+          isPrimary: false,
+          canCall: false,
+          canReceive: false,
+          canRecord: false,
+          enabled: false,
+          canSendSms: false,
+          canReceiveSms: false,
+          canSendMms: false,
+          canReceiveMms: false,
+        },
+      },
+      phoneNumber: phoneNumber.phoneNumber,
+      isoCountry: phoneNumber.countryCode,
+      phoneNumberType: phoneNumber.phoneNumberType,
+      status: "pending",
+      provider: purchase.provider,
+      providerNumberId: phoneNumber.id,
+      providerOrderId: purchase.orderId,
+      purchaseDate: new Date(),
+      // No assignedDate / connection: number is not provisioned yet.
+      billingGroupId: purchase.billingGroupId,
+      monthlyCost: costInformation.monthlyCost,
+      currency: costInformation.currency,
+      upfrontCost: costInformation.upfrontCost,
+      messagingStatus: "pending",
+    });
+  }
+
+  /**
+   * Reads the regulatory requirements (documents / fields) still needed for a
+   * pending number, enriched with descriptions so the UI can guide the user.
+   */
+  async getNumberRequirements(
+    numberPurchasedId: string,
+  ): Promise<NumberOrderRequirements> {
+    const number =
+      await this.numberPurchasedRepository.findById(numberPurchasedId);
+    if (!number) throw new NotFoundException("Number not found");
+    if (!number.providerNumberId) {
+      throw new BadRequestException(
+        "This number has no provider order to fulfil requirements for",
+      );
+    }
+
+    return this.telephonyService.getNumberOrderRequirements(
+      number.providerNumberId,
+    );
+  }
+
+  /** Uploads a single requirement document to the provider. */
+  uploadRequirementDocument(file: {
+    buffer: Buffer;
+    filename: string;
+    contentType: string;
+  }): Promise<UploadedDocument> {
+    return this.telephonyService.uploadDocument(file);
+  }
+
+  /**
+   * Resolves each submitted requirement into a provider field_value (creating
+   * addresses as needed), submits them to the provider, then emails a
+   * descriptive follow-up to the client (CC the internal inbox) so any further
+   * communication with the provider can happen in that thread.
+   */
+  async submitNumberRequirements(
+    numberPurchasedId: string,
+    inputs: SubmitRegulatoryRequirementInput[],
+  ): Promise<NumberOrderRequirements> {
+    const number =
+      await this.numberPurchasedRepository.findById(numberPurchasedId);
+    if (!number) throw new NotFoundException("Number not found");
+    if (!number.providerNumberId) {
+      throw new BadRequestException(
+        "This number has no provider order to fulfil requirements for",
+      );
+    }
+    if (!inputs?.length) {
+      throw new BadRequestException("No requirements provided");
+    }
+
+    // Track a human-readable summary per requirement for the follow-up email.
+    const summaries: { requirementId: string; summary: string }[] = [];
+    const values: RegulatoryRequirementValue[] = [];
+
+    for (const input of inputs) {
+      if (!input.requirementId) {
+        throw new BadRequestException("Missing requirementId on a requirement");
+      }
+
+      if (input.fieldType === "address") {
+        if (!input.address) {
+          throw new BadRequestException(
+            `Requirement ${input.requirementId} needs an address`,
+          );
+        }
+        const { addressId } = await this.telephonyService.createAddress(
+          input.address,
+        );
+        values.push({
+          requirementId: input.requirementId,
+          fieldValue: addressId,
+        });
+        summaries.push({
+          requirementId: input.requirementId,
+          summary: `Address: ${this.formatAddress(input.address)} (Telnyx address ${addressId})`,
+        });
+      } else if (input.fieldType === "document") {
+        if (!input.documentId) {
+          throw new BadRequestException(
+            `Requirement ${input.requirementId} needs an uploaded document`,
+          );
+        }
+        values.push({
+          requirementId: input.requirementId,
+          fieldValue: input.documentId,
+        });
+        summaries.push({
+          requirementId: input.requirementId,
+          summary: `Document uploaded (Telnyx document ${input.documentId})`,
+        });
+      } else {
+        const text = input.textValue?.trim();
+        if (!text) {
+          throw new BadRequestException(
+            `Requirement ${input.requirementId} needs a value`,
+          );
+        }
+        values.push({ requirementId: input.requirementId, fieldValue: text });
+        summaries.push({
+          requirementId: input.requirementId,
+          summary: text,
+        });
+      }
+    }
+
+    const result = await this.telephonyService.submitNumberOrderRequirements(
+      number.providerNumberId,
+      values,
+    );
+
+    // A previously rejected number goes back to `pending` so the reconciliation
+    // poller re-evaluates it once the carrier reviews the resubmission.
+    if (number.status !== "pending") {
+      await this.numberPurchasedRepository.update(number.id, {
+        status: "pending",
+      });
+    }
+
+    // Best-effort follow-up email; never fail the submission because email did.
+    try {
+      await this.sendRequirementsSubmittedEmail(number, result, summaries);
+    } catch (err) {
+      this.logger.error(
+        `Requirements submitted for ${number.phoneNumber} but follow-up email failed: ${(err as Error).message}`,
+      );
+    }
+
+    return result;
+  }
+
+  private formatAddress(a: {
+    businessName?: string;
+    firstName?: string;
+    lastName?: string;
+    streetAddress: string;
+    extendedAddress?: string;
+    locality: string;
+    administrativeArea?: string;
+    postalCode?: string;
+    countryCode: string;
+  }): string {
+    const who =
+      a.businessName || `${a.firstName ?? ""} ${a.lastName ?? ""}`.trim();
+    return [
+      who,
+      a.streetAddress,
+      a.extendedAddress,
+      a.locality,
+      a.administrativeArea,
+      a.postalCode,
+      a.countryCode,
+    ]
+      .filter(Boolean)
+      .join(", ");
+  }
+
+  private async resolveClient(
+    number: NumberPurchased,
+  ): Promise<{ email: string | null; name: string }> {
+    if (!number.userId) return { email: null, name: "Ringee user" };
+    const user = await this.userRepository.findById(number.userId);
+    const emails = (
+      user as unknown as { emails?: { email: string; isPrimary: boolean }[] }
+    )?.emails;
+    const email =
+      emails?.find((e) => e.isPrimary)?.email ?? emails?.[0]?.email ?? null;
+    const name =
+      `${user?.firstName ?? ""} ${user?.lastName ?? ""}`.trim() ||
+      "Ringee user";
+    return { email, name };
+  }
+
+  private async sendRequirementsSubmittedEmail(
+    number: NumberPurchased,
+    result: NumberOrderRequirements,
+    summaries: { requirementId: string; summary: string }[],
+  ): Promise<void> {
+    const client = await this.resolveClient(number);
+
+    // Map each submitted requirement to its human-readable name when known.
+    const nameById = new Map(
+      result.requirements.map((r) => [r.id, r.name] as const),
+    );
+    const rows = summaries
+      .map((s) => {
+        const label = nameById.get(s.requirementId) ?? s.requirementId;
+        return `<tr>
+          <td style="padding:6px 12px;border-bottom:1px solid #eee;vertical-align:top;"><strong>${escapeHtml(label)}</strong></td>
+          <td style="padding:6px 12px;border-bottom:1px solid #eee;vertical-align:top;">${escapeHtml(s.summary)}</td>
+        </tr>`;
+      })
+      .join("");
+
+    const html = `
+      <div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#171717;max-width:640px;">
+        <h2 style="margin:0 0 12px;">Verification documents submitted</h2>
+        <p>The regulatory documents for the number below have been submitted to Telnyx and are now under review.</p>
+        <table style="border-collapse:collapse;margin:12px 0;">
+          <tr><td style="padding:4px 12px;color:#737373;">Phone number</td><td style="padding:4px 12px;"><strong>${escapeHtml(number.phoneNumber)}</strong></td></tr>
+          <tr><td style="padding:4px 12px;color:#737373;">Country</td><td style="padding:4px 12px;">${escapeHtml(number.isoCountry)} (${escapeHtml(number.phoneNumberType ?? "local")})</td></tr>
+          <tr><td style="padding:4px 12px;color:#737373;">Telnyx order</td><td style="padding:4px 12px;">${escapeHtml(number.providerOrderId ?? "")}</td></tr>
+          <tr><td style="padding:4px 12px;color:#737373;">Status</td><td style="padding:4px 12px;">${escapeHtml(result.requirementsStatus)}</td></tr>
+        </table>
+        <h3 style="margin:16px 0 4px;">Submitted requirements</h3>
+        <table style="border-collapse:collapse;width:100%;">${rows}</table>
+        <p style="margin-top:16px;color:#737373;">
+          Telnyx usually reviews regulatory documents within a couple of business days.
+          Reply to this email to follow up — both the account owner and the Ringee team are on this thread.
+        </p>
+      </div>
+    `;
+
+    const recipients = client.email ? [client.email] : [REGULATORY_FOLLOWUP_CC];
+    const cc = client.email ? [REGULATORY_FOLLOWUP_CC] : undefined;
+
+    await this.email.sendEmail(
+      recipients,
+      `Verification submitted for ${number.phoneNumber}`,
+      html,
+      "Ringee Notifications",
+      apiConfiguration.EMAIL_FROM_ADDRESS,
+      REGULATORY_FOLLOWUP_CC,
+      cc,
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Reconciliation (orchestrator poller)
+  // ────────────────────────────────────────────────────────────
+
+  /**
+   * Polls the provider for every number still awaiting regulatory approval and
+   * transitions it: approved → provision + notify; rejected/expired → mark +
+   * notify with reasons; otherwise leave pending. Returns how many numbers
+   * changed state this run. Per-number failures are isolated and logged.
+   */
+  async reconcilePendingVerifications(): Promise<number> {
+    const pending =
+      await this.numberPurchasedRepository.findPendingProviderOrders();
+    let changed = 0;
+
+    for (const number of pending) {
+      try {
+        const outcome = await this.reconcileOne(number);
+        if (outcome !== "pending") changed++;
+      } catch (err) {
+        this.logger.error(
+          `Failed to reconcile verification for ${number.phoneNumber}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    return changed;
+  }
+
+  private async reconcileOne(
+    number: NumberPurchased,
+  ): Promise<NumberVerificationOutcome> {
+    const result = await this.telephonyService.getNumberOrderRequirements(
+      number.providerNumberId!,
+    );
+    const outcome = classifyVerification(result);
+
+    if (outcome === "approved") {
+      const provisioned = await this.provisionApprovedNumber(number);
+      // Assignment can fail transiently — leave pending so the next tick retries.
+      if (!provisioned) return "pending";
+      await this.sendVerificationApprovedEmail(number);
+      this.logger.log(`Number ${number.phoneNumber} approved and provisioned`);
+      return "approved";
+    }
+
+    if (outcome === "rejected" || outcome === "expired") {
+      await this.numberPurchasedRepository.update(number.id, {
+        status: outcome,
+      });
+      await this.sendVerificationRejectedEmail(number, result, outcome);
+      this.logger.log(`Number ${number.phoneNumber} verification ${outcome}`);
+      return outcome;
+    }
+
+    return "pending";
+  }
+
+  /**
+   * Assigns an approved number to the voice connection and flips it to
+   * `assigned`, enabling its UserNumber so it can place calls. Returns false if
+   * the provider assignment failed (caller leaves it pending to retry).
+   */
+  private async provisionApprovedNumber(
+    number: NumberPurchased,
+  ): Promise<boolean> {
+    let connectionId = "";
+    let connectionName = "";
+    try {
+      const assigned = await this.telephonyService.assignNumberToConnection(
+        number.phoneNumber,
+      );
+      connectionId = assigned.connectionId;
+      connectionName = assigned.connectionName;
+    } catch (err) {
+      this.logger.warn(
+        `Approved number ${number.phoneNumber} could not be assigned to a connection yet: ${(err as Error).message}`,
+      );
+      return false;
+    }
+
+    let features: {
+      sms?: boolean;
+      mms?: boolean;
+      voice?: boolean;
+      fax?: boolean;
+      hdVoice?: boolean;
+      internationalSms?: boolean;
+      emergency?: boolean;
+      raw?: any;
+    } = {};
+    try {
+      features = await this.telephonyService.getPhoneNumberFeatures(
+        number.phoneNumber,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Could not read features for newly provisioned ${number.phoneNumber}: ${(err as Error).message}`,
+      );
+    }
+
+    const smsEnabled = !!features.sms;
+    const mmsEnabled = !!features.mms;
+    const messagingEnabled = smsEnabled || mmsEnabled;
+    const profileId =
+      features.raw?.messaging_profile_id ??
+      apiConfiguration.TELNYX_MESSAGING_PROFILE_ID ??
+      null;
+
+    // Match buyNumber: become the owner's primary number only if they have none.
+    const ctx: OwnershipContext = {
+      userId: number.userId!,
+      organizationId: number.organizationId ?? null,
+    };
+    const owned = await this.numberPurchasedRepository.findByOwner(ctx);
+    const hasPrimary = owned.some((n) =>
+      n.userNumbers?.some((u) => u.isPrimary),
+    );
+
+    await this.numberPurchasedRepository.update(number.id, {
+      status: "assigned",
+      assignedDate: new Date(),
+      providerConnectionId: connectionId,
+      providerConnectionName: connectionName,
+      smsEnabled,
+      mmsEnabled,
+      voiceEnabled: features.voice ?? true,
+      faxEnabled: !!features.fax,
+      hdVoiceEnabled: features.hdVoice ?? true,
+      internationalSmsEnabled: !!features.internationalSms,
+      emergencyEnabled: !!features.emergency,
+      messagingEnabled,
+      providerMessagingProfileId: profileId,
+      messagingStatus: messagingEnabled ? "ready" : "unavailable",
+      features: {
+        sms: smsEnabled,
+        mms: mmsEnabled,
+        voice: features.voice ?? true,
+        fax: !!features.fax,
+        hdVoice: features.hdVoice ?? true,
+        internationalSms: !!features.internationalSms,
+        emergency: !!features.emergency,
+      },
+    });
+
+    await this.numberPurchasedRepository.enableUserNumbersOnProvision(
+      number.id,
+      !hasPrimary,
+    );
+    await this.numberPurchasedRepository.updateMessagingForUserNumbers(
+      number.id,
+      {
+        canSendSms: smsEnabled,
+        canReceiveSms: smsEnabled,
+        canSendMms: mmsEnabled,
+        canReceiveMms: mmsEnabled,
+      },
+    );
+
+    return true;
+  }
+
+  private async sendVerificationApprovedEmail(
+    number: NumberPurchased,
+  ): Promise<void> {
+    const html = `
+      <div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#171717;max-width:640px;">
+        <h2 style="margin:0 0 12px;">Your number is verified and active 🎉</h2>
+        <p>Good news — the carrier approved the regulatory documents for <strong>${escapeHtml(number.phoneNumber)}</strong>. The number is now active and ready to make and receive calls in Ringee.</p>
+        <table style="border-collapse:collapse;margin:12px 0;">
+          <tr><td style="padding:4px 12px;color:#737373;">Phone number</td><td style="padding:4px 12px;"><strong>${escapeHtml(number.phoneNumber)}</strong></td></tr>
+          <tr><td style="padding:4px 12px;color:#737373;">Country</td><td style="padding:4px 12px;">${escapeHtml(number.isoCountry)} (${escapeHtml(number.phoneNumberType ?? "local")})</td></tr>
+          <tr><td style="padding:4px 12px;color:#737373;">Telnyx order</td><td style="padding:4px 12px;">${escapeHtml(number.providerOrderId ?? "")}</td></tr>
+        </table>
+        <p style="margin-top:16px;color:#737373;">Reply to this email if you need anything — the Ringee team is on this thread.</p>
+      </div>
+    `;
+    await this.sendClientEmail(
+      number,
+      `${number.phoneNumber} is verified and active`,
+      html,
+    );
+  }
+
+  private async sendVerificationRejectedEmail(
+    number: NumberPurchased,
+    result: NumberOrderRequirements,
+    outcome: "rejected" | "expired",
+  ): Promise<void> {
+    const rejected = result.requirements.filter((r) =>
+      /reject|declin|fail/i.test(r.status ?? ""),
+    );
+    // If the carrier flagged the order but not individual items, show them all.
+    const toShow = rejected.length > 0 ? rejected : result.requirements;
+
+    const rows = toShow
+      .map(
+        (r) => `<tr>
+          <td style="padding:6px 12px;border-bottom:1px solid #eee;vertical-align:top;"><strong>${escapeHtml(r.name)}</strong></td>
+          <td style="padding:6px 12px;border-bottom:1px solid #eee;vertical-align:top;">${escapeHtml(r.reason || r.status || "Needs to be corrected and resubmitted")}</td>
+        </tr>`,
+      )
+      .join("");
+
+    const intro =
+      outcome === "expired"
+        ? `The order for <strong>${escapeHtml(number.phoneNumber)}</strong> expired before verification completed. Please open Ringee to submit the documents again.`
+        : `The carrier could not approve the regulatory documents for <strong>${escapeHtml(number.phoneNumber)}</strong>. Please review the items below, correct them, and resubmit from Ringee.`;
+
+    const html = `
+      <div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#171717;max-width:640px;">
+        <h2 style="margin:0 0 12px;">Action needed: verification ${outcome === "expired" ? "expired" : "not approved"}</h2>
+        <p>${intro}</p>
+        <table style="border-collapse:collapse;margin:12px 0;">
+          <tr><td style="padding:4px 12px;color:#737373;">Phone number</td><td style="padding:4px 12px;"><strong>${escapeHtml(number.phoneNumber)}</strong></td></tr>
+          <tr><td style="padding:4px 12px;color:#737373;">Country</td><td style="padding:4px 12px;">${escapeHtml(number.isoCountry)} (${escapeHtml(number.phoneNumberType ?? "local")})</td></tr>
+          <tr><td style="padding:4px 12px;color:#737373;">Telnyx order</td><td style="padding:4px 12px;">${escapeHtml(number.providerOrderId ?? "")}</td></tr>
+        </table>
+        <h3 style="margin:16px 0 4px;">${outcome === "expired" ? "Documents to resubmit" : "What needs attention"}</h3>
+        <table style="border-collapse:collapse;width:100%;">${rows}</table>
+        <p style="margin-top:16px;color:#737373;">Reply to this email if you need help — both the account owner and the Ringee team are on this thread.</p>
+      </div>
+    `;
+
+    await this.sendClientEmail(
+      number,
+      outcome === "expired"
+        ? `${number.phoneNumber} verification expired — action needed`
+        : `${number.phoneNumber} verification not approved — action needed`,
+      html,
+    );
+  }
+
+  /** Sends an email TO the number's owner, CC the internal follow-up inbox. */
+  private async sendClientEmail(
+    number: NumberPurchased,
+    subject: string,
+    html: string,
+  ): Promise<void> {
+    const client = await this.resolveClient(number);
+    const recipients = client.email ? [client.email] : [REGULATORY_FOLLOWUP_CC];
+    const cc = client.email ? [REGULATORY_FOLLOWUP_CC] : undefined;
+
+    await this.email.sendEmail(
+      recipients,
+      subject,
+      html,
+      "Ringee Notifications",
+      apiConfiguration.EMAIL_FROM_ADDRESS,
+      REGULATORY_FOLLOWUP_CC,
+      cc,
+    );
+  }
+}
+
+/**
+ * Coarse outcome from a provider order line. Approved when all requirements are
+ * met; expired/rejected when the line or any requirement reached a terminal
+ * non-approved state; pending otherwise.
+ */
+function classifyVerification(
+  result: NumberOrderRequirements,
+): NumberVerificationOutcome {
+  if (result.requirementsMet) return "approved";
+
+  const signals = [
+    result.requirementsStatus ?? "",
+    ...result.requirements.map((r) => r.status ?? ""),
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  if (/cancel|expired/.test(signals)) return "expired";
+  if (/reject|declin|fail/.test(signals)) return "rejected";
+  return "pending";
+}
+
+function escapeHtml(value: string): string {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }


### PR DESCRIPTION
- Added `numberVerificationCheck` to workflow names in contracts.
- Enhanced `NumberPurchasedService` to handle regulatory requirements for purchased numbers, including:
  - Creating pending numbers for those requiring document verification.
  - Fetching and submitting regulatory requirements.
  - Sending follow-up emails upon submission.
- Introduced `VerifyNumberCell` component in the frontend for managing number verification, including:
  - Displaying requirements and their statuses.
  - Handling document uploads and address submissions.
  - Providing user feedback through toast notifications.