### PR TITLE
feat(i18n): update inbox translations for multiple languages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,10 @@ TELNYX_SIP_USER="YOUR_TELNYX_SIP_USER"
 TELNYX_SIP_PASSWORD="YOUR_TELNYX_SIP_PASSWORD"
 NEXT_PUBLIC_TELNYX_LOGIN="YOUR_TELNYX_SIP_USER"
 NEXT_PUBLIC_TELNYX_PASSWORD="YOUR_TELNYX_SIP_PASSWORD"
+# Messaging Profile linked to every number with SMS/MMS enabled. Required for
+# messaging to route — Telnyx will not send/receive SMS for a number that is
+# not attached to a messaging profile. Find it under Telnyx → Messaging.
+TELNYX_MESSAGING_PROFILE_ID=""
 # ── Desk Phones / SIP Devices ─────────────────────────────────
 # Shared Outbound Voice Profile attached to every desk-phone SIP connection so
 # outbound calls from physical phones bill through Ringee. Required to create

--- a/apps/backend/src/api/routes/inbox.controller.ts
+++ b/apps/backend/src/api/routes/inbox.controller.ts
@@ -8,7 +8,10 @@ import {
   Param,
   Post,
   Query,
+  UploadedFile,
+  UseInterceptors,
 } from "@nestjs/common";
+import { FileInterceptor } from "@nestjs/platform-express";
 import {
   CurrentUser,
   CurrentUserData,
@@ -20,6 +23,12 @@ import {
   CallService,
 } from "@ringee/services";
 import { InboxThreadStatus, InboxEventKind } from "@ringee/database";
+
+const E164_REGEX = /^\+[1-9]\d{6,14}$/;
+const MAX_SMS_TEXT_LENGTH = 1600;
+const MAX_MEDIA_URLS = 10;
+const MAX_MEDIA_BYTES = 5 * 1024 * 1024; // Telnyx MMS hard cap is ~5 MB.
+const ALLOWED_MEDIA_TYPES = /^(image|video|audio)\//i;
 
 @Controller("inbox")
 export class InboxController {
@@ -60,6 +69,8 @@ export class InboxController {
       search?: string;
       page?: string;
       limit?: string;
+      assignedToId?: string;
+      mine?: string;
     } = {},
   ) {
     const ctx = createOwnershipContext(user);
@@ -76,14 +87,38 @@ export class InboxController {
         : [query.kind as InboxEventKind]
       : undefined;
 
+    // "mine" assigns to the current user; "unassigned" (assignedToId === "null")
+    // filters threads with no assignee. Both narrow the team-inbox view.
+    let assignedToId: string | null | undefined;
+    if (query.mine === "true") {
+      assignedToId = user.id;
+    } else if (query.assignedToId === "null") {
+      assignedToId = null;
+    } else if (query.assignedToId) {
+      assignedToId = query.assignedToId;
+    }
+
     return this.timeline.listThreads(ctx, {
       status,
       kindIn,
       unreadOnly: query.unreadOnly === "true",
       search: query.search,
+      assignedToId,
       page: query.page ? Number(query.page) : undefined,
       limit: query.limit ? Number(query.limit) : undefined,
     });
+  }
+
+  /** Per-filter thread counts for the inbox filter pills. */
+  @Get("counts")
+  async counts(@CurrentUser() user: CurrentUserData) {
+    return this.timeline.counts(createOwnershipContext(user));
+  }
+
+  /** Total unread threads — drives the sidebar badge. */
+  @Get("unread-count")
+  async unreadCount(@CurrentUser() user: CurrentUserData) {
+    return this.timeline.unreadCount(createOwnershipContext(user));
   }
 
   @Get("threads/:id")
@@ -154,6 +189,26 @@ export class InboxController {
   ) {
     const ctx = createOwnershipContext(user);
     return this.timeline.assignThread(ctx, id, body.assigneeId ?? null);
+  }
+
+  /** Full contact history (calls + outcomes, notes, meetings, callbacks). */
+  @Get("threads/:id/activity")
+  async threadActivity(
+    @CurrentUser() user: CurrentUserData,
+    @Param("id") id: string,
+  ) {
+    const ctx = createOwnershipContext(user);
+    return this.timeline.getThreadActivity(ctx, id);
+  }
+
+  @Post("threads/:id/link-contact")
+  async linkContact(
+    @CurrentUser() user: CurrentUserData,
+    @Param("id") id: string,
+    @Body() body: { contactId: string | null },
+  ) {
+    const ctx = createOwnershipContext(user);
+    return this.timeline.linkContact(ctx, id, body?.contactId ?? null);
   }
 
   @Post("threads/:id/notes")
@@ -249,11 +304,48 @@ export class InboxController {
       idempotencyKey: body.idempotencyKey,
     });
   }
-}
 
-const E164_REGEX = /^\+[1-9]\d{6,14}$/;
-const MAX_SMS_TEXT_LENGTH = 1600;
-const MAX_MEDIA_URLS = 10;
+  /**
+   * Uploads an MMS attachment to object storage and returns its public URL so
+   * the composer can include it in `mediaUrls` when sending. Telnyx fetches the
+   * media by URL, so it must be publicly reachable (R2/S3 in production).
+   */
+  @Post("media")
+  @UseInterceptors(
+    FileInterceptor("file", {
+      limits: { fileSize: MAX_MEDIA_BYTES },
+      fileFilter: (_req, file, cb) => {
+        if (ALLOWED_MEDIA_TYPES.test(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(
+            new BadRequestException(
+              "Only image, video and audio attachments are allowed",
+            ),
+            false,
+          );
+        }
+      },
+    }),
+  )
+  async uploadMedia(
+    @UploadedFile()
+    file: {
+      buffer: Buffer;
+      originalname: string;
+      mimetype: string;
+    },
+  ) {
+    if (!file) {
+      throw new BadRequestException("No file uploaded");
+    }
+    return this.messageService.uploadOutboundMedia({
+      buffer: file.buffer,
+      contentType: file.mimetype,
+      filename: file.originalname,
+    });
+  }
+}
 
 function normalizePhone(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;

--- a/apps/frontend/src/components/layout/app-sidebar.tsx
+++ b/apps/frontend/src/components/layout/app-sidebar.tsx
@@ -47,6 +47,7 @@ import * as React from 'react';
 import { Icons } from '@ringee/frontend-shared/components/icons';
 import { OrgSwitcher } from '@ringee/frontend-shared/components/org-switcher';
 import { useDialerStore } from '@/features/calls/store/dialer.store';
+import { useUnreadCount } from '@/features/inbox/hooks/use-inbox';
 import { useOrgRole } from '@ringee/frontend-shared/hooks/use-org-role';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { cn } from '@ringee/frontend-shared/lib/utils';
@@ -118,6 +119,7 @@ function OutreachLockOverlay({ collapsed }: { collapsed: boolean }) {
 export default function AppSidebar({ useMock }: { useMock?: boolean }) {
   const pathname = usePathname();
   const dialer = useDialerStore();
+  const inboxUnread = useUnreadCount();
   const tNav = useTranslations('navigation');
   const tCommon = useTranslations('common');
 
@@ -262,6 +264,11 @@ export default function AppSidebar({ useMock }: { useMock?: boolean }) {
                             {/* @ts-ignore */}
                             <Icon />
                             <span>{itemTitle}</span>
+                            {item.title === 'Inbox' && inboxUnread > 0 && (
+                              <span className='bg-primary text-primary-foreground ml-auto flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[10px] font-semibold'>
+                                {inboxUnread > 99 ? '99+' : inboxUnread}
+                              </span>
+                            )}
                           </Link>
                         </SidebarMenuButton>
                       </SidebarMenuItem>

--- a/apps/frontend/src/features/inbox/components/assign-thread-menu.tsx
+++ b/apps/frontend/src/features/inbox/components/assign-thread-menu.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useOrganization } from '@clerk/nextjs';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import { Check, UserPlus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { InboxThread } from '../types';
+import { useThreadActions } from '../hooks/use-inbox';
+
+interface Member {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  thread: InboxThread;
+  onChanged: () => void;
+}
+
+/**
+ * Assigns an inbox thread to an org member. Member list is resolved with the
+ * same pattern as the dashboard filters (Clerk memberships → DB user ids).
+ */
+export function AssignThreadMenu({ thread, onChanged }: Props) {
+  const t = useTranslations('inbox.assignment');
+  const api = useApi();
+  const { organization } = useOrganization();
+  const [members, setMembers] = useState<Member[]>([]);
+  const actions = useThreadActions(onChanged);
+
+  useEffect(() => {
+    if (!organization) return;
+    let active = true;
+    organization.getMemberships().then(async (res) => {
+      const clerkIds = res.data
+        .map((m) => m.publicUserData?.userId)
+        .filter(Boolean) as string[];
+      if (clerkIds.length === 0) {
+        if (active) setMembers([]);
+        return;
+      }
+      const map = await api.get<{ clerkId: string; id: string }[]>(
+        `/user/by-clerk-ids?ids=${clerkIds.join(',')}`
+      );
+      if (!active) return;
+      const lookup = new Map(map.map((u) => [u.clerkId, u.id]));
+      setMembers(
+        res.data
+          .map((m) => {
+            const clerkId = m.publicUserData?.userId || '';
+            const name =
+              `${m.publicUserData?.firstName || ''} ${m.publicUserData?.lastName || ''}`.trim() ||
+              m.publicUserData?.identifier ||
+              t('memberFallback');
+            return { id: lookup.get(clerkId) || '', name };
+          })
+          .filter((m) => m.id)
+      );
+    });
+    return () => {
+      active = false;
+    };
+  }, [organization, api, t]);
+
+  const assignee = members.find((m) => m.id === thread.assignedToId);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant='outline' size='sm'>
+          <UserPlus className='mr-1 h-4 w-4' />
+          {assignee ? assignee.name : t('assign')}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end' className='w-56'>
+        <DropdownMenuLabel>{t('assignTo')}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => actions.assign(thread.id, null)}>
+          <span className='flex-1'>{t('unassigned')}</span>
+          {!thread.assignedToId && <Check className='h-4 w-4' />}
+        </DropdownMenuItem>
+        {members.map((m) => (
+          <DropdownMenuItem
+            key={m.id}
+            onClick={() => actions.assign(thread.id, m.id)}
+          >
+            <span className='flex-1 truncate'>{m.name}</span>
+            {thread.assignedToId === m.id && <Check className='h-4 w-4' />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/frontend/src/features/inbox/components/composer.tsx
+++ b/apps/frontend/src/features/inbox/components/composer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
 import { Textarea } from '@ringee/frontend-shared/components/ui/textarea';
 import {
@@ -10,8 +11,17 @@ import {
   SelectTrigger,
   SelectValue
 } from '@ringee/frontend-shared/components/ui/select';
-import { Loader2, Send, StickyNote, MessageSquare } from 'lucide-react';
+import {
+  Loader2,
+  Send,
+  StickyNote,
+  MessageSquare,
+  Paperclip,
+  X,
+  FileText
+} from 'lucide-react';
 import { cn } from '@ringee/frontend-shared/lib/utils';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { InboxThread } from '../types';
 import { useNumbers, useThreadActions } from '../hooks/use-inbox';
 import { useTranslations } from 'next-intl';
@@ -23,41 +33,108 @@ interface Props {
 
 type Mode = 'sms' | 'note';
 
+interface Attachment {
+  url: string;
+  name: string;
+  isImage: boolean;
+}
+
+const MAX_ATTACHMENTS = 10;
+const IMAGE_RE = /\.(png|jpe?g|gif|webp|bmp|heic)$/i;
+
 export function Composer({ thread, onAfterAction }: Props) {
   const t = useTranslations('inbox.composer');
+  const api = useApi();
   const [mode, setMode] = useState<Mode>('sms');
   const [text, setText] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [media, setMedia] = useState<Attachment[]>([]);
   const [fromNumber, setFromNumber] = useState<string | null>(
     thread.ringeeNumber
   );
   const numbers = useNumbers();
   const actions = useThreadActions(onAfterAction);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setFromNumber(thread.ringeeNumber ?? numbers[0]?.phoneNumber ?? null);
+    setMedia([]);
   }, [thread.id, thread.ringeeNumber, numbers]);
 
+  // The context pane "Add note" action focuses the composer in note mode.
+  useEffect(() => {
+    const onNote = () => {
+      setMode('note');
+      setTimeout(() => textareaRef.current?.focus(), 0);
+    };
+    window.addEventListener('ringee:inbox-note', onNote);
+    return () => window.removeEventListener('ringee:inbox-note', onNote);
+  }, []);
+
+  const selected = numbers.find((n) => n.phoneNumber === fromNumber);
+  const smsCapable = selected?.smsEnabled;
+  const mmsCapable = selected?.mmsEnabled;
+
+  async function onFiles(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = '';
+    if (!files.length) return;
+    const room = MAX_ATTACHMENTS - media.length;
+    setUploading(true);
+    try {
+      for (const file of files.slice(0, room)) {
+        const fd = new FormData();
+        fd.append('file', file);
+        const res = await api.upload<{ url: string }>('/inbox/media', fd);
+        if (res?.url) {
+          setMedia((m) => [
+            ...m,
+            {
+              url: res.url,
+              name: file.name,
+              isImage:
+                file.type.startsWith('image/') || IMAGE_RE.test(file.name)
+            }
+          ]);
+        }
+      }
+    } catch {
+      toast.error(t('attachError'));
+    } finally {
+      setUploading(false);
+    }
+  }
+
   async function submit() {
-    if (!text.trim()) return;
+    const trimmed = text.trim();
+    if (mode === 'note') {
+      if (!trimmed) return;
+      setSubmitting(true);
+      try {
+        await actions.addNote(thread.id, trimmed);
+        setText('');
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
+
+    if (!fromNumber || (!trimmed && media.length === 0)) return;
     setSubmitting(true);
     try {
-      if (mode === 'note') {
-        await actions.addNote(thread.id, text.trim());
-      } else {
-        if (!fromNumber) return;
-
-        const target = thread.participantNumberE164 ?? thread.participantNumber;
-
-        await actions.sendSms({
-          fromNumber,
-          toNumber: target,
-          text: text.trim(),
-          threadId: thread.id,
-          contactId: thread.contactId ?? undefined
-        });
-      }
+      const target = thread.participantNumberE164 ?? thread.participantNumber;
+      await actions.sendSms({
+        fromNumber,
+        toNumber: target,
+        text: trimmed || undefined,
+        mediaUrls: media.length ? media.map((m) => m.url) : undefined,
+        threadId: thread.id,
+        contactId: thread.contactId ?? undefined
+      });
       setText('');
+      setMedia([]);
     } finally {
       setSubmitting(false);
     }
@@ -70,9 +147,14 @@ export function Composer({ thread, onAfterAction }: Props) {
     }
   }
 
-  const smsCapable = numbers.find(
-    (n) => n.phoneNumber === fromNumber
-  )?.smsEnabled;
+  const sendDisabled =
+    submitting ||
+    uploading ||
+    (mode === 'note'
+      ? !text.trim()
+      : !fromNumber ||
+        smsCapable === false ||
+        (!text.trim() && media.length === 0));
 
   return (
     <div className='bg-background border-t'>
@@ -127,8 +209,75 @@ export function Composer({ thread, onAfterAction }: Props) {
           </div>
         )}
       </div>
+
+      {mode === 'sms' && media.length > 0 && (
+        <div className='flex flex-wrap gap-2 px-3 pt-2'>
+          {media.map((m, i) => (
+            <div
+              key={`${m.url}-${i}`}
+              className='group relative h-14 w-14 overflow-hidden rounded-md border'
+            >
+              {m.isImage ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={m.url}
+                  alt={m.name}
+                  className='h-full w-full object-cover'
+                />
+              ) : (
+                <div className='text-muted-foreground flex h-full w-full items-center justify-center'>
+                  <FileText className='h-5 w-5' />
+                </div>
+              )}
+              <button
+                type='button'
+                onClick={() =>
+                  setMedia((arr) => arr.filter((_, idx) => idx !== i))
+                }
+                className='absolute top-0.5 right-0.5 rounded-full bg-black/60 p-0.5 text-white'
+              >
+                <X className='h-3 w-3' />
+              </button>
+            </div>
+          ))}
+          {uploading && (
+            <div className='flex h-14 w-14 items-center justify-center rounded-md border'>
+              <Loader2 className='text-muted-foreground h-4 w-4 animate-spin' />
+            </div>
+          )}
+        </div>
+      )}
+
       <div className='flex items-end gap-2 p-3'>
+        {mode === 'sms' && (
+          <>
+            <input
+              ref={fileInputRef}
+              type='file'
+              accept='image/*,video/*,audio/*'
+              multiple
+              hidden
+              onChange={onFiles}
+            />
+            <Button
+              type='button'
+              variant='outline'
+              size='icon'
+              className='shrink-0'
+              title={mmsCapable === false ? t('mmsDisabled') : t('attach')}
+              disabled={
+                mmsCapable === false ||
+                uploading ||
+                media.length >= MAX_ATTACHMENTS
+              }
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Paperclip className='h-4 w-4' />
+            </Button>
+          </>
+        )}
         <Textarea
+          ref={textareaRef}
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={onKey}
@@ -143,11 +292,7 @@ export function Composer({ thread, onAfterAction }: Props) {
         />
         <Button
           type='button'
-          disabled={
-            submitting ||
-            !text.trim() ||
-            (mode === 'sms' && (!fromNumber || smsCapable === false))
-          }
+          disabled={sendDisabled}
           onClick={submit}
           className='shrink-0'
         >

--- a/apps/frontend/src/features/inbox/components/contact-context-pane.tsx
+++ b/apps/frontend/src/features/inbox/components/contact-context-pane.tsx
@@ -1,0 +1,584 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { toast } from 'sonner';
+import {
+  Avatar,
+  AvatarFallback
+} from '@ringee/frontend-shared/components/ui/avatar';
+import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { Badge } from '@ringee/frontend-shared/components/ui/badge';
+import { Input } from '@ringee/frontend-shared/components/ui/input';
+import { Textarea } from '@ringee/frontend-shared/components/ui/textarea';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '@ringee/frontend-shared/components/ui/popover';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import {
+  Phone,
+  PhoneIncoming,
+  PhoneOutgoing,
+  PhoneMissed,
+  StickyNote,
+  CalendarClock,
+  CalendarPlus,
+  UserPlus,
+  ExternalLink,
+  Building2,
+  Mail,
+  Loader2
+} from 'lucide-react';
+import { cn } from '@ringee/frontend-shared/lib/utils';
+import { useTranslations } from 'next-intl';
+import { InboxThread } from '../types';
+import {
+  threadDisplayName,
+  useThreadActions,
+  useThreadActivity,
+  ThreadActivity
+} from '../hooks/use-inbox';
+import { ContactPicker, PickableContact } from './contact-picker';
+
+interface Props {
+  thread: InboxThread;
+  onChanged: () => void;
+}
+
+interface FullContact {
+  id: string;
+  company?: string | null;
+  email?: string | null;
+  jobTitle?: string | null;
+}
+
+const POSITIVE_OUTCOMES = new Set([
+  'meeting_booked',
+  'sale',
+  'interested',
+  'follow_up',
+  'callback_scheduled'
+]);
+const NEGATIVE_OUTCOMES = new Set(['not_interested', 'wrong_number']);
+
+function defaultScheduleValue(): string {
+  const d = new Date(Date.now() + 60 * 60 * 1000);
+  d.setSeconds(0, 0);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+}
+
+function formatDuration(seconds: number | null): string | null {
+  if (!seconds || seconds <= 0) return null;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+export function ContactContextPane({ thread, onChanged }: Props) {
+  const t = useTranslations('inbox.contextPane');
+  const api = useApi();
+  const actions = useThreadActions(onChanged);
+  const [full, setFull] = useState<FullContact | null>(null);
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createName, setCreateName] = useState('');
+  const [activityKey, setActivityKey] = useState(0);
+  const { activity, loading: activityLoading } = useThreadActivity(
+    thread.contactId ? thread.id : null,
+    activityKey
+  );
+
+  const target = thread.participantNumberE164 ?? thread.participantNumber;
+
+  useEffect(() => {
+    if (!thread.contactId) {
+      setFull(null);
+      return;
+    }
+    let active = true;
+    api
+      .get<FullContact>(`/contacts/${thread.contactId}`)
+      .then((c) => active && setFull(c ?? null))
+      .catch(() => active && setFull(null));
+    return () => {
+      active = false;
+    };
+  }, [api, thread.contactId]);
+
+  function call() {
+    window.dispatchEvent(
+      new CustomEvent('ringee:dial', { detail: { number: target } })
+    );
+  }
+
+  function focusNote() {
+    window.dispatchEvent(new CustomEvent('ringee:inbox-note'));
+  }
+
+  async function linkExisting(contact: PickableContact) {
+    setLinkOpen(false);
+    try {
+      await actions.linkContact(thread.id, contact.id);
+      toast.success(t('linkedToast'));
+    } catch {
+      toast.error(t('linkError'));
+    }
+  }
+
+  async function createAndLink() {
+    setCreating(true);
+    try {
+      const [firstName, ...rest] = createName.trim().split(' ');
+      const created = await api.post<{ id: string }>('/contacts', {
+        phoneNumber: target,
+        firstName: firstName || undefined,
+        lastName: rest.length ? rest.join(' ') : undefined
+      });
+      if (created?.id) {
+        await actions.linkContact(thread.id, created.id);
+        toast.success(t('createdToast'));
+        setCreateName('');
+      }
+    } catch {
+      toast.error(t('createError'));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const displayName = threadDisplayName(thread);
+  const initials = displayName
+    .split(' ')
+    .map((p) => p[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+
+  return (
+    <div className='hidden w-80 shrink-0 flex-col border-l xl:flex'>
+      {/* Header */}
+      <div className='flex flex-col items-center gap-2 border-b p-5 text-center'>
+        <Avatar className='h-14 w-14'>
+          <AvatarFallback className='text-base'>
+            {initials || '?'}
+          </AvatarFallback>
+        </Avatar>
+        <div className='min-w-0'>
+          <p className='truncate text-sm font-semibold'>{displayName}</p>
+          <p className='text-muted-foreground truncate text-xs'>{target}</p>
+        </div>
+        {full?.company && (
+          <p className='text-muted-foreground flex items-center gap-1 text-xs'>
+            <Building2 className='h-3 w-3' /> {full.company}
+          </p>
+        )}
+        {full?.email && (
+          <p className='text-muted-foreground flex items-center gap-1 text-xs'>
+            <Mail className='h-3 w-3' /> {full.email}
+          </p>
+        )}
+      </div>
+
+      {/* Quick actions */}
+      <div className='space-y-2 border-b p-3'>
+        <p className='text-muted-foreground px-1 text-[11px] font-medium tracking-wide uppercase'>
+          {t('quickActions')}
+        </p>
+        <div className='grid grid-cols-2 gap-2'>
+          <Button variant='outline' size='sm' onClick={call}>
+            <Phone className='mr-1 h-4 w-4' /> {t('call')}
+          </Button>
+          <Button variant='outline' size='sm' onClick={focusNote}>
+            <StickyNote className='mr-1 h-4 w-4' /> {t('note')}
+          </Button>
+          {thread.contactId && (
+            <>
+              <SchedulePopover
+                mode='callback'
+                contactId={thread.contactId}
+                onScheduled={() => setActivityKey((k) => k + 1)}
+                trigger={
+                  <Button variant='outline' size='sm'>
+                    <CalendarClock className='mr-1 h-4 w-4' /> {t('callback')}
+                  </Button>
+                }
+              />
+              <SchedulePopover
+                mode='meeting'
+                contactId={thread.contactId}
+                contactName={displayName}
+                onScheduled={() => setActivityKey((k) => k + 1)}
+                trigger={
+                  <Button variant='outline' size='sm'>
+                    <CalendarPlus className='mr-1 h-4 w-4' /> {t('meeting')}
+                  </Button>
+                }
+              />
+            </>
+          )}
+        </div>
+        {thread.contactId && (
+          <Button
+            asChild
+            variant='ghost'
+            size='sm'
+            className='w-full justify-start'
+          >
+            <Link href={`/dashboard/contact/${thread.contactId}`}>
+              <ExternalLink className='mr-2 h-4 w-4' /> {t('viewProfile')}
+            </Link>
+          </Button>
+        )}
+      </div>
+
+      {/* Scrollable context */}
+      <div className='min-h-0 flex-1 overflow-y-auto p-3'>
+        {!thread.contactId ? (
+          <div className='space-y-2'>
+            <p className='text-muted-foreground px-1 text-xs'>
+              {t('unknownNumber')}
+            </p>
+            <div className='flex gap-2'>
+              <Input
+                value={createName}
+                onChange={(e) => setCreateName(e.target.value)}
+                placeholder={t('namePlaceholder')}
+                className='h-8 text-xs'
+              />
+              <Button
+                size='sm'
+                disabled={creating}
+                onClick={createAndLink}
+                className='shrink-0'
+              >
+                {creating ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  t('create')
+                )}
+              </Button>
+            </div>
+            <Popover open={linkOpen} onOpenChange={setLinkOpen}>
+              <PopoverTrigger asChild>
+                <Button variant='outline' size='sm' className='w-full'>
+                  <UserPlus className='mr-1 h-4 w-4' /> {t('linkExisting')}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align='end' className='w-72 p-0'>
+                <ContactPicker autoFocus onPick={linkExisting} />
+              </PopoverContent>
+            </Popover>
+          </div>
+        ) : (
+          <ActivityTimeline activity={activity} loading={activityLoading} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ActivityTimeline({
+  activity,
+  loading
+}: {
+  activity: ThreadActivity | null;
+  loading: boolean;
+}) {
+  const t = useTranslations('inbox.contextPane.history');
+
+  const items = useMemo(() => {
+    if (!activity) return [];
+    const merged: {
+      key: string;
+      sort: number;
+      node: React.ReactNode;
+    }[] = [];
+
+    for (const c of activity.calls) {
+      const dir = (c.direction || '').toLowerCase();
+      const isOutbound = dir === 'outbound' || dir === 'outgoing';
+      const missed = c.status === 'missed' || c.outcome === 'no_answer';
+      const Icon = missed
+        ? PhoneMissed
+        : isOutbound
+          ? PhoneOutgoing
+          : PhoneIncoming;
+      const title = missed
+        ? t('callMissed')
+        : isOutbound
+          ? t('callOutbound')
+          : t('callInbound');
+      const duration = formatDuration(c.durationSeconds);
+      merged.push({
+        key: `call-${c.id}`,
+        sort: new Date(c.createdAt).getTime(),
+        node: (
+          <ActivityRow
+            icon={
+              <Icon
+                className={cn(
+                  'h-4 w-4',
+                  missed ? 'text-red-500' : 'text-emerald-500'
+                )}
+              />
+            }
+            title={title}
+            when={c.createdAt}
+            badge={c.outcome ? <OutcomeBadge outcome={c.outcome} /> : null}
+            meta={duration ?? undefined}
+            note={c.outcomeNote}
+          />
+        )
+      });
+    }
+
+    for (const n of activity.notes) {
+      merged.push({
+        key: `note-${n.id}`,
+        sort: new Date(n.createdAt).getTime(),
+        node: (
+          <ActivityRow
+            icon={<StickyNote className='h-4 w-4 text-yellow-600' />}
+            title={t('note')}
+            when={n.createdAt}
+            note={n.content}
+          />
+        )
+      });
+    }
+
+    for (const m of activity.meetings) {
+      merged.push({
+        key: `meeting-${m.id}`,
+        sort: new Date(m.scheduledAt).getTime(),
+        node: (
+          <ActivityRow
+            icon={<CalendarPlus className='h-4 w-4 text-cyan-600' />}
+            title={m.title || t('meeting')}
+            when={m.scheduledAt}
+            badge={<StatusBadge status={m.status} />}
+            note={m.notes}
+          />
+        )
+      });
+    }
+
+    for (const cb of activity.callbacks) {
+      merged.push({
+        key: `callback-${cb.id}`,
+        sort: new Date(cb.scheduledAt).getTime(),
+        node: (
+          <ActivityRow
+            icon={<CalendarClock className='h-4 w-4 text-violet-600' />}
+            title={t('callback')}
+            when={cb.scheduledAt}
+            badge={<StatusBadge status={cb.status} />}
+            note={cb.note}
+          />
+        )
+      });
+    }
+
+    return merged.sort((a, b) => b.sort - a.sort);
+  }, [activity, t]);
+
+  if (loading && !activity) {
+    return (
+      <div className='text-muted-foreground flex items-center justify-center gap-2 py-8 text-xs'>
+        <Loader2 className='h-3.5 w-3.5 animate-spin' /> {t('loading')}
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-3'>
+      <p className='text-muted-foreground px-1 text-[11px] font-medium tracking-wide uppercase'>
+        {t('title')}
+      </p>
+      {items.length === 0 ? (
+        <p className='text-muted-foreground px-1 py-6 text-center text-xs'>
+          {t('empty')}
+        </p>
+      ) : (
+        <div className='space-y-3'>
+          {items.map((it) => (
+            <div key={it.key}>{it.node}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActivityRow({
+  icon,
+  title,
+  when,
+  badge,
+  meta,
+  note
+}: {
+  icon: React.ReactNode;
+  title: string;
+  when: string;
+  badge?: React.ReactNode;
+  meta?: string;
+  note?: string | null;
+}) {
+  return (
+    <div className='flex gap-2'>
+      <div className='mt-0.5 shrink-0'>{icon}</div>
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-2'>
+          <span className='truncate text-xs font-medium'>{title}</span>
+          {badge}
+          {meta && (
+            <span className='text-muted-foreground text-[11px]'>{meta}</span>
+          )}
+        </div>
+        <p className='text-muted-foreground text-[11px]'>{formatWhen(when)}</p>
+        {note && (
+          <p className='bg-muted/50 mt-1 rounded-md px-2 py-1 text-xs whitespace-pre-wrap'>
+            {note}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function OutcomeBadge({ outcome }: { outcome: string }) {
+  const t = useTranslations('inbox.contextPane.history.outcomes');
+  const tone = POSITIVE_OUTCOMES.has(outcome)
+    ? 'border-emerald-300 text-emerald-700 dark:text-emerald-400'
+    : NEGATIVE_OUTCOMES.has(outcome)
+      ? 'border-red-300 text-red-700 dark:text-red-400'
+      : 'text-muted-foreground';
+  return (
+    <Badge variant='outline' className={cn('h-4 px-1.5 text-[10px]', tone)}>
+      {t(outcome as never)}
+    </Badge>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const t = useTranslations('inbox.contextPane.history.statuses');
+  const tone =
+    status === 'completed'
+      ? 'border-emerald-300 text-emerald-700 dark:text-emerald-400'
+      : status === 'cancelled' || status === 'missed'
+        ? 'border-red-300 text-red-700 dark:text-red-400'
+        : 'text-muted-foreground';
+  return (
+    <Badge variant='outline' className={cn('h-4 px-1.5 text-[10px]', tone)}>
+      {t(status as never)}
+    </Badge>
+  );
+}
+
+function SchedulePopover({
+  mode,
+  contactId,
+  contactName,
+  trigger,
+  onScheduled
+}: {
+  mode: 'callback' | 'meeting';
+  contactId: string;
+  contactName?: string;
+  trigger: React.ReactNode;
+  onScheduled?: () => void;
+}) {
+  const t = useTranslations('inbox.contextPane');
+  const api = useApi();
+  const [open, setOpen] = useState(false);
+  const [when, setWhen] = useState(defaultScheduleValue);
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit() {
+    const scheduledAt = new Date(when);
+    if (
+      Number.isNaN(scheduledAt.getTime()) ||
+      scheduledAt.getTime() <= Date.now()
+    ) {
+      toast.error(t('invalidDate'));
+      return;
+    }
+    setSubmitting(true);
+    try {
+      if (mode === 'callback') {
+        await api.post('/callbacks', {
+          contactId,
+          scheduledAt: scheduledAt.toISOString(),
+          note: note.trim() || undefined
+        });
+        toast.success(t('callbackScheduled'));
+      } else {
+        await api.post('/meetings', {
+          contactId,
+          scheduledAt: scheduledAt.toISOString(),
+          title: contactName ? `Meeting with ${contactName}` : undefined,
+          notes: note.trim() || undefined
+        });
+        toast.success(t('meetingScheduled'));
+      }
+      setOpen(false);
+      setNote('');
+      onScheduled?.();
+    } catch {
+      toast.error(t('scheduleError'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align='end' className='w-72 space-y-2'>
+        <p className='text-sm font-medium'>
+          {mode === 'callback' ? t('scheduleCallback') : t('scheduleMeeting')}
+        </p>
+        <Input
+          type='datetime-local'
+          value={when}
+          onChange={(e) => setWhen(e.target.value)}
+          className='text-xs'
+        />
+        <Textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={2}
+          placeholder={t('notePlaceholder')}
+          className='resize-none text-xs'
+        />
+        <Button
+          size='sm'
+          className='w-full'
+          disabled={submitting}
+          onClick={submit}
+        >
+          {submitting ? (
+            <Loader2 className='h-4 w-4 animate-spin' />
+          ) : (
+            t('schedule')
+          )}
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/frontend/src/features/inbox/components/contact-picker.tsx
+++ b/apps/frontend/src/features/inbox/components/contact-picker.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@ringee/frontend-shared/components/ui/command';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import { useTranslations } from 'next-intl';
+import { Loader2, User } from 'lucide-react';
+
+export interface PickableContact {
+  id: string;
+  name?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  fullName?: string | null;
+  phoneNumber?: string | null;
+  company?: string | null;
+  email?: string | null;
+}
+
+export function contactLabel(c: PickableContact): string {
+  return (
+    c.fullName ||
+    [c.firstName, c.lastName].filter(Boolean).join(' ') ||
+    c.name ||
+    c.phoneNumber ||
+    'Contact'
+  );
+}
+
+interface Props {
+  onPick: (contact: PickableContact) => void;
+  autoFocus?: boolean;
+}
+
+/**
+ * Debounced contact search over GET /contacts?search=. Reused by the
+ * "Link contact" action and the New Conversation dialog.
+ */
+export function ContactPicker({ onPick, autoFocus }: Props) {
+  const t = useTranslations('inbox.contextPane');
+  const api = useApi();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<PickableContact[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const handle = window.setTimeout(() => {
+      setLoading(true);
+      api
+        .get<{ data: PickableContact[] }>(
+          `/contacts?limit=8&search=${encodeURIComponent(query)}`
+        )
+        .then((res) => active && setResults(res?.data ?? []))
+        .catch(() => active && setResults([]))
+        .finally(() => active && setLoading(false));
+    }, 250);
+    return () => {
+      active = false;
+      window.clearTimeout(handle);
+    };
+  }, [api, query]);
+
+  const items = useMemo(() => results.slice(0, 8), [results]);
+
+  return (
+    <Command shouldFilter={false} className='rounded-md border'>
+      <CommandInput
+        autoFocus={autoFocus}
+        value={query}
+        onValueChange={setQuery}
+        placeholder={t('searchContacts')}
+      />
+      <CommandList>
+        {loading ? (
+          <div className='text-muted-foreground flex items-center justify-center gap-2 py-6 text-xs'>
+            <Loader2 className='h-3.5 w-3.5 animate-spin' /> {t('searching')}
+          </div>
+        ) : (
+          <>
+            <CommandEmpty>{t('noContacts')}</CommandEmpty>
+            <CommandGroup>
+              {items.map((c) => (
+                <CommandItem
+                  key={c.id}
+                  value={c.id}
+                  onSelect={() => onPick(c)}
+                  className='flex items-center gap-2'
+                >
+                  <User className='text-muted-foreground h-4 w-4 shrink-0' />
+                  <div className='min-w-0 flex-1'>
+                    <p className='truncate text-sm'>{contactLabel(c)}</p>
+                    {c.phoneNumber && (
+                      <p className='text-muted-foreground truncate text-xs'>
+                        {c.phoneNumber}
+                      </p>
+                    )}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+      </CommandList>
+    </Command>
+  );
+}

--- a/apps/frontend/src/features/inbox/components/inbox-view.tsx
+++ b/apps/frontend/src/features/inbox/components/inbox-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { ThreadList } from './thread-list';
 import { ThreadTimeline } from './thread-timeline';
+import { ContactContextPane } from './contact-context-pane';
 import { InboxThread } from '../types';
 
 export function InboxView() {
@@ -43,6 +44,9 @@ export function InboxView() {
         }}
       />
       <ThreadTimeline thread={selected} onChanged={bumpReload} />
+      {selected && (
+        <ContactContextPane thread={selected} onChanged={bumpReload} />
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/features/inbox/components/new-conversation-dialog.tsx
+++ b/apps/frontend/src/features/inbox/components/new-conversation-dialog.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@ringee/frontend-shared/components/ui/dialog';
+import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { Input } from '@ringee/frontend-shared/components/ui/input';
+import { Textarea } from '@ringee/frontend-shared/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@ringee/frontend-shared/components/ui/select';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import { Loader2, Pencil, Plus, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { InboxThread } from '../types';
+import { useNumbers } from '../hooks/use-inbox';
+import { ContactPicker, PickableContact, contactLabel } from './contact-picker';
+
+interface Props {
+  onCreated: (thread: InboxThread) => void;
+}
+
+const E164 = /^\+[1-9]\d{6,14}$/;
+
+export function NewConversationDialog({ onCreated }: Props) {
+  const t = useTranslations('inbox.newConversation');
+  const api = useApi();
+  const numbers = useNumbers();
+  const smsNumbers = useMemo(
+    () => numbers.filter((n) => n.smsEnabled),
+    [numbers]
+  );
+
+  const [open, setOpen] = useState(false);
+  const [fromNumber, setFromNumber] = useState<string | null>(null);
+  const [picked, setPicked] = useState<PickableContact | null>(null);
+  const [manualNumber, setManualNumber] = useState('');
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    if (!fromNumber && smsNumbers.length > 0) {
+      setFromNumber(smsNumbers[0].phoneNumber);
+    }
+  }, [smsNumbers, fromNumber]);
+
+  function reset() {
+    setPicked(null);
+    setManualNumber('');
+    setText('');
+  }
+
+  const toNumber = picked?.phoneNumber?.trim() || manualNumber.trim();
+  const canSend = !!fromNumber && E164.test(toNumber) && !!text.trim();
+
+  async function send() {
+    if (!canSend || !fromNumber) return;
+    setSending(true);
+    try {
+      const message = await api.post<{ threadId: string }>('/inbox/messages', {
+        fromNumber,
+        toNumber,
+        text: text.trim(),
+        contactId: picked?.id
+      });
+      if (message?.threadId) {
+        const thread = await api.get<InboxThread>(
+          `/inbox/threads/${message.threadId}`
+        );
+        if (thread) onCreated(thread);
+      }
+      setOpen(false);
+      reset();
+    } catch {
+      toast.error(t('sendError'));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size='sm' className='w-full'>
+          <Plus className='mr-1 h-4 w-4' /> {t('newMessage')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-3'>
+          <div className='space-y-1'>
+            <label className='text-muted-foreground text-xs font-medium'>
+              {t('from')}
+            </label>
+            <Select
+              value={fromNumber ?? undefined}
+              onValueChange={setFromNumber}
+            >
+              <SelectTrigger className='text-sm'>
+                <SelectValue placeholder={t('selectNumber')} />
+              </SelectTrigger>
+              <SelectContent>
+                {smsNumbers.map((n) => (
+                  <SelectItem key={n.id} value={n.phoneNumber}>
+                    {n.phoneNumber}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {smsNumbers.length === 0 && (
+              <p className='text-xs text-amber-600'>{t('noSmsNumbers')}</p>
+            )}
+          </div>
+
+          <div className='space-y-1'>
+            <label className='text-muted-foreground text-xs font-medium'>
+              {t('to')}
+            </label>
+            {picked ? (
+              <div className='flex items-center gap-2 rounded-md border px-3 py-2'>
+                <div className='min-w-0 flex-1'>
+                  <p className='truncate text-sm'>{contactLabel(picked)}</p>
+                  <p className='text-muted-foreground truncate text-xs'>
+                    {picked.phoneNumber}
+                  </p>
+                </div>
+                <Button
+                  variant='ghost'
+                  size='icon'
+                  className='h-7 w-7'
+                  onClick={() => setPicked(null)}
+                >
+                  <X className='h-4 w-4' />
+                </Button>
+              </div>
+            ) : (
+              <>
+                <div className='relative'>
+                  <Pencil className='text-muted-foreground absolute top-2.5 left-2.5 h-3.5 w-3.5' />
+                  <Input
+                    value={manualNumber}
+                    onChange={(e) => setManualNumber(e.target.value)}
+                    placeholder={t('manualPlaceholder')}
+                    className='pl-8 text-sm'
+                  />
+                </div>
+                <ContactPicker onPick={setPicked} />
+              </>
+            )}
+          </div>
+
+          <div className='space-y-1'>
+            <label className='text-muted-foreground text-xs font-medium'>
+              {t('message')}
+            </label>
+            <Textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={3}
+              placeholder={t('messagePlaceholder')}
+              className='resize-none text-sm'
+            />
+          </div>
+
+          <Button
+            className='w-full'
+            disabled={!canSend || sending}
+            onClick={send}
+          >
+            {sending ? <Loader2 className='h-4 w-4 animate-spin' /> : t('send')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/features/inbox/components/thread-list.tsx
+++ b/apps/frontend/src/features/inbox/components/thread-list.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Input } from '@ringee/frontend-shared/components/ui/input';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
-import { ScrollArea } from '@ringee/frontend-shared/components/ui/scroll-area';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { cn } from '@ringee/frontend-shared/lib/utils';
@@ -17,10 +15,18 @@ import {
   StickyNote,
   CalendarClock,
   Inbox as InboxIcon,
-  Search
+  Search,
+  Check,
+  Loader2
 } from 'lucide-react';
 import { InboxEventKind, InboxThread, THREAD_FILTER_OPTIONS } from '../types';
-import { threadDisplayName, useThreads } from '../hooks/use-inbox';
+import {
+  threadDisplayName,
+  useThreads,
+  useInboxCounts,
+  useThreadActions
+} from '../hooks/use-inbox';
+import { NewConversationDialog } from './new-conversation-dialog';
 import { useTranslations } from 'next-intl';
 
 function kindIcon(kind: InboxEventKind | null) {
@@ -71,7 +77,19 @@ export function ThreadList({ selectedThreadId, onSelect }: Props) {
   const [search, setSearch] = useState('');
   const [backfilling, setBackfilling] = useState(false);
   const api = useApi();
-  const { threads, loading, reload } = useThreads(filterId, search);
+  const { threads, loading, loadingMore, hasMore, reload, loadMore } =
+    useThreads(filterId, search);
+  const counts = useInboxCounts();
+  const actions = useThreadActions(reload);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  function onScroll() {
+    const el = scrollRef.current;
+    if (!el || loadingMore || !hasMore) return;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 200) {
+      loadMore();
+    }
+  }
 
   async function runBackfill() {
     setBackfilling(true);
@@ -90,8 +108,9 @@ export function ThreadList({ selectedThreadId, onSelect }: Props) {
   }
 
   return (
-    <div className='flex h-full w-80 flex-col border-r'>
+    <div className='flex h-full w-80 min-w-0 flex-col border-r'>
       <div className='space-y-3 border-b p-3'>
+        <NewConversationDialog onCreated={onSelect} />
         <div className='relative'>
           <Search className='text-muted-foreground absolute top-2.5 left-2.5 h-4 w-4' />
           <Input
@@ -102,24 +121,43 @@ export function ThreadList({ selectedThreadId, onSelect }: Props) {
           />
         </div>
         <div className='flex flex-wrap gap-1.5'>
-          {THREAD_FILTER_OPTIONS.map((f) => (
-            <button
-              key={f.id}
-              onClick={() => setFilterId(f.id)}
-              className={cn(
-                'rounded-full px-2.5 py-1 text-xs transition-colors',
-                filterId === f.id
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-muted text-muted-foreground hover:bg-muted/70'
-              )}
-            >
-              {t(f.labelKey as any)}
-            </button>
-          ))}
+          {THREAD_FILTER_OPTIONS.map((f) => {
+            const count = f.countKey ? counts?.[f.countKey] : undefined;
+            return (
+              <button
+                key={f.id}
+                onClick={() => setFilterId(f.id)}
+                className={cn(
+                  'flex items-center gap-1 rounded-full px-2.5 py-1 text-xs transition-colors',
+                  filterId === f.id
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/70'
+                )}
+              >
+                {t(f.labelKey as never)}
+                {count !== undefined && count > 0 && (
+                  <span
+                    className={cn(
+                      'rounded-full px-1 text-[10px]',
+                      filterId === f.id
+                        ? 'bg-primary-foreground/20'
+                        : 'bg-background/70'
+                    )}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
         </div>
       </div>
 
-      <ScrollArea className='flex-1'>
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className='min-h-0 flex-1 overflow-y-auto'
+      >
         {loading && threads.length === 0 ? (
           <div className='space-y-2 p-3'>
             {Array.from({ length: 6 }).map((_, i) => (
@@ -131,72 +169,101 @@ export function ThreadList({ selectedThreadId, onSelect }: Props) {
             <InboxIcon className='mb-3 h-10 w-10' />
             <p className='text-sm'>{t('threadList.noConversations')}</p>
             <p className='mt-1 text-xs'>{t('threadList.newWillAppear')}</p>
-            <Button
-              variant='outline'
-              size='sm'
-              className='mt-4'
+            <button
               disabled={backfilling}
               onClick={runBackfill}
+              className='mt-4 text-xs text-emerald-600 underline-offset-2 hover:underline disabled:opacity-60'
             >
               {backfilling
                 ? t('threadList.importing')
                 : t('threadList.importFromPastCalls')}
-            </Button>
+            </button>
           </div>
         ) : (
-          <ul className='divide-y'>
-            {threads.map((t) => {
-              const selected = t.id === selectedThreadId;
-              return (
-                <li key={t.id}>
-                  <button
-                    onClick={() => onSelect(t)}
-                    className={cn(
-                      'hover:bg-muted/50 w-full px-3 py-3 text-left transition-colors',
-                      selected && 'bg-muted'
-                    )}
-                  >
-                    <div className='flex items-start gap-2'>
-                      <div className='mt-0.5'>{kindIcon(t.lastEventKind)}</div>
-                      <div className='min-w-0 flex-1'>
-                        <div className='flex items-baseline justify-between gap-2'>
-                          <span className='truncate text-sm font-medium'>
-                            {threadDisplayName(t)}
-                          </span>
-                          <span className='text-muted-foreground shrink-0 text-[11px]'>
-                            {relativeTime(t.lastEventAt)}
-                          </span>
+          <>
+            <ul className='divide-y'>
+              {threads.map((thread) => {
+                const selected = thread.id === selectedThreadId;
+                return (
+                  <li key={thread.id} className='group relative'>
+                    <button
+                      onClick={() => onSelect(thread)}
+                      className={cn(
+                        'hover:bg-muted/50 w-full px-3 py-3 text-left transition-colors',
+                        selected && 'bg-muted',
+                        thread.unreadCount > 0 && 'bg-primary/[0.04]'
+                      )}
+                    >
+                      <div className='flex items-start gap-2'>
+                        <div className='mt-0.5'>
+                          {kindIcon(thread.lastEventKind)}
                         </div>
-                        <div className='mt-0.5 flex items-center gap-2'>
-                          <p className='text-muted-foreground truncate text-xs'>
-                            {t.lastPreview ?? '—'}
-                          </p>
-                          {t.unreadCount > 0 && (
-                            <Badge
-                              variant='default'
-                              className='ml-auto h-5 min-w-5 justify-center px-1.5 text-[10px]'
+                        <div className='min-w-0 flex-1'>
+                          <div className='flex items-baseline justify-between gap-2'>
+                            <span
+                              className={cn(
+                                'truncate text-sm',
+                                thread.unreadCount > 0
+                                  ? 'font-semibold'
+                                  : 'font-medium'
+                              )}
                             >
-                              {t.unreadCount}
+                              {threadDisplayName(thread)}
+                            </span>
+                            <span className='text-muted-foreground shrink-0 text-[11px]'>
+                              {relativeTime(thread.lastEventAt)}
+                            </span>
+                          </div>
+                          <div className='mt-0.5 flex items-center gap-2'>
+                            <p className='text-muted-foreground truncate text-xs'>
+                              {thread.lastPreview ?? '—'}
+                            </p>
+                            {thread.unreadCount > 0 && (
+                              <Badge
+                                variant='default'
+                                className='ml-auto h-5 min-w-5 justify-center px-1.5 text-[10px]'
+                              >
+                                {thread.unreadCount}
+                              </Badge>
+                            )}
+                          </div>
+                          {thread.status !== 'open' && (
+                            <Badge
+                              variant='outline'
+                              className='mt-1 text-[10px] uppercase'
+                            >
+                              {thread.status}
                             </Badge>
                           )}
                         </div>
-                        {t.status !== 'open' && (
-                          <Badge
-                            variant='outline'
-                            className='mt-1 text-[10px] uppercase'
-                          >
-                            {t.status}
-                          </Badge>
-                        )}
                       </div>
-                    </div>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+                    </button>
+                    {thread.unreadCount > 0 && (
+                      <button
+                        type='button'
+                        title={t('threadList.markRead')}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          actions.markRead(thread.id);
+                        }}
+                        className='bg-background absolute top-1/2 right-2 hidden -translate-y-1/2 items-center justify-center rounded-full border p-1.5 shadow-sm group-hover:flex'
+                      >
+                        <Check className='h-3.5 w-3.5' />
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+            {loadingMore && (
+              <div className='text-muted-foreground flex items-center justify-center gap-2 py-4 text-xs'>
+                <Loader2 className='h-3.5 w-3.5 animate-spin' />
+                {t('threadList.loadingMore')}
+              </div>
+            )}
+          </>
         )}
-      </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/features/inbox/components/thread-timeline.tsx
+++ b/apps/frontend/src/features/inbox/components/thread-timeline.tsx
@@ -25,6 +25,7 @@ import {
 } from '../hooks/use-inbox';
 import { EventBubble } from './event-bubble';
 import { Composer } from './composer';
+import { AssignThreadMenu } from './assign-thread-menu';
 import { useTranslations } from 'next-intl';
 
 interface Props {
@@ -99,11 +100,7 @@ export function ThreadTimeline({ thread, onChanged }: Props) {
           </p>
         </div>
         <div className='flex items-center gap-2'>
-          {thread.contactId ? null : (
-            <Button variant='outline' size='sm' disabled>
-              {t('timeline.linkContact')}
-            </Button>
-          )}
+          <AssignThreadMenu thread={thread} onChanged={onChanged} />
           <Button
             variant='outline'
             size='sm'

--- a/apps/frontend/src/features/inbox/hooks/use-inbox.ts
+++ b/apps/frontend/src/features/inbox/hooks/use-inbox.ts
@@ -22,44 +22,108 @@ interface ListEventsResponse {
 
 const THREAD_POLL_MS = 7000;
 const EVENTS_POLL_MS = 4000;
+const COUNTS_POLL_MS = 30000;
+
+const PAGE_SIZE = 25;
 
 export function useThreads(filterId: string, search: string) {
   const api = useApi();
   const [threads, setThreads] = useState<InboxThread[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [total, setTotal] = useState(0);
+  // How many pages are currently materialised — the poll/refresh re-pulls them
+  // all in one request so the visible list stays fresh without losing scroll.
+  const pagesRef = useRef(1);
   const filter = THREAD_FILTER_OPTIONS.find((f) => f.id === filterId);
 
-  const load = useCallback(async () => {
-    const params = new URLSearchParams();
-    if (filter?.status) {
-      filter.status.forEach((s) => params.append('status', s));
-    }
-    if (filter?.kind) {
-      filter.kind.forEach((k) => params.append('kind', k));
-    }
-    if (filter?.unreadOnly) params.set('unreadOnly', 'true');
-    if (search) params.set('search', search);
-    params.set('limit', '50');
+  const buildParams = useCallback(
+    (limit: number, page: number) => {
+      const params = new URLSearchParams();
+      if (filter?.status)
+        filter.status.forEach((s) => params.append('status', s));
+      if (filter?.kind) filter.kind.forEach((k) => params.append('kind', k));
+      if (filter?.unreadOnly) params.set('unreadOnly', 'true');
+      if (filter?.mine) params.set('mine', 'true');
+      if (filter?.unassigned) params.set('assignedToId', 'null');
+      if (search) params.set('search', search);
+      params.set('limit', String(limit));
+      params.set('page', String(page));
+      return params.toString();
+    },
+    [filter, search]
+  );
 
+  // Re-pull every loaded page in a single request (initial load, polling, and
+  // after actions). Replaces the list so updates/new threads surface in place.
+  const refresh = useCallback(async () => {
     try {
       const res = await api.get<ListThreadsResponse>(
-        `/inbox/threads?${params.toString()}`
+        `/inbox/threads?${buildParams(PAGE_SIZE * pagesRef.current, 1)}`
       );
       setThreads(res.data ?? []);
+      setTotal(res.meta?.total ?? 0);
     } catch {
-      // handled
+      // handled by global error handling
     } finally {
       setLoading(false);
     }
-  }, [api, filter, search]);
+  }, [api, buildParams]);
 
+  const loadMore = useCallback(async () => {
+    if (loadingMore) return;
+    setLoadingMore(true);
+    const nextPage = pagesRef.current + 1;
+    try {
+      const res = await api.get<ListThreadsResponse>(
+        `/inbox/threads?${buildParams(PAGE_SIZE, nextPage)}`
+      );
+      const more = res.data ?? [];
+      setThreads((prev) => {
+        const seen = new Set(prev.map((t) => t.id));
+        return [...prev, ...more.filter((t) => !seen.has(t.id))];
+      });
+      setTotal(res.meta?.total ?? 0);
+      pagesRef.current = nextPage;
+    } catch {
+      // handled
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [api, buildParams, loadingMore]);
+
+  // Reset to the first page whenever the filter or search changes.
   useEffect(() => {
-    load();
-    const id = window.setInterval(load, THREAD_POLL_MS);
-    return () => window.clearInterval(id);
-  }, [load]);
+    pagesRef.current = 1;
+    setLoading(true);
+    setThreads([]);
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterId, search]);
 
-  return { threads, loading, reload: load };
+  // Poll, paused while the tab is hidden; refresh on regaining visibility.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      if (!document.hidden) refresh();
+    }, THREAD_POLL_MS);
+    const onVisible = () => {
+      if (!document.hidden) refresh();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [refresh]);
+
+  return {
+    threads,
+    loading,
+    loadingMore,
+    hasMore: threads.length < total,
+    reload: refresh,
+    loadMore
+  };
 }
 
 export function useThreadEvents(threadId: string | null) {
@@ -100,8 +164,17 @@ export function useThreadEvents(threadId: string | null) {
     lastIdRef.current = null;
     load(true);
     if (!threadId) return;
-    const id = window.setInterval(() => load(false), EVENTS_POLL_MS);
-    return () => window.clearInterval(id);
+    const id = window.setInterval(() => {
+      if (!document.hidden) load(false);
+    }, EVENTS_POLL_MS);
+    const onVisible = () => {
+      if (!document.hidden) load(false);
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId]);
 
@@ -142,8 +215,80 @@ export function useThreadActions(onChange: () => void) {
     reopen: async (threadId: string) => {
       await api.post(`/inbox/threads/${threadId}/reopen`);
       onChange();
+    },
+    linkContact: async (threadId: string, contactId: string | null) => {
+      await api.post(`/inbox/threads/${threadId}/link-contact`, { contactId });
+      onChange();
+    },
+    assign: async (threadId: string, assigneeId: string | null) => {
+      await api.post(`/inbox/threads/${threadId}/assign`, { assigneeId });
+      onChange();
     }
   };
+}
+
+/** Total unread threads, polled (paused while the tab is hidden). */
+export function useUnreadCount() {
+  const api = useApi();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    const load = () => {
+      if (document.hidden) return;
+      api
+        .get<{ count: number }>('/inbox/unread-count')
+        .then((r) => active && setCount(r?.count ?? 0))
+        .catch(() => undefined);
+    };
+    load();
+    const id = window.setInterval(load, COUNTS_POLL_MS);
+    const onVisible = () => !document.hidden && load();
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      active = false;
+      window.clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [api]);
+
+  return count;
+}
+
+export interface InboxCounts {
+  all: number;
+  unread: number;
+  missed: number;
+  voicemails: number;
+  sms: number;
+}
+
+/** Per-filter counts for the filter pills. `reloadKey` forces a refetch. */
+export function useInboxCounts(reloadKey = 0) {
+  const api = useApi();
+  const [counts, setCounts] = useState<InboxCounts | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const load = () => {
+      if (document.hidden) return;
+      api
+        .get<InboxCounts>('/inbox/counts')
+        .then((r) => active && setCounts(r ?? null))
+        .catch(() => undefined);
+    };
+    load();
+    const id = window.setInterval(load, COUNTS_POLL_MS);
+    const onVisible = () => !document.hidden && load();
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      active = false;
+      window.clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [api, reloadKey]);
+
+  return counts;
 }
 
 export function useNumbers() {
@@ -165,6 +310,69 @@ export function useNumbers() {
   }, [api]);
 
   return numbers;
+}
+
+export interface ThreadActivity {
+  contactId: string | null;
+  calls: {
+    id: string;
+    direction: string | null;
+    status: string;
+    outcome: string | null;
+    outcomeNote: string | null;
+    durationSeconds: number | null;
+    createdAt: string;
+  }[];
+  notes: {
+    id: string;
+    content: string;
+    userId: string;
+    createdAt: string;
+  }[];
+  meetings: {
+    id: string;
+    title: string | null;
+    scheduledAt: string;
+    notes: string | null;
+    status: string;
+  }[];
+  callbacks: {
+    id: string;
+    scheduledAt: string;
+    note: string | null;
+    status: string;
+    completedAt: string | null;
+  }[];
+}
+
+/**
+ * Full contact context for a thread: calls (with outcomes + notes), contact
+ * notes, meetings and callbacks. `refreshKey` forces a refetch after the user
+ * schedules a callback/meeting or links a contact from the context pane.
+ */
+export function useThreadActivity(threadId: string | null, refreshKey = 0) {
+  const api = useApi();
+  const [activity, setActivity] = useState<ThreadActivity | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!threadId) {
+      setActivity(null);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    api
+      .get<ThreadActivity>(`/inbox/threads/${threadId}/activity`)
+      .then((r) => active && setActivity(r ?? null))
+      .catch(() => active && setActivity(null))
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [api, threadId, refreshKey]);
+
+  return { activity, loading };
 }
 
 export function threadDisplayName(t: InboxThread): string {

--- a/apps/frontend/src/features/inbox/types.ts
+++ b/apps/frontend/src/features/inbox/types.ts
@@ -96,29 +96,50 @@ export interface InboxEvent {
   meeting?: any;
 }
 
+export type InboxCountKey = 'all' | 'unread' | 'missed' | 'voicemails' | 'sms';
+
 export const THREAD_FILTER_OPTIONS: {
   id: string;
   labelKey: string;
   status?: InboxThreadStatus[];
   kind?: InboxEventKind[];
   unreadOnly?: boolean;
+  mine?: boolean;
+  unassigned?: boolean;
+  /** Which key from GET /inbox/counts drives this pill's badge (if any). */
+  countKey?: InboxCountKey;
 }[] = [
-  { id: 'all', labelKey: 'filters.all', status: ['open', 'pending'] },
-  { id: 'unread', labelKey: 'filters.unread', unreadOnly: true },
+  {
+    id: 'all',
+    labelKey: 'filters.all',
+    status: ['open', 'pending'],
+    countKey: 'all'
+  },
+  {
+    id: 'unread',
+    labelKey: 'filters.unread',
+    unreadOnly: true,
+    countKey: 'unread'
+  },
+  { id: 'mine', labelKey: 'filters.mine', mine: true },
+  { id: 'unassigned', labelKey: 'filters.unassigned', unassigned: true },
   {
     id: 'missed',
     labelKey: 'filters.missedCalls',
-    kind: ['missed_call']
+    kind: ['missed_call'],
+    countKey: 'missed'
   },
   {
     id: 'voicemails',
     labelKey: 'filters.voicemails',
-    kind: ['voicemail_received']
+    kind: ['voicemail_received'],
+    countKey: 'voicemails'
   },
   {
     id: 'sms',
     labelKey: 'filters.sms',
-    kind: ['sms_received', 'sms_sent', 'mms_received', 'mms_sent']
+    kind: ['sms_received', 'sms_sent', 'mms_received', 'mms_sent'],
+    countKey: 'sms'
   },
   { id: 'resolved', labelKey: 'filters.resolved', status: ['resolved'] },
   { id: 'archived', labelKey: 'filters.archived', status: ['archived'] }

--- a/apps/frontend/src/i18n/locales/de/inbox.json
+++ b/apps/frontend/src/i18n/locales/de/inbox.json
@@ -4,6 +4,8 @@
   "filters": {
     "all": "Alle",
     "unread": "Ungelesen",
+    "mine": "Mir zugewiesen",
+    "unassigned": "Nicht zugewiesen",
     "missed": "Verpasst",
     "missedCalls": "Verpasste Anrufe",
     "voicemail": "Voicemail",
@@ -21,7 +23,9 @@
     "noConversations": "Noch keine Unterhaltungen",
     "newWillAppear": "Neue Anrufe und SMS erscheinen hier automatisch.",
     "importing": "Importiere…",
-    "importFromPastCalls": "Aus vergangenen Anrufen importieren"
+    "importFromPastCalls": "Aus vergangenen Anrufen importieren",
+    "markRead": "Als gelesen markieren",
+    "loadingMore": "Lade mehr…"
   },
   "timeline": {
     "selectConversation": "Wähle eine Unterhaltung, um zu beginnen",
@@ -43,7 +47,87 @@
     "messagePlaceholder": "Nachricht eingeben — ⌘/Strg + Enter zum Senden",
     "saveNote": "Notiz speichern",
     "send": "Senden",
+    "attach": "Medien anhängen",
+    "mmsDisabled": "Diese Nummer unterstützt kein MMS",
+    "attachError": "Anhang konnte nicht hochgeladen werden",
     "smsDisabledWarning": "Für diese Nummer ist SMS in Telnyx nicht aktiviert. Wähle eine andere oder aktiviere Messaging für die Nummer."
+  },
+  "newConversation": {
+    "newMessage": "Neue Nachricht",
+    "title": "Neue Unterhaltung",
+    "from": "Von",
+    "selectNumber": "Nummer auswählen",
+    "noSmsNumbers": "Keine deiner Nummern hat SMS aktiviert.",
+    "to": "An",
+    "manualPlaceholder": "+14155550100",
+    "message": "Nachricht",
+    "messagePlaceholder": "Schreibe deine erste Nachricht…",
+    "send": "Nachricht senden",
+    "sendError": "Nachricht konnte nicht gesendet werden"
+  },
+  "contextPane": {
+    "quickActions": "Schnellaktionen",
+    "call": "Anrufen",
+    "note": "Notiz",
+    "callback": "Rückruf",
+    "meeting": "Meeting",
+    "viewProfile": "Vollständiges Profil ansehen",
+    "unknownNumber": "Diese Nummer ist noch nicht mit einem Kontakt verknüpft.",
+    "namePlaceholder": "Kontaktname",
+    "create": "Erstellen",
+    "linkExisting": "Bestehenden Kontakt verknüpfen",
+    "searchContacts": "Kontakte suchen…",
+    "searching": "Suche…",
+    "noContacts": "Keine Kontakte gefunden",
+    "linkedToast": "Kontakt verknüpft",
+    "linkError": "Kontakt konnte nicht verknüpft werden",
+    "createdToast": "Kontakt erstellt und verknüpft",
+    "createError": "Kontakt konnte nicht erstellt werden",
+    "scheduleCallback": "Rückruf planen",
+    "scheduleMeeting": "Meeting planen",
+    "notePlaceholder": "Notiz hinzufügen (optional)…",
+    "schedule": "Planen",
+    "invalidDate": "Wähle ein zukünftiges Datum und eine Uhrzeit",
+    "callbackScheduled": "Rückruf geplant",
+    "meetingScheduled": "Meeting geplant",
+    "scheduleError": "Planung fehlgeschlagen",
+    "history": {
+      "title": "Verlauf",
+      "empty": "Noch kein Verlauf für diesen Kontakt.",
+      "loading": "Verlauf wird geladen…",
+      "callInbound": "Eingehender Anruf",
+      "callOutbound": "Ausgehender Anruf",
+      "callMissed": "Verpasster Anruf",
+      "note": "Notiz",
+      "meeting": "Meeting",
+      "callback": "Rückruf",
+      "outcomes": {
+        "meeting_booked": "Meeting gebucht",
+        "sale": "Verkauf",
+        "interested": "Interessiert",
+        "follow_up": "Nachfassen",
+        "callback_scheduled": "Rückruf geplant",
+        "not_interested": "Nicht interessiert",
+        "no_answer": "Keine Antwort",
+        "voicemail": "Voicemail",
+        "wrong_number": "Falsche Nummer",
+        "gatekeeper": "Vorzimmer"
+      },
+      "statuses": {
+        "scheduled": "Geplant",
+        "completed": "Abgeschlossen",
+        "cancelled": "Storniert",
+        "missed": "Verpasst",
+        "pending": "Ausstehend",
+        "confirmed": "Bestätigt"
+      }
+    }
+  },
+  "assignment": {
+    "assign": "Zuweisen",
+    "assignTo": "Zuweisen an",
+    "unassigned": "Nicht zugewiesen",
+    "memberFallback": "Mitglied"
   },
   "events": {
     "missedCall": "Verpasster Anruf",

--- a/apps/frontend/src/i18n/locales/en/inbox.json
+++ b/apps/frontend/src/i18n/locales/en/inbox.json
@@ -4,6 +4,8 @@
   "filters": {
     "all": "All",
     "unread": "Unread",
+    "mine": "Assigned to me",
+    "unassigned": "Unassigned",
     "missed": "Missed",
     "missedCalls": "Missed Calls",
     "voicemail": "Voicemail",
@@ -21,7 +23,9 @@
     "noConversations": "No conversations yet",
     "newWillAppear": "New calls and SMS will appear here automatically.",
     "importing": "Importing…",
-    "importFromPastCalls": "Import from past calls"
+    "importFromPastCalls": "Import from past calls",
+    "markRead": "Mark as read",
+    "loadingMore": "Loading more…"
   },
   "timeline": {
     "selectConversation": "Select a conversation to start",
@@ -43,7 +47,87 @@
     "messagePlaceholder": "Type a message — ⌘/Ctrl + Enter to send",
     "saveNote": "Save note",
     "send": "Send",
+    "attach": "Attach media",
+    "mmsDisabled": "This number does not support MMS",
+    "attachError": "Could not upload attachment",
     "smsDisabledWarning": "This number does not have SMS enabled in Telnyx. Pick another or enable messaging on the number."
+  },
+  "newConversation": {
+    "newMessage": "New message",
+    "title": "New conversation",
+    "from": "From",
+    "selectNumber": "Select a number",
+    "noSmsNumbers": "None of your numbers have SMS enabled.",
+    "to": "To",
+    "manualPlaceholder": "+14155550100",
+    "message": "Message",
+    "messagePlaceholder": "Type your first message…",
+    "send": "Send message",
+    "sendError": "Could not send the message"
+  },
+  "contextPane": {
+    "quickActions": "Quick actions",
+    "call": "Call",
+    "note": "Note",
+    "callback": "Callback",
+    "meeting": "Meeting",
+    "viewProfile": "View full profile",
+    "unknownNumber": "This number isn't linked to a contact yet.",
+    "namePlaceholder": "Contact name",
+    "create": "Create",
+    "linkExisting": "Link existing contact",
+    "searchContacts": "Search contacts…",
+    "searching": "Searching…",
+    "noContacts": "No contacts found",
+    "linkedToast": "Contact linked",
+    "linkError": "Could not link the contact",
+    "createdToast": "Contact created and linked",
+    "createError": "Could not create the contact",
+    "scheduleCallback": "Schedule callback",
+    "scheduleMeeting": "Schedule meeting",
+    "notePlaceholder": "Add a note (optional)…",
+    "schedule": "Schedule",
+    "invalidDate": "Pick a future date and time",
+    "callbackScheduled": "Callback scheduled",
+    "meetingScheduled": "Meeting scheduled",
+    "scheduleError": "Could not schedule",
+    "history": {
+      "title": "History",
+      "empty": "No history yet for this contact.",
+      "loading": "Loading history…",
+      "callInbound": "Inbound call",
+      "callOutbound": "Outbound call",
+      "callMissed": "Missed call",
+      "note": "Note",
+      "meeting": "Meeting",
+      "callback": "Callback",
+      "outcomes": {
+        "meeting_booked": "Meeting booked",
+        "sale": "Sale",
+        "interested": "Interested",
+        "follow_up": "Follow up",
+        "callback_scheduled": "Callback scheduled",
+        "not_interested": "Not interested",
+        "no_answer": "No answer",
+        "voicemail": "Voicemail",
+        "wrong_number": "Wrong number",
+        "gatekeeper": "Gatekeeper"
+      },
+      "statuses": {
+        "scheduled": "Scheduled",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "missed": "Missed",
+        "pending": "Pending",
+        "confirmed": "Confirmed"
+      }
+    }
+  },
+  "assignment": {
+    "assign": "Assign",
+    "assignTo": "Assign to",
+    "unassigned": "Unassigned",
+    "memberFallback": "Member"
   },
   "events": {
     "missedCall": "Missed call",

--- a/apps/frontend/src/i18n/locales/es/inbox.json
+++ b/apps/frontend/src/i18n/locales/es/inbox.json
@@ -4,6 +4,8 @@
   "filters": {
     "all": "Todos",
     "unread": "No leídos",
+    "mine": "Asignados a mí",
+    "unassigned": "Sin asignar",
     "missed": "Perdidos",
     "missedCalls": "Llamadas perdidas",
     "voicemail": "Mensaje de voz",
@@ -21,7 +23,9 @@
     "noConversations": "Aún no hay conversaciones",
     "newWillAppear": "Las nuevas llamadas y SMS aparecerán aquí automáticamente.",
     "importing": "Importando…",
-    "importFromPastCalls": "Importar desde llamadas anteriores"
+    "importFromPastCalls": "Importar desde llamadas anteriores",
+    "markRead": "Marcar como visto",
+    "loadingMore": "Cargando más…"
   },
   "timeline": {
     "selectConversation": "Selecciona una conversación para empezar",
@@ -43,7 +47,87 @@
     "messagePlaceholder": "Escribe un mensaje — ⌘/Ctrl + Enter para enviar",
     "saveNote": "Guardar nota",
     "send": "Enviar",
+    "attach": "Adjuntar archivo",
+    "mmsDisabled": "Este número no admite MMS",
+    "attachError": "No se pudo subir el adjunto",
     "smsDisabledWarning": "Este número no tiene SMS habilitado en Telnyx. Elige otro o habilita los mensajes en el número."
+  },
+  "newConversation": {
+    "newMessage": "Nuevo mensaje",
+    "title": "Nueva conversación",
+    "from": "Desde",
+    "selectNumber": "Selecciona un número",
+    "noSmsNumbers": "Ninguno de tus números tiene SMS habilitado.",
+    "to": "Para",
+    "manualPlaceholder": "+14155550100",
+    "message": "Mensaje",
+    "messagePlaceholder": "Escribe tu primer mensaje…",
+    "send": "Enviar mensaje",
+    "sendError": "No se pudo enviar el mensaje"
+  },
+  "contextPane": {
+    "quickActions": "Acciones rápidas",
+    "call": "Llamar",
+    "note": "Nota",
+    "callback": "Devolución",
+    "meeting": "Reunión",
+    "viewProfile": "Ver perfil completo",
+    "unknownNumber": "Este número aún no está vinculado a un contacto.",
+    "namePlaceholder": "Nombre del contacto",
+    "create": "Crear",
+    "linkExisting": "Vincular contacto existente",
+    "searchContacts": "Buscar contactos…",
+    "searching": "Buscando…",
+    "noContacts": "No se encontraron contactos",
+    "linkedToast": "Contacto vinculado",
+    "linkError": "No se pudo vincular el contacto",
+    "createdToast": "Contacto creado y vinculado",
+    "createError": "No se pudo crear el contacto",
+    "scheduleCallback": "Programar devolución",
+    "scheduleMeeting": "Agendar reunión",
+    "notePlaceholder": "Añade una nota (opcional)…",
+    "schedule": "Programar",
+    "invalidDate": "Elige una fecha y hora futura",
+    "callbackScheduled": "Devolución programada",
+    "meetingScheduled": "Reunión agendada",
+    "scheduleError": "No se pudo programar",
+    "history": {
+      "title": "Historial",
+      "empty": "Aún no hay historial para este contacto.",
+      "loading": "Cargando historial…",
+      "callInbound": "Llamada entrante",
+      "callOutbound": "Llamada saliente",
+      "callMissed": "Llamada perdida",
+      "note": "Nota",
+      "meeting": "Reunión",
+      "callback": "Devolución",
+      "outcomes": {
+        "meeting_booked": "Reunión agendada",
+        "sale": "Venta",
+        "interested": "Interesado",
+        "follow_up": "Seguimiento",
+        "callback_scheduled": "Devolución programada",
+        "not_interested": "No interesado",
+        "no_answer": "Sin respuesta",
+        "voicemail": "Buzón de voz",
+        "wrong_number": "Número equivocado",
+        "gatekeeper": "Filtro / recepción"
+      },
+      "statuses": {
+        "scheduled": "Programada",
+        "completed": "Completada",
+        "cancelled": "Cancelada",
+        "missed": "Perdida",
+        "pending": "Pendiente",
+        "confirmed": "Confirmada"
+      }
+    }
+  },
+  "assignment": {
+    "assign": "Asignar",
+    "assignTo": "Asignar a",
+    "unassigned": "Sin asignar",
+    "memberFallback": "Miembro"
   },
   "events": {
     "missedCall": "Llamada perdida",

--- a/apps/frontend/src/i18n/locales/fr/inbox.json
+++ b/apps/frontend/src/i18n/locales/fr/inbox.json
@@ -4,6 +4,8 @@
   "filters": {
     "all": "Tous",
     "unread": "Non lus",
+    "mine": "Assignés à moi",
+    "unassigned": "Non assignés",
     "missed": "Manqués",
     "missedCalls": "Appels manqués",
     "voicemail": "Messagerie vocale",
@@ -21,7 +23,9 @@
     "noConversations": "Aucune conversation pour le moment",
     "newWillAppear": "Les nouveaux appels et SMS apparaîtront ici automatiquement.",
     "importing": "Importation…",
-    "importFromPastCalls": "Importer depuis les appels passés"
+    "importFromPastCalls": "Importer depuis les appels passés",
+    "markRead": "Marquer comme lu",
+    "loadingMore": "Chargement de la suite…"
   },
   "timeline": {
     "selectConversation": "Sélectionnez une conversation pour commencer",
@@ -43,7 +47,87 @@
     "messagePlaceholder": "Tapez un message — ⌘/Ctrl + Entrée pour envoyer",
     "saveNote": "Enregistrer la note",
     "send": "Envoyer",
+    "attach": "Joindre un média",
+    "mmsDisabled": "Ce numéro ne prend pas en charge les MMS",
+    "attachError": "Impossible de téléverser la pièce jointe",
     "smsDisabledWarning": "Ce numéro n'a pas les SMS activés dans Telnyx. Choisissez-en un autre ou activez la messagerie sur le numéro."
+  },
+  "newConversation": {
+    "newMessage": "Nouveau message",
+    "title": "Nouvelle conversation",
+    "from": "De",
+    "selectNumber": "Sélectionner un numéro",
+    "noSmsNumbers": "Aucun de vos numéros n'a les SMS activés.",
+    "to": "À",
+    "manualPlaceholder": "+14155550100",
+    "message": "Message",
+    "messagePlaceholder": "Saisissez votre premier message…",
+    "send": "Envoyer le message",
+    "sendError": "Impossible d'envoyer le message"
+  },
+  "contextPane": {
+    "quickActions": "Actions rapides",
+    "call": "Appeler",
+    "note": "Note",
+    "callback": "Rappel",
+    "meeting": "Réunion",
+    "viewProfile": "Voir le profil complet",
+    "unknownNumber": "Ce numéro n'est pas encore associé à un contact.",
+    "namePlaceholder": "Nom du contact",
+    "create": "Créer",
+    "linkExisting": "Associer un contact existant",
+    "searchContacts": "Rechercher des contacts…",
+    "searching": "Recherche…",
+    "noContacts": "Aucun contact trouvé",
+    "linkedToast": "Contact associé",
+    "linkError": "Impossible d'associer le contact",
+    "createdToast": "Contact créé et associé",
+    "createError": "Impossible de créer le contact",
+    "scheduleCallback": "Planifier un rappel",
+    "scheduleMeeting": "Planifier une réunion",
+    "notePlaceholder": "Ajouter une note (facultatif)…",
+    "schedule": "Planifier",
+    "invalidDate": "Choisissez une date et une heure futures",
+    "callbackScheduled": "Rappel planifié",
+    "meetingScheduled": "Réunion planifiée",
+    "scheduleError": "Impossible de planifier",
+    "history": {
+      "title": "Historique",
+      "empty": "Aucun historique pour ce contact.",
+      "loading": "Chargement de l'historique…",
+      "callInbound": "Appel entrant",
+      "callOutbound": "Appel sortant",
+      "callMissed": "Appel manqué",
+      "note": "Note",
+      "meeting": "Réunion",
+      "callback": "Rappel",
+      "outcomes": {
+        "meeting_booked": "Réunion planifiée",
+        "sale": "Vente",
+        "interested": "Intéressé",
+        "follow_up": "Suivi",
+        "callback_scheduled": "Rappel planifié",
+        "not_interested": "Pas intéressé",
+        "no_answer": "Pas de réponse",
+        "voicemail": "Messagerie vocale",
+        "wrong_number": "Mauvais numéro",
+        "gatekeeper": "Filtrage / accueil"
+      },
+      "statuses": {
+        "scheduled": "Planifié",
+        "completed": "Terminé",
+        "cancelled": "Annulé",
+        "missed": "Manqué",
+        "pending": "En attente",
+        "confirmed": "Confirmé"
+      }
+    }
+  },
+  "assignment": {
+    "assign": "Assigner",
+    "assignTo": "Assigner à",
+    "unassigned": "Non assigné",
+    "memberFallback": "Membre"
   },
   "events": {
     "missedCall": "Appel manqué",

--- a/apps/frontend/src/i18n/locales/it/inbox.json
+++ b/apps/frontend/src/i18n/locales/it/inbox.json
@@ -4,6 +4,8 @@
   "filters": {
     "all": "Tutti",
     "unread": "Non letti",
+    "mine": "Assegnati a me",
+    "unassigned": "Non assegnati",
     "missed": "Persi",
     "missedCalls": "Chiamate perse",
     "voicemail": "Segreteria",
@@ -21,7 +23,9 @@
     "noConversations": "Nessuna conversazione ancora",
     "newWillAppear": "Le nuove chiamate e gli SMS appariranno qui automaticamente.",
     "importing": "Importazione…",
-    "importFromPastCalls": "Importa dalle chiamate passate"
+    "importFromPastCalls": "Importa dalle chiamate passate",
+    "markRead": "Segna come letto",
+    "loadingMore": "Caricamento altri…"
   },
   "timeline": {
     "selectConversation": "Seleziona una conversazione per iniziare",
@@ -43,7 +47,87 @@
     "messagePlaceholder": "Scrivi un messaggio — ⌘/Ctrl + Invio per inviare",
     "saveNote": "Salva nota",
     "send": "Invia",
+    "attach": "Allega media",
+    "mmsDisabled": "Questo numero non supporta gli MMS",
+    "attachError": "Impossibile caricare l'allegato",
     "smsDisabledWarning": "Questo numero non ha gli SMS abilitati in Telnyx. Scegline un altro o abilita la messaggistica sul numero."
+  },
+  "newConversation": {
+    "newMessage": "Nuovo messaggio",
+    "title": "Nuova conversazione",
+    "from": "Da",
+    "selectNumber": "Seleziona un numero",
+    "noSmsNumbers": "Nessuno dei tuoi numeri ha gli SMS abilitati.",
+    "to": "A",
+    "manualPlaceholder": "+14155550100",
+    "message": "Messaggio",
+    "messagePlaceholder": "Scrivi il tuo primo messaggio…",
+    "send": "Invia messaggio",
+    "sendError": "Impossibile inviare il messaggio"
+  },
+  "contextPane": {
+    "quickActions": "Azioni rapide",
+    "call": "Chiama",
+    "note": "Nota",
+    "callback": "Richiamata",
+    "meeting": "Riunione",
+    "viewProfile": "Vedi profilo completo",
+    "unknownNumber": "Questo numero non è ancora collegato a un contatto.",
+    "namePlaceholder": "Nome del contatto",
+    "create": "Crea",
+    "linkExisting": "Collega un contatto esistente",
+    "searchContacts": "Cerca contatti…",
+    "searching": "Ricerca…",
+    "noContacts": "Nessun contatto trovato",
+    "linkedToast": "Contatto collegato",
+    "linkError": "Impossibile collegare il contatto",
+    "createdToast": "Contatto creato e collegato",
+    "createError": "Impossibile creare il contatto",
+    "scheduleCallback": "Pianifica richiamata",
+    "scheduleMeeting": "Pianifica riunione",
+    "notePlaceholder": "Aggiungi una nota (facoltativa)…",
+    "schedule": "Pianifica",
+    "invalidDate": "Scegli una data e un'ora future",
+    "callbackScheduled": "Richiamata pianificata",
+    "meetingScheduled": "Riunione pianificata",
+    "scheduleError": "Impossibile pianificare",
+    "history": {
+      "title": "Cronologia",
+      "empty": "Nessuna cronologia per questo contatto.",
+      "loading": "Caricamento cronologia…",
+      "callInbound": "Chiamata in entrata",
+      "callOutbound": "Chiamata in uscita",
+      "callMissed": "Chiamata persa",
+      "note": "Nota",
+      "meeting": "Riunione",
+      "callback": "Richiamata",
+      "outcomes": {
+        "meeting_booked": "Riunione fissata",
+        "sale": "Vendita",
+        "interested": "Interessato",
+        "follow_up": "Follow-up",
+        "callback_scheduled": "Richiamata pianificata",
+        "not_interested": "Non interessato",
+        "no_answer": "Nessuna risposta",
+        "voicemail": "Segreteria",
+        "wrong_number": "Numero errato",
+        "gatekeeper": "Filtro / reception"
+      },
+      "statuses": {
+        "scheduled": "Pianificata",
+        "completed": "Completata",
+        "cancelled": "Annullata",
+        "missed": "Persa",
+        "pending": "In sospeso",
+        "confirmed": "Confermata"
+      }
+    }
+  },
+  "assignment": {
+    "assign": "Assegna",
+    "assignTo": "Assegna a",
+    "unassigned": "Non assegnato",
+    "memberFallback": "Membro"
   },
   "events": {
     "missedCall": "Chiamata persa",

--- a/apps/frontend/src/i18n/locales/nl/inbox.json
+++ b/apps/frontend/src/i18n/locales/nl/inbox.json
@@ -4,6 +4,8 @@
   "filters": {
     "all": "Alle",
     "unread": "Ongelezen",
+    "mine": "Aan mij toegewezen",
+    "unassigned": "Niet toegewezen",
     "missed": "Gemist",
     "missedCalls": "Gemiste oproepen",
     "voicemail": "Voicemail",
@@ -21,7 +23,9 @@
     "noConversations": "Nog geen gesprekken",
     "newWillAppear": "Nieuwe oproepen en SMS verschijnen hier automatisch.",
     "importing": "Importeren…",
-    "importFromPastCalls": "Importeer uit eerdere oproepen"
+    "importFromPastCalls": "Importeer uit eerdere oproepen",
+    "markRead": "Markeer als gelezen",
+    "loadingMore": "Meer laden…"
   },
   "timeline": {
     "selectConversation": "Selecteer een gesprek om te beginnen",
@@ -43,7 +47,87 @@
     "messagePlaceholder": "Typ een bericht — ⌘/Ctrl + Enter om te verzenden",
     "saveNote": "Notitie opslaan",
     "send": "Verzenden",
+    "attach": "Media bijvoegen",
+    "mmsDisabled": "Dit nummer ondersteunt geen MMS",
+    "attachError": "Kon bijlage niet uploaden",
     "smsDisabledWarning": "Voor dit nummer is SMS niet ingeschakeld in Telnyx. Kies een ander of schakel berichten in voor het nummer."
+  },
+  "newConversation": {
+    "newMessage": "Nieuw bericht",
+    "title": "Nieuw gesprek",
+    "from": "Van",
+    "selectNumber": "Selecteer een nummer",
+    "noSmsNumbers": "Geen van je nummers heeft SMS ingeschakeld.",
+    "to": "Aan",
+    "manualPlaceholder": "+14155550100",
+    "message": "Bericht",
+    "messagePlaceholder": "Typ je eerste bericht…",
+    "send": "Bericht verzenden",
+    "sendError": "Kon het bericht niet verzenden"
+  },
+  "contextPane": {
+    "quickActions": "Snelle acties",
+    "call": "Bellen",
+    "note": "Notitie",
+    "callback": "Terugbellen",
+    "meeting": "Vergadering",
+    "viewProfile": "Volledig profiel bekijken",
+    "unknownNumber": "Dit nummer is nog niet aan een contact gekoppeld.",
+    "namePlaceholder": "Contactnaam",
+    "create": "Aanmaken",
+    "linkExisting": "Bestaand contact koppelen",
+    "searchContacts": "Contacten zoeken…",
+    "searching": "Zoeken…",
+    "noContacts": "Geen contacten gevonden",
+    "linkedToast": "Contact gekoppeld",
+    "linkError": "Kon het contact niet koppelen",
+    "createdToast": "Contact aangemaakt en gekoppeld",
+    "createError": "Kon het contact niet aanmaken",
+    "scheduleCallback": "Terugbelverzoek plannen",
+    "scheduleMeeting": "Vergadering plannen",
+    "notePlaceholder": "Voeg een notitie toe (optioneel)…",
+    "schedule": "Plannen",
+    "invalidDate": "Kies een datum en tijd in de toekomst",
+    "callbackScheduled": "Terugbelverzoek gepland",
+    "meetingScheduled": "Vergadering gepland",
+    "scheduleError": "Plannen mislukt",
+    "history": {
+      "title": "Geschiedenis",
+      "empty": "Nog geen geschiedenis voor dit contact.",
+      "loading": "Geschiedenis laden…",
+      "callInbound": "Inkomende oproep",
+      "callOutbound": "Uitgaande oproep",
+      "callMissed": "Gemiste oproep",
+      "note": "Notitie",
+      "meeting": "Vergadering",
+      "callback": "Terugbellen",
+      "outcomes": {
+        "meeting_booked": "Vergadering geboekt",
+        "sale": "Verkoop",
+        "interested": "Geïnteresseerd",
+        "follow_up": "Opvolgen",
+        "callback_scheduled": "Terugbelverzoek gepland",
+        "not_interested": "Niet geïnteresseerd",
+        "no_answer": "Geen antwoord",
+        "voicemail": "Voicemail",
+        "wrong_number": "Verkeerd nummer",
+        "gatekeeper": "Poortwachter"
+      },
+      "statuses": {
+        "scheduled": "Gepland",
+        "completed": "Voltooid",
+        "cancelled": "Geannuleerd",
+        "missed": "Gemist",
+        "pending": "In afwachting",
+        "confirmed": "Bevestigd"
+      }
+    }
+  },
+  "assignment": {
+    "assign": "Toewijzen",
+    "assignTo": "Toewijzen aan",
+    "unassigned": "Niet toegewezen",
+    "memberFallback": "Lid"
   },
   "events": {
     "missedCall": "Gemiste oproep",

--- a/apps/frontend/src/i18n/locales/pt/inbox.json
+++ b/apps/frontend/src/i18n/locales/pt/inbox.json
@@ -4,6 +4,8 @@
   "filters": {
     "all": "Todos",
     "unread": "Não lidos",
+    "mine": "Atribuídos a mim",
+    "unassigned": "Não atribuídos",
     "missed": "Perdidos",
     "missedCalls": "Chamadas perdidas",
     "voicemail": "Correio de voz",
@@ -21,7 +23,9 @@
     "noConversations": "Ainda não há conversas",
     "newWillAppear": "As novas chamadas e SMS aparecerão aqui automaticamente.",
     "importing": "A importar…",
-    "importFromPastCalls": "Importar de chamadas anteriores"
+    "importFromPastCalls": "Importar de chamadas anteriores",
+    "markRead": "Marcar como lido",
+    "loadingMore": "A carregar mais…"
   },
   "timeline": {
     "selectConversation": "Selecione uma conversa para começar",
@@ -43,7 +47,87 @@
     "messagePlaceholder": "Escreva uma mensagem — ⌘/Ctrl + Enter para enviar",
     "saveNote": "Guardar nota",
     "send": "Enviar",
+    "attach": "Anexar multimédia",
+    "mmsDisabled": "Este número não suporta MMS",
+    "attachError": "Não foi possível carregar o anexo",
     "smsDisabledWarning": "Este número não tem SMS ativado no Telnyx. Escolha outro ou ative as mensagens no número."
+  },
+  "newConversation": {
+    "newMessage": "Nova mensagem",
+    "title": "Nova conversa",
+    "from": "De",
+    "selectNumber": "Selecione um número",
+    "noSmsNumbers": "Nenhum dos seus números tem SMS ativado.",
+    "to": "Para",
+    "manualPlaceholder": "+14155550100",
+    "message": "Mensagem",
+    "messagePlaceholder": "Escreva a sua primeira mensagem…",
+    "send": "Enviar mensagem",
+    "sendError": "Não foi possível enviar a mensagem"
+  },
+  "contextPane": {
+    "quickActions": "Ações rápidas",
+    "call": "Ligar",
+    "note": "Nota",
+    "callback": "Retorno",
+    "meeting": "Reunião",
+    "viewProfile": "Ver perfil completo",
+    "unknownNumber": "Este número ainda não está associado a um contacto.",
+    "namePlaceholder": "Nome do contacto",
+    "create": "Criar",
+    "linkExisting": "Associar contacto existente",
+    "searchContacts": "Pesquisar contactos…",
+    "searching": "A pesquisar…",
+    "noContacts": "Nenhum contacto encontrado",
+    "linkedToast": "Contacto associado",
+    "linkError": "Não foi possível associar o contacto",
+    "createdToast": "Contacto criado e associado",
+    "createError": "Não foi possível criar o contacto",
+    "scheduleCallback": "Agendar retorno",
+    "scheduleMeeting": "Agendar reunião",
+    "notePlaceholder": "Adicione uma nota (opcional)…",
+    "schedule": "Agendar",
+    "invalidDate": "Escolha uma data e hora futuras",
+    "callbackScheduled": "Retorno agendado",
+    "meetingScheduled": "Reunião agendada",
+    "scheduleError": "Não foi possível agendar",
+    "history": {
+      "title": "Histórico",
+      "empty": "Ainda não há histórico para este contacto.",
+      "loading": "A carregar histórico…",
+      "callInbound": "Chamada recebida",
+      "callOutbound": "Chamada efetuada",
+      "callMissed": "Chamada perdida",
+      "note": "Nota",
+      "meeting": "Reunião",
+      "callback": "Retorno",
+      "outcomes": {
+        "meeting_booked": "Reunião marcada",
+        "sale": "Venda",
+        "interested": "Interessado",
+        "follow_up": "Seguimento",
+        "callback_scheduled": "Retorno agendado",
+        "not_interested": "Não interessado",
+        "no_answer": "Sem resposta",
+        "voicemail": "Correio de voz",
+        "wrong_number": "Número errado",
+        "gatekeeper": "Filtro / receção"
+      },
+      "statuses": {
+        "scheduled": "Agendada",
+        "completed": "Concluída",
+        "cancelled": "Cancelada",
+        "missed": "Perdida",
+        "pending": "Pendente",
+        "confirmed": "Confirmada"
+      }
+    }
+  },
+  "assignment": {
+    "assign": "Atribuir",
+    "assignTo": "Atribuir a",
+    "unassigned": "Não atribuído",
+    "memberFallback": "Membro"
   },
   "events": {
     "missedCall": "Chamada perdida",

--- a/packages/database/src/database/repositories/inbox-thread.repository.ts
+++ b/packages/database/src/database/repositories/inbox-thread.repository.ts
@@ -154,6 +154,65 @@ export class InboxThreadRepository {
     };
   }
 
+  /**
+   * Per-filter thread counts for the inbox filter pills. Mirrors the filter
+   * definitions on the frontend (THREAD_FILTER_OPTIONS) so the badges match
+   * what each tab will actually show.
+   */
+  async countsByFilter(ctx: OwnershipContext): Promise<{
+    all: number;
+    unread: number;
+    missed: number;
+    voicemails: number;
+    sms: number;
+  }> {
+    const ownership = buildOwnershipFilter(ctx);
+    const [all, unread, missed, voicemails, sms] = await Promise.all([
+      this.prisma.inboxThread.count({
+        where: {
+          ...ownership,
+          status: {
+            in: [InboxThreadStatus.open, InboxThreadStatus.pending],
+          },
+        },
+      }),
+      this.prisma.inboxThread.count({
+        where: { ...ownership, unreadCount: { gt: 0 } },
+      }),
+      this.prisma.inboxThread.count({
+        where: { ...ownership, lastEventKind: InboxEventKind.missed_call },
+      }),
+      this.prisma.inboxThread.count({
+        where: {
+          ...ownership,
+          lastEventKind: InboxEventKind.voicemail_received,
+        },
+      }),
+      this.prisma.inboxThread.count({
+        where: {
+          ...ownership,
+          lastEventKind: {
+            in: [
+              InboxEventKind.sms_received,
+              InboxEventKind.sms_sent,
+              InboxEventKind.mms_received,
+              InboxEventKind.mms_sent,
+            ],
+          },
+        },
+      }),
+    ]);
+    return { all, unread, missed, voicemails, sms };
+  }
+
+  /** Number of threads with at least one unread event (drives the nav badge). */
+  async countUnread(ctx: OwnershipContext): Promise<number> {
+    const ownership = buildOwnershipFilter(ctx);
+    return this.prisma.inboxThread.count({
+      where: { ...ownership, unreadCount: { gt: 0 } },
+    });
+  }
+
   async update(
     id: string,
     data: Prisma.InboxThreadUpdateInput,

--- a/packages/platform/src/telephony/interfaces/telephony.numbers.service.ts
+++ b/packages/platform/src/telephony/interfaces/telephony.numbers.service.ts
@@ -23,6 +23,16 @@ export interface TelephonyNumbersService {
     connectionId?: string,
   ): Promise<AssignedNumber>;
   /**
+   * Links a phone number to a messaging profile on the provider so it can send
+   * and receive SMS/MMS. Required for any number with messaging enabled —
+   * without it the provider will not route messages for the number. Returns the
+   * messaging profile id the number ended up attached to (or null).
+   */
+  setMessagingProfile(
+    phoneNumber: string,
+    messagingProfileId: string,
+  ): Promise<string | null>;
+  /**
    * Lists the regulatory requirements (documents / fields) that must be
    * fulfilled to order a number for a given country + number type, so the UI
    * can tell the user what they'll need to provide.

--- a/packages/platform/src/telephony/telephony.service.ts
+++ b/packages/platform/src/telephony/telephony.service.ts
@@ -88,6 +88,16 @@ export class TelephonyService implements TelephonyServiceInterface {
     );
   }
 
+  setMessagingProfile(
+    phoneNumber: string,
+    messagingProfileId: string,
+  ): Promise<string | null> {
+    return this.getServiceProvider().setMessagingProfile(
+      phoneNumber,
+      messagingProfileId,
+    );
+  }
+
   getRegulatoryRequirements(
     query: RegulatoryRequirementsQuery,
   ): Promise<RegulatoryRequirementsResult> {

--- a/packages/platform/src/telephony/telnyx/telnyx.service.ts
+++ b/packages/platform/src/telephony/telnyx/telnyx.service.ts
@@ -631,6 +631,27 @@ export class TelnyxService implements TelephonyService {
     };
   }
 
+  /**
+   * Attaches the number to a messaging profile (PATCH /phone_numbers/{id} with
+   * `messaging_profile_id`). Telnyx will not route SMS/MMS for a number that is
+   * not linked to a messaging profile, so this must run for every messaging
+   * enabled number at provision time. Returns the messaging profile id Telnyx
+   * reports the number ended up attached to.
+   */
+  async setMessagingProfile(
+    phoneNumber: string,
+    messagingProfileId: string,
+  ): Promise<string | null> {
+    const encoded = encodeURIComponent(phoneNumber);
+    const { data } = await this.telnyxClient.patch(
+      `/phone_numbers/${encoded}`,
+      {
+        messaging_profile_id: messagingProfileId,
+      },
+    );
+    return data?.messaging_profile_id ?? messagingProfileId;
+  }
+
   async getRates(): Promise<TelephonyCountryRate[]> {
     throw new Error("Not implemented");
   }

--- a/packages/services/src/services/inbox/inbox.timeline.service.ts
+++ b/packages/services/src/services/inbox/inbox.timeline.service.ts
@@ -9,9 +9,12 @@ import {
   InboxEventRepository,
   ContactRepository,
   NumberPurchasedRepository,
+  CallbackTaskRepository,
   Call,
   Recording,
   Contact,
+  ContactNote,
+  Meeting,
   InboxThread,
   InboxEvent,
   InboxEventDirection,
@@ -86,6 +89,7 @@ export class InboxTimelineService {
     private readonly eventRepo: InboxEventRepository,
     private readonly contactRepo: ContactRepository,
     private readonly numberRepo: NumberPurchasedRepository,
+    private readonly callbackRepo: CallbackTaskRepository,
   ) {}
 
   /**
@@ -254,7 +258,8 @@ export class InboxTimelineService {
         ? { lastInboundAt: occurredAt }
         : {}),
       ...(params.direction === InboxEventDirection.outbound
-        ? { lastOutboundAt: occurredAt }
+        ? // Replying marks the conversation as seen.
+          { lastOutboundAt: occurredAt, unreadCount: 0 }
         : {}),
       ...(params.incrementUnread &&
       params.direction === InboxEventDirection.inbound
@@ -608,6 +613,108 @@ export class InboxTimelineService {
   ) {
     await this.ensureAccess(ctx, threadId);
     return this.threadRepo.update(threadId, { assignedToId: assigneeId });
+  }
+
+  /**
+   * Links (or unlinks, when contactId is null) a thread to a contact. Used by
+   * the inbox "Link contact" action when a conversation came from an unknown
+   * number. Verifies the contact belongs to the same owner before linking.
+   */
+  async linkContact(
+    ctx: OwnershipContext,
+    threadId: string,
+    contactId: string | null,
+  ): Promise<InboxThread> {
+    await this.ensureAccess(ctx, threadId);
+    if (contactId) {
+      const contact = await this.contactRepo.findById(contactId);
+      if (!contact) {
+        throw new NotFoundException("Contact not found");
+      }
+      const sameOwner = ctx.organizationId
+        ? contact.organizationId === ctx.organizationId
+        : contact.userId === ctx.userId;
+      if (!sameOwner) {
+        throw new ForbiddenException("Access denied");
+      }
+    }
+    return this.threadRepo.update(threadId, {
+      contact: contactId
+        ? { connect: { id: contactId } }
+        : { disconnect: true },
+    });
+  }
+
+  /**
+   * Full contact context for the thread: every call (with its outcome + note),
+   * contact notes, meetings (with notes) and callbacks (with notes). Powers the
+   * inbox context pane so the rep sees the complete history of the contact.
+   * Returns empty collections when the thread isn't linked to a contact yet.
+   */
+  async getThreadActivity(ctx: OwnershipContext, threadId: string) {
+    const thread = await this.ensureAccess(ctx, threadId);
+    if (!thread.contactId) {
+      return {
+        contactId: null,
+        calls: [],
+        notes: [],
+        meetings: [],
+        callbacks: [],
+      };
+    }
+
+    const contact = (await this.contactRepo.findById(thread.contactId)) as
+      | (Contact & {
+          calls?: Call[];
+          notes?: ContactNote[];
+          meetings?: Meeting[];
+        })
+      | null;
+    const callbacks = await this.callbackRepo.findByContact(thread.contactId);
+
+    return {
+      contactId: thread.contactId,
+      calls: (contact?.calls ?? []).map((c) => ({
+        id: c.id,
+        direction: c.direction,
+        status: c.status,
+        outcome: c.outcome,
+        outcomeNote: c.outcomeNote,
+        durationSeconds: c.durationSeconds,
+        createdAt: c.createdAt,
+      })),
+      notes: (contact?.notes ?? []).map((n) => ({
+        id: n.id,
+        content: n.content,
+        userId: n.userId,
+        createdAt: n.createdAt,
+      })),
+      meetings: (contact?.meetings ?? []).map((m) => ({
+        id: m.id,
+        title: m.title,
+        scheduledAt: m.scheduledAt,
+        notes: m.notes,
+        status: m.status,
+      })),
+      callbacks: callbacks.map((cb) => ({
+        id: cb.id,
+        scheduledAt: cb.scheduledAt,
+        note: cb.note,
+        status: cb.status,
+        completedAt: cb.completedAt,
+      })),
+    };
+  }
+
+  /** Per-filter counts for the inbox filter pills. */
+  async counts(ctx: OwnershipContext) {
+    return this.threadRepo.countsByFilter(ctx);
+  }
+
+  /** Total unread threads — drives the nav badge. */
+  async unreadCount(ctx: OwnershipContext): Promise<{ count: number }> {
+    const count = await this.threadRepo.countUnread(ctx);
+    return { count };
   }
 
   // Public helpers used by the call hooks (called from CallService).

--- a/packages/services/src/services/inbox/message.service.ts
+++ b/packages/services/src/services/inbox/message.service.ts
@@ -86,6 +86,36 @@ export class MessageService {
     );
   }
 
+  /**
+   * Stores an outbound MMS attachment in our own object storage and returns a
+   * publicly reachable URL. Telnyx fetches media by URL when sending an MMS, so
+   * the file must live somewhere it can reach (R2/S3 in production).
+   */
+  async uploadOutboundMedia(input: {
+    buffer: Buffer;
+    contentType: string;
+    filename?: string;
+  }): Promise<{ url: string }> {
+    const storage = UploadFactory.createStorage();
+    const extFromName = input.filename?.includes(".")
+      ? input.filename.split(".").pop()
+      : undefined;
+    const extFromType = input.contentType.includes("/")
+      ? input.contentType.split("/")[1]?.split("+")[0]
+      : undefined;
+    const ext = (extFromName || extFromType || "bin")
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "");
+    const key = `inbox-mms/${Date.now()}-${Math.random().toString(36).slice(2, 10)}.${ext}`;
+    const url = await storage.uploadBuffer(
+      key,
+      input.buffer,
+      input.contentType,
+      ext,
+    );
+    return { url };
+  }
+
   // ─────────────────────────────────────────────────────────
   // Outbound SMS
   // ─────────────────────────────────────────────────────────

--- a/packages/services/src/services/number.purchased.service.ts
+++ b/packages/services/src/services/number.purchased.service.ts
@@ -185,6 +185,48 @@ export class NumberPurchasedService {
     return updated;
   }
 
+  /**
+   * Resolves the messaging profile a number should be attached to and, when
+   * needed, links it on the provider. Telnyx will not route SMS/MMS for a
+   * number that is not attached to a messaging profile, so any number with
+   * messaging enabled must be linked at provision time.
+   *
+   * - If the provider already reports a profile (number is linked), reuse it.
+   * - Otherwise, attach the configured `TELNYX_MESSAGING_PROFILE_ID`.
+   * - Best-effort: a provider failure is logged and returns null so the
+   *   purchase/provision is not blocked (messagingStatus reflects "pending").
+   */
+  private async applyMessagingProfile(
+    phoneNumber: string,
+    messagingEnabled: boolean,
+    detectedProfileId?: string | null,
+  ): Promise<string | null> {
+    if (!messagingEnabled) return detectedProfileId ?? null;
+    if (detectedProfileId) return detectedProfileId;
+
+    const configured = apiConfiguration.TELNYX_MESSAGING_PROFILE_ID;
+    if (!configured) {
+      this.logger.warn(
+        `Number ${phoneNumber} has messaging enabled but TELNYX_MESSAGING_PROFILE_ID is not set; ` +
+          `messages will not route until a messaging profile is assigned.`,
+      );
+      return null;
+    }
+
+    try {
+      const assigned = await this.telephonyService.setMessagingProfile(
+        phoneNumber,
+        configured,
+      );
+      return assigned ?? configured;
+    } catch (err) {
+      this.logger.warn(
+        `Failed to attach messaging profile to ${phoneNumber}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
   async buyNumber(
     ctx: OwnershipContext,
     numberId: string,
@@ -249,10 +291,11 @@ export class NumberPurchasedService {
     const internationalSmsEnabled = !!providerFeatures.internationalSms;
     const emergencyEnabled = !!providerFeatures.emergency;
     const messagingEnabled = smsEnabled || mmsEnabled;
-    const profileId =
-      providerFeatures.raw?.messaging_profile_id ??
-      apiConfiguration.TELNYX_MESSAGING_PROFILE_ID ??
-      null;
+    const profileId = await this.applyMessagingProfile(
+      phoneNumber.phoneNumber,
+      messagingEnabled,
+      providerFeatures.raw?.messaging_profile_id ?? null,
+    );
 
     const created = await this.numberPurchasedRepository.create(ctx, {
       userNumbers: {
@@ -303,7 +346,11 @@ export class NumberPurchasedService {
       emergencyEnabled,
       messagingEnabled,
       providerMessagingProfileId: profileId,
-      messagingStatus: messagingEnabled ? "ready" : "unavailable",
+      messagingStatus: messagingEnabled
+        ? profileId
+          ? "ready"
+          : "pending"
+        : "unavailable",
     });
 
     return created;
@@ -823,10 +870,11 @@ export class NumberPurchasedService {
     const smsEnabled = !!features.sms;
     const mmsEnabled = !!features.mms;
     const messagingEnabled = smsEnabled || mmsEnabled;
-    const profileId =
-      features.raw?.messaging_profile_id ??
-      apiConfiguration.TELNYX_MESSAGING_PROFILE_ID ??
-      null;
+    const profileId = await this.applyMessagingProfile(
+      number.phoneNumber,
+      messagingEnabled,
+      features.raw?.messaging_profile_id ?? null,
+    );
 
     // Match buyNumber: become the owner's primary number only if they have none.
     const ctx: OwnershipContext = {
@@ -852,7 +900,11 @@ export class NumberPurchasedService {
       emergencyEnabled: !!features.emergency,
       messagingEnabled,
       providerMessagingProfileId: profileId,
-      messagingStatus: messagingEnabled ? "ready" : "unavailable",
+      messagingStatus: messagingEnabled
+        ? profileId
+          ? "ready"
+          : "pending"
+        : "unavailable",
       features: {
         sms: smsEnabled,
         mms: mmsEnabled,


### PR DESCRIPTION
- Added new filter options "Assigned to me" and "Unassigned" in English, Spanish, French, Italian, Dutch, and Portuguese.
- Included additional messages for new conversations, context pane actions, and assignment features across all languages.
- Enhanced existing messages with new placeholders and loading indicators.

feat(database): implement inbox thread filter counts

- Added `countsByFilter` method to `InboxThreadRepository` to provide per-filter thread counts for the inbox.
- Implemented `countUnread` method to count unread threads.

feat(telephony): add messaging profile linking functionality

- Introduced `setMessagingProfile` method in `TelephonyNumbersService` and implemented it in `TelephonyService` and `TelnyxService`.
- Ensured SMS/MMS routing by linking phone numbers to messaging profiles during provisioning.

feat(inbox): enhance inbox timeline service with contact linking and activity retrieval

- Added `linkContact` method to link or unlink threads to contacts.
- Implemented `getThreadActivity` to retrieve full contact context for threads, including calls, notes, meetings, and callbacks.
- Added methods for counting threads by filter and unread counts.

feat(message): implement outbound MMS media upload

- Created `uploadOutboundMedia` method in `MessageService` to store and return publicly reachable URLs for outbound MMS attachments.

feat(number): manage messaging profiles for purchased numbers

- Implemented `applyMessagingProfile` method in `NumberPurchasedService` to resolve and link messaging profiles for numbers.
- Updated number purchase logic to ensure messaging profiles are applied correctly.