### PR TITLE
feat: add Dialer SDK page and components

### DIFF
--- a/apps/frontend/public/llms-full.txt
+++ b/apps/frontend/public/llms-full.txt
@@ -89,6 +89,24 @@ Ringee exposes its outbound workflow through an MCP server, so AI assistants and
 
 ---
 
+## Dialer SDK
+
+Page: https://www.ringee.io/dialer-sdk — Package: https://www.npmjs.com/package/@ringee/dialer-sdk
+
+`@ringee/dialer-sdk` is a browser SDK that embeds Ringee outbound calling directly into another web application — a CRM, a back office, or an internal tool. It ships three integration modes: Floating (a launcher in the page corner that opens a full dialer panel), Bar (the same dialer rendered inline inside an element you own), and Headless (no UI at all — authentication, calls, devices, states, and typed events, with every screen built by the host). It is open source under the MIT license and published on npm; install with `npm install @ringee/dialer-sdk` or load the global bundle from a CDN with a single script tag.
+
+The SDK has no React dependency and renders its bundled UIs inside a Shadow DOM, so it works with plain JavaScript, TypeScript, React, Vue, Angular, Svelte, or a server-rendered page; in React or Next.js it is mounted from a `useEffect` with a dynamic import so it never runs during SSR. English and Spanish ship in the box, individual labels can be overridden, and colors, radius, shadow, and font are theme tokens that can be set at mount time, changed at runtime, or driven from CSS custom properties such as `--ringee-primary`.
+
+The SDK encapsulates WebRTC and Telnyx entirely: the host application never handles SIP passwords, provider tokens, or provider-specific objects. It also owns microphone capture, remote audio, device selection, reconnects, the call state machine (dialing, ringing, active, held, reconnecting, ending, ended), and a browser lock that prevents a second tab from dialing over a live call.
+
+Security: a `pk_live_...` publishable key is designed to be visible in the browser. It is signed and scoped to an exact list of allowed origins (no wildcards, paths, or implicit subdomains), and it does not authenticate an agent on its own — agents are verified with a one-time code sent to their email, and Ringee validates workspace membership, permissions, caller ID, credit, and DNC on the server before a call connects. The private `cik_live_...` Custom Integrations API key and webhook signing secret are different credentials and must never be shipped to a browser. Publishable keys are generated inside a Custom Integration in the Ringee dashboard (Integrations → Custom Integrations → Dialer SDK · Publishable keys).
+
+Calls placed through the SDK are normal Ringee calls: they appear in call history, use the same pay-as-you-go calling credits (from $0.020/min, with no separate SDK fee), follow the workspace's recording and transcription settings, respect caller ID rotation, and trigger the same Custom Integration webhooks. Passing `externalContactId` lets Ringee resolve a CRM id to the right contact. A self-hosted Ringee deployment is supported by passing the API base origin as the `apiUrl` option. Requirements: a modern browser with WebRTC and `navigator.mediaDevices`, a secure context (HTTPS in production or localhost in development), and E.164 destination numbers.
+
+This release does not include a public Ringee URL that can be dropped into an `<iframe src>`, an automatic `data-ringee-key` loader, or a separate React wrapper package.
+
+---
+
 ## Integrations
 
 - Lead sources: Apollo (pull and enrich leads), Prospeo (enrich contacts).
@@ -143,6 +161,7 @@ Ringee runs wherever you work, all signed in to the same account so contacts, ca
 - iPhone app: the full Ringee dialer on iOS — call, log outcomes, and book follow-ups on the go. Apple App Store: https://apps.apple.com/app/ringee-app/id6773448247
 - Android app: the full Ringee dialer on Android. Google Play: https://play.google.com/store/apps/details?id=io.ringee.twa
 - Web app: no install required — open Ringee in any modern browser at https://www.ringee.io and start calling.
+- Your own app: embed the Ringee dialer in a CRM, back office, or internal tool with the `@ringee/dialer-sdk` browser package — floating, inline, or headless. Details: https://www.ringee.io/dialer-sdk
 - AI tools: drive outbound from Claude and ChatGPT through Ringee's MCP server. Agents prospect leads, build call lists, start calls, and log outcomes; a human always takes the call. Demo (Ringee inside Claude): https://www.youtube.com/watch?v=5yjDOIjfBPM
 
 The apps and the extension are free to install; you only pay for your Ringee plan and pay-as-you-go calling credits.
@@ -163,6 +182,8 @@ The apps and the extension are free to install; you only pay for your Ringee pla
 - Developer documentation: https://docs.ringee.io
 - Blog: https://blog.ringee.io
 - CLI on npm: https://www.npmjs.com/package/ringee
+- Dialer SDK: https://www.ringee.io/dialer-sdk
+- Dialer SDK on npm: https://www.npmjs.com/package/@ringee/dialer-sdk
 - Apps & extensions: https://www.ringee.io/apps
 - Chrome extension: https://chromewebstore.google.com/detail/ringee-%E2%80%94-low-cost-outboun/hmgbaielacnpemblmoahpfdlnfdlmeel
 - iOS app: https://apps.apple.com/app/ringee-app/id6773448247

--- a/apps/frontend/public/llms.txt
+++ b/apps/frontend/public/llms.txt
@@ -30,6 +30,7 @@
 - [Real-time call transcription](https://www.ringee.io/features/call-transcription): Accurate, searchable transcripts, with or without recording.
 - [CRM sync](https://www.ringee.io/features/crm-sync): Keep your CRM in step with your calling.
 - [AI call automation](https://www.ringee.io/features/ai-call-automation): Let agents prospect, build lists, log outcomes, and book follow-ups.
+- [Dialer SDK](https://www.ringee.io/dialer-sdk): Embed the Ringee dialer in your own CRM or web app with the `@ringee/dialer-sdk` browser package.
 
 ## Integrations
 
@@ -74,6 +75,7 @@
 - [Features](https://www.ringee.io/features): Full feature catalog.
 - [Integrations](https://www.ringee.io/integrations): Lead sources, CRMs, calendar, and AI tools.
 - [Apps & extensions](https://www.ringee.io/apps): Use Ringee from the Chrome extension, iPhone, Android, the web, and AI tools.
+- [Dialer SDK](https://www.ringee.io/dialer-sdk): Embed Ringee calling in your own app — floating dialer, inline bar, or headless engine.
 - [Use cases](https://www.ringee.io/use-cases): Who Ringee is built for.
 - [Security](https://www.ringee.io/security): Data protection and an honest certification stance.
 - [Open source](https://www.ringee.io/open-source): MIT-licensed, auditable, self-hostable.
@@ -86,6 +88,7 @@
 - [Developer documentation](https://docs.ringee.io): Guides and API/MCP reference.
 - [Blog](https://blog.ringee.io): Outbound and product articles.
 - [Command-line interface](https://www.npmjs.com/package/ringee): The `ringee` CLI on npm.
+- [Dialer SDK on npm](https://www.npmjs.com/package/@ringee/dialer-sdk): The `@ringee/dialer-sdk` browser package for embedding the dialer.
 - [Chrome extension](https://chromewebstore.google.com/detail/ringee-%E2%80%94-low-cost-outboun/hmgbaielacnpemblmoahpfdlnfdlmeel): One-click outbound calling from your browser.
 - [iOS app](https://apps.apple.com/app/ringee-app/id6773448247): Ringee on the Apple App Store.
 - [Android app](https://play.google.com/store/apps/details?id=io.ringee.twa): Ringee on Google Play.

--- a/apps/frontend/src/app/(marketing)/dialer-sdk/page.tsx
+++ b/apps/frontend/src/app/(marketing)/dialer-sdk/page.tsx
@@ -1,0 +1,868 @@
+import type { Metadata } from 'next';
+import {
+  Boxes,
+  Braces,
+  Code2,
+  Fingerprint,
+  Gauge,
+  Globe2,
+  KeyRound,
+  Languages,
+  MicVocal,
+  PanelBottom,
+  Paintbrush,
+  PhoneCall,
+  ShieldCheck,
+  Sparkles,
+  SquareDashedBottomCode,
+  Wallet
+} from 'lucide-react';
+
+import { buildMetadata } from '@/features/marketing/seo';
+import { DetailLayout } from '@/features/marketing/components/detail-layout';
+import { CtaSection } from '@/features/marketing/components/cta-section';
+import { FaqSection } from '@/features/marketing/components/faq';
+import { CodeBlock } from '@/features/marketing/components/code-block';
+import {
+  SdkLiveDemo,
+  SdkStateGallery
+} from '@/features/marketing/components/sdk-demo';
+import {
+  JsonLd,
+  softwareSourceCodeJsonLd
+} from '@/features/marketing/components/json-ld';
+import {
+  ButtonLink,
+  Card,
+  CheckList,
+  Container,
+  Eyebrow,
+  Section,
+  SectionHeading
+} from '@/features/marketing/components/primitives';
+import {
+  DOCS_URL,
+  GITHUB_URL,
+  SDK_NPM_URL,
+  SIGN_UP_URL,
+  SITE_URL
+} from '@/features/marketing/site';
+
+export const metadata: Metadata = buildMetadata({
+  title: 'Dialer SDK — Embed Ringee Calling in Your CRM or App | Ringee',
+  description:
+    'Add outbound calling to any web app with @ringee/dialer-sdk. A floating dialer, an inline bar, or a headless engine — no React dependency, no Telnyx or WebRTC credentials to manage. Open source and MIT-licensed.',
+  path: '/dialer-sdk'
+});
+
+const INSTALL_SNIPPET = `npm install @ringee/dialer-sdk`;
+
+const CDN_SNIPPET = `<script src="https://unpkg.com/@ringee/dialer-sdk"></script>
+<script>
+  const ringee = Ringee.mount({ key: "pk_live_xxxxx" });
+
+  // Call whoever the CRM is showing right now
+  ringee.startCall({
+    to: "+13055550142",
+    name: "Morgan Reed",
+    externalContactId: "crm-contact-294"
+  });
+</script>`;
+
+const FLOATING_SNIPPET = `import { createFloating } from "@ringee/dialer-sdk/ui";
+
+const ringee = createFloating({
+  key: "pk_live_xxxxx",
+  agentEmail: currentUser.email,
+  locale: "en",
+  side: "right",
+  allowHold: true
+});
+
+ringee.open();`;
+
+const BAR_SNIPPET = `import { createBar } from "@ringee/dialer-sdk/ui";
+
+const bar = createBar({
+  key: "pk_live_xxxxx",
+  container: "#ringee-bar"
+});
+
+bar.setContact({
+  name: "Avery Stone",
+  number: "+14155550142",
+  externalContactId: "contact-802"
+});`;
+
+const HEADLESS_SNIPPET = `import { RingeeDialer } from "@ringee/dialer-sdk";
+
+const dialer = new RingeeDialer({ key: "pk_live_xxxxx" });
+
+// Subscribe before initialize() so no state change is missed
+dialer.on("authRequired", () => showEmailForm());
+dialer.on("ready", () => enableDialButton());
+dialer.on("answered", ({ call }) => startTimer(call.answeredAt));
+dialer.on("ended", ({ call }) => showSummary(call));
+dialer.on("failed", ({ error }) => showError(error.code));
+
+await dialer.initialize();
+await dialer.call({ to: "+13055550198" });`;
+
+const CONTACT_SNIPPET = `ringee.setContact({
+  name: "Morgan Reed",
+  number: "+13055550142",
+  imageUrl: "https://crm.example.com/avatars/294.png",
+  externalContactId: "crm-contact-294"
+});
+
+// Or just drop a number into the field
+ringee.prefill("+13055550142");`;
+
+const THEME_SNIPPET = `const ringee = createFloating({
+  key: "pk_live_xxxxx",
+  locale: "en", // "es" also ships
+  theme: {
+    primary: "#4f46e5",
+    primaryHover: "#4338ca",
+    radius: "14px",
+    fontFamily: "Inter, sans-serif",
+    colorScheme: "auto"
+  },
+  strings: {
+    callButton: "Call prospect"
+  }
+});
+
+// Follow your app's theme switcher at runtime
+ringee.setTheme({ colorScheme: "dark" });`;
+
+const REACT_SNIPPET = `"use client";
+
+import { useEffect, useRef } from "react";
+import type { FloatingController } from "@ringee/dialer-sdk/ui";
+
+export function RingeeDialer({ email }: { email: string }) {
+  const controller = useRef<FloatingController | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // Dynamic import keeps the browser-only package out of SSR
+    void import("@ringee/dialer-sdk/ui").then(({ createFloating }) => {
+      if (cancelled) return;
+      controller.current = createFloating({
+        key: process.env.NEXT_PUBLIC_RINGEE_KEY!,
+        agentEmail: email
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      const current = controller.current;
+      controller.current = null;
+      current?.destroy();
+      void current?.dialer.destroy();
+    };
+  }, [email]);
+
+  return null;
+}`;
+
+const CSP_SNIPPET = `script-src 'self' https://unpkg.com;
+connect-src 'self'
+  https://api.ringee.io
+  wss://rtc.telnyx.com;
+media-src 'self' blob:;`;
+
+const SELF_HOST_SNIPPET = `createFloating({
+  key: "pk_live_xxxxx",
+  apiUrl: "https://api.acme.com"
+});`;
+
+type Mode = {
+  name: string;
+  icon: typeof Code2;
+  best: string;
+  description: string;
+  points: string[];
+};
+
+const MODES: Mode[] = [
+  {
+    name: 'Floating',
+    icon: PhoneCall,
+    best: 'Fastest path to calling',
+    description:
+      'A launcher docks in the corner of your app and opens a full dialer panel: agent sign-in, caller ID, number entry, keypad, and in-call controls.',
+    points: [
+      'One call to createFloating() — or a single CDN script tag',
+      'open(), close(), toggle(), startCall() from your own buttons',
+      'Left or right side, opened by default or remembered per tab'
+    ]
+  },
+  {
+    name: 'Inline bar',
+    icon: PanelBottom,
+    best: 'Toolbars and record pages',
+    description:
+      'The same dialer rendered inside an element you already own. It adapts to the available width and never floats over your layout.',
+    points: [
+      'Mount into an element, an id, or any CSS selector',
+      'Sits inside a sidebar, a toolbar, or a contact record',
+      'Same contact, theming, and event API as Floating'
+    ]
+  },
+  {
+    name: 'Headless',
+    icon: Braces,
+    best: 'Fully custom interfaces',
+    description:
+      'No UI at all. You get authentication, calls, devices, states, and typed events, and you build every screen yourself.',
+    points: [
+      'Typed state machines for auth and call lifecycle',
+      'Events for dialing, ringing, answered, held, ended, failed',
+      'RingeeError with a code and a retryable flag on every rejection'
+    ]
+  }
+];
+
+const HANDLED = [
+  {
+    icon: MicVocal,
+    title: 'WebRTC and telephony',
+    body: 'Microphone capture, remote audio, device selection, reconnects, and the Telnyx leg are all inside the SDK. No SIP passwords or provider JWTs ever reach your frontend.'
+  },
+  {
+    icon: Fingerprint,
+    title: 'Agent identity',
+    body: 'Agents prove who they are with a one-time code sent to their email. Your publishable key identifies the installation, never a person.'
+  },
+  {
+    icon: Boxes,
+    title: 'Style isolation',
+    body: 'The bundled UIs render inside a Shadow DOM, so your CSS cannot leak into the dialer and the dialer cannot leak into your app.'
+  },
+  {
+    icon: Languages,
+    title: 'Copy and locales',
+    body: 'English and Spanish ship in the box, every label can be overridden, and backend error codes are turned into plain, actionable sentences.'
+  },
+  {
+    icon: Gauge,
+    title: 'Call state',
+    body: 'Dialing, ringing, active, held, reconnecting, ending, ended — mapped from provider events into one stable state machine you can render.'
+  },
+  {
+    icon: Globe2,
+    title: 'One call at a time',
+    body: 'A browser lock stops a second tab from dialing over a live call, and the server enforces the same rule again.'
+  }
+];
+
+const PLATFORM_POINTS = [
+  'Calls land in your Ringee call history like any other call',
+  'Your workspace’s recording and transcription settings apply unchanged',
+  'Caller ID rotation picks a local-presence number when it’s enabled',
+  'Credit, DNC, and permission checks run server-side before the call connects',
+  'Custom Integration webhooks fire, so your CRM stays in sync',
+  'Pass externalContactId and Ringee resolves it to the right contact'
+];
+
+const SECURITY_POINTS = [
+  'The pk_live_… key is signed and scoped to the exact origins you list',
+  'Origins match exactly — no wildcards, no paths, no implicit subdomains',
+  'Every agent is verified by email OTP before a call is authorized',
+  'Workspace membership, caller ID, credit, DNC, and blocks are checked server-side',
+  'Sessions live in sessionStorage; WebRTC credentials stay in memory only',
+  'Your cik_live_… API key and webhook secret never belong in frontend code'
+];
+
+const NOT_INCLUDED = [
+  'There’s no public Ringee URL to drop straight into an iframe src',
+  'There’s no automatic data-ringee-key loader — you call mount() yourself',
+  'There’s no separate React wrapper package; mount from useEffect as shown above'
+];
+
+const SDK_FAQS = [
+  {
+    question: 'What is the Ringee Dialer SDK?',
+    answer:
+      '@ringee/dialer-sdk is a browser SDK that embeds Ringee outbound calling into any web application — a CRM, a back office, or an internal tool. It ships three integration modes: a floating dialer, an inline bar, and a headless engine with no UI. It is open source under the MIT license and published on npm.'
+  },
+  {
+    question: 'Do I need React to use it?',
+    answer:
+      'No. The SDK has no React dependency and renders its UI inside a Shadow DOM, so it works with plain JavaScript, TypeScript, React, Vue, Angular, Svelte, or a server-rendered page with a single script tag. In React or Next.js you mount it from a useEffect and destroy it on unmount.'
+  },
+  {
+    question: 'Is the publishable key safe to put in frontend code?',
+    answer:
+      'Yes. A pk_live_… publishable key is designed to be visible in the browser. It is signed, scoped to an exact list of allowed origins, and it does not authenticate an agent on its own — Ringee still verifies the agent with an email one-time code and validates permissions, caller ID, credit, and DNC on the server. The private cik_live_… API key and webhook secret are different credentials and must never be shipped to a browser.'
+  },
+  {
+    question: 'Do I have to manage Telnyx or WebRTC credentials?',
+    answer:
+      'No. The SDK encapsulates WebRTC and Telnyx entirely. Your application never sees SIP passwords, provider tokens, or provider-specific objects — it only calls Ringee methods and reacts to Ringee events.'
+  },
+  {
+    question: 'How do agents sign in?',
+    answer:
+      'The agent enters their email address and Ringee sends a one-time code. Once verified, Ringee checks that the agent belongs to the integration’s workspace and is allowed to call, then issues a session and temporary WebRTC credentials. The session is stored in sessionStorage for that tab, so a reload does not force a new code.'
+  },
+  {
+    question: 'Do calls placed through the SDK show up in Ringee?',
+    answer:
+      'Yes. An SDK call is a normal Ringee call. It appears in call history, uses the same pay-as-you-go calling credits, follows your workspace’s recording and transcription settings, respects caller ID rotation, and triggers the same Custom Integration webhooks — so your CRM stays in sync without extra work.'
+  },
+  {
+    question: 'How much does the Dialer SDK cost?',
+    answer:
+      'The SDK itself is free and MIT-licensed — there is no separate SDK fee. Calls placed through it consume the same pay-as-you-go calling credits as any other Ringee call, from $0.020/min depending on the destination.'
+  },
+  {
+    question: 'Can I use it with a self-hosted Ringee?',
+    answer:
+      'Yes. Pass your API base origin as the apiUrl option (without the /api suffix) and the SDK talks to your deployment instead of api.ringee.io. The same option points the SDK at a local backend during development.'
+  },
+  {
+    question: 'What do browsers need for it to work?',
+    answer:
+      'A modern browser with WebRTC and navigator.mediaDevices, plus a secure context — HTTPS in production, or localhost while developing. Microphone permission is requested when the first call starts. If the SDK runs inside an iframe, the host page must grant microphone access with allow="microphone".'
+  }
+];
+
+export default function DialerSdkPage() {
+  return (
+    <DetailLayout
+      items={[
+        { name: 'Home', href: '/' },
+        { name: 'Dialer SDK', href: '/dialer-sdk' }
+      ]}
+      cta={
+        <CtaSection
+          title='Put a dialer in your product this afternoon'
+          description='Create a free Ringee account, generate a publishable key for your origin, and drop in the SDK. Calling credits are pay-as-you-go — the SDK is free.'
+          primaryLabel='Start calling for free'
+          secondaryHref={SDK_NPM_URL}
+          secondaryLabel='View on npm'
+        />
+      }
+    >
+      <Section className='pt-8 pb-4'>
+        <Container className='max-w-3xl'>
+          <Eyebrow>Dialer SDK</Eyebrow>
+          <h1 className='mt-4 text-4xl font-bold tracking-tight text-balance sm:text-5xl'>
+            Embed Ringee calling in your own app
+          </h1>
+          <p className='text-muted-foreground mt-6 text-lg text-pretty'>
+            <code className='font-mono text-base'>@ringee/dialer-sdk</code>{' '}
+            drops a working dialer into your CRM, back office, or internal tool
+            — floating, inline, or fully headless. No React dependency, no
+            Telnyx credentials in your frontend, no WebRTC plumbing to maintain.
+          </p>
+          <div className='mt-8'>
+            <CodeBlock code={INSTALL_SNIPPET} label='Terminal' />
+          </div>
+          <div className='mt-6 flex flex-col gap-3 sm:flex-row sm:gap-4'>
+            <ButtonLink href={SIGN_UP_URL} withArrow>
+              Get a publishable key
+            </ButtonLink>
+            <ButtonLink
+              href={SDK_NPM_URL}
+              variant='secondary'
+              external
+              withArrow
+            >
+              View on npm
+            </ButtonLink>
+          </div>
+          <p className='text-muted-foreground mt-4 text-sm'>
+            MIT-licensed and open source, like the rest of Ringee.
+          </p>
+        </Container>
+      </Section>
+
+      <Section id='integration-modes' className='pt-8'>
+        <Container>
+          <SectionHeading
+            title='Three ways to embed the dialer'
+            description='Start with Floating for the fastest result, use the Bar when your app already has a place for calling, and go Headless when you want to design every screen yourself.'
+            align='left'
+          />
+          <div className='mt-10 grid gap-5 lg:grid-cols-3'>
+            {MODES.map((mode) => (
+              <Card key={mode.name} className='flex h-full flex-col'>
+                <mode.icon className='text-primary h-7 w-7' />
+                <h3 className='mt-4 text-lg font-semibold'>{mode.name}</h3>
+                <p className='mt-1 text-sm font-medium text-emerald-600 dark:text-emerald-400'>
+                  {mode.best}
+                </p>
+                <p className='text-muted-foreground mt-3 text-sm text-pretty'>
+                  {mode.description}
+                </p>
+                <ul className='mt-4 flex flex-1 flex-col gap-2'>
+                  {mode.points.map((point) => (
+                    <li
+                      key={point}
+                      className='text-muted-foreground flex gap-2 text-sm'
+                    >
+                      <span
+                        className='mt-2 h-1 w-1 shrink-0 rounded-full bg-emerald-500'
+                        aria-hidden
+                      />
+                      {point}
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ))}
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='screens'>
+        <Container>
+          <SectionHeading
+            eyebrow='The real UI'
+            title='Every screen, already built'
+            description='Sign-in, the one-time code, caller ID selection, the keypad, live call controls, the call summary, and readable errors — all shipped and themeable. Everything below is the actual package running on this page, not a screenshot.'
+            align='left'
+          />
+          <SdkLiveDemo className='mt-10' />
+          <SdkStateGallery className='mt-5' />
+          <p className='text-muted-foreground mt-6 text-sm text-pretty'>
+            The demo runs the production components against a simulated dialer,
+            so no call is placed and no data leaves the page. Headless mode
+            gives you the same states with no UI at all.
+          </p>
+        </Container>
+      </Section>
+
+      <Section id='quickstart' className='bg-muted/20'>
+        <Container>
+          <SectionHeading
+            eyebrow='Quickstart'
+            title='A dialer in a few lines'
+            description='One script tag if you have no build step, one import if you do. The UI initializes itself, handles agent sign-in, and is ready to place a call.'
+            align='left'
+          />
+          <div className='mt-10 grid gap-8'>
+            <div className='flex flex-col gap-3'>
+              <h3 className='text-sm font-semibold'>
+                Floating, straight from a CDN
+              </h3>
+              <CodeBlock
+                code={CDN_SNIPPET}
+                label='index.html'
+                language='html'
+              />
+              <p className='text-muted-foreground text-sm'>
+                Pin a version in production so a host deployment never picks up
+                an unexpected release.
+              </p>
+            </div>
+            <div className='flex flex-col gap-3'>
+              <h3 className='text-sm font-semibold'>Floating, from npm</h3>
+              <CodeBlock
+                code={FLOATING_SNIPPET}
+                label='dialer.ts'
+                language='ts'
+              />
+              <p className='text-muted-foreground text-sm'>
+                <code className='font-mono'>agentEmail</code> only prefills the
+                field — Ringee always verifies the agent with a one-time code.
+              </p>
+            </div>
+            <div className='flex flex-col gap-3'>
+              <h3 className='text-sm font-semibold'>
+                Inline bar in a container
+              </h3>
+              <CodeBlock code={BAR_SNIPPET} label='sidebar.ts' language='ts' />
+            </div>
+            <div className='flex flex-col gap-3'>
+              <h3 className='text-sm font-semibold'>Headless engine</h3>
+              <CodeBlock
+                code={HEADLESS_SNIPPET}
+                label='engine.ts'
+                language='ts'
+              />
+            </div>
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='what-you-skip'>
+        <Container>
+          <SectionHeading
+            title='What you don’t have to build'
+            description='Browser calling is mostly edge cases. The SDK owns them so your team can stay on the product.'
+            align='left'
+          />
+          <div className='mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3'>
+            {HANDLED.map((item) => (
+              <Card key={item.title} className='flex h-full flex-col'>
+                <span className='flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'>
+                  <item.icon className='h-5 w-5' />
+                </span>
+                <h3 className='mt-4 font-semibold'>{item.title}</h3>
+                <p className='text-muted-foreground mt-2 text-sm text-pretty'>
+                  {item.body}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='crm-contacts' className='bg-muted/20'>
+        <Container>
+          <div className='grid items-start gap-8'>
+            <div className='max-w-3xl'>
+              <Eyebrow>CRM contacts</Eyebrow>
+              <h2 className='mt-4 text-3xl font-bold tracking-tight text-balance'>
+                The dialer follows the record on screen
+              </h2>
+              <p className='text-muted-foreground mt-5 text-lg text-pretty'>
+                Hand the SDK whichever contact your app is displaying and the
+                panel fills in the name, avatar, and number. Send your own CRM
+                id as{' '}
+                <code className='font-mono text-sm'>externalContactId</code> and
+                Ringee links the call to the matching contact — no id mapping
+                table on your side.
+              </p>
+              <CheckList
+                className='mt-6'
+                items={[
+                  'setContact() attaches name, number, avatar, and ids',
+                  'prefill() drops a number into the field without a contact',
+                  'startCall() dials immediately — even before the session finishes restoring',
+                  'contactId works too when you already know the Ringee UUID'
+                ]}
+              />
+            </div>
+            <CodeBlock
+              code={CONTACT_SNIPPET}
+              label='crm-record.ts'
+              language='ts'
+            />
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='theming'>
+        <Container>
+          <div className='grid items-start gap-8'>
+            <div className='max-w-3xl'>
+              <Eyebrow>Customization</Eyebrow>
+              <h2 className='mt-4 text-3xl font-bold tracking-tight text-balance'>
+                Make it look like your product
+              </h2>
+              <p className='text-muted-foreground mt-5 text-lg text-pretty'>
+                Colors, radius, shadow, and font are theme tokens you can set at
+                mount time, change at runtime, or drive from CSS custom
+                properties such as{' '}
+                <code className='font-mono text-sm'>--ringee-primary</code>. The
+                color scheme follows the host page, or you pin it to light or
+                dark.
+              </p>
+            </div>
+            <CodeBlock code={THEME_SNIPPET} label='theme.ts' language='ts' />
+            <div>
+              <div className='grid gap-4 sm:grid-cols-2'>
+                <Card className='p-5'>
+                  <Paintbrush className='h-5 w-5 text-emerald-600 dark:text-emerald-400' />
+                  <h3 className='mt-3 text-sm font-semibold'>Themeable</h3>
+                  <p className='text-muted-foreground mt-1.5 text-sm'>
+                    Primary, surface, text, border, danger, success, warning,
+                    radius, shadow, and font family.
+                  </p>
+                </Card>
+                <Card className='p-5'>
+                  <Languages className='h-5 w-5 text-emerald-600 dark:text-emerald-400' />
+                  <h3 className='mt-3 text-sm font-semibold'>
+                    Your words, two locales
+                  </h3>
+                  <p className='text-muted-foreground mt-1.5 text-sm'>
+                    English and Spanish ship in the box, and any individual
+                    label can be replaced with{' '}
+                    <code className='font-mono text-xs'>strings</code>.
+                  </p>
+                </Card>
+              </div>
+            </div>
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='frameworks' className='bg-muted/20'>
+        <Container>
+          <div className='grid items-start gap-8'>
+            <div className='max-w-3xl'>
+              <Eyebrow>Any stack</Eyebrow>
+              <h2 className='mt-4 text-3xl font-bold tracking-tight text-balance'>
+                React, Next.js, or no framework at all
+              </h2>
+              <p className='text-muted-foreground mt-5 text-lg text-pretty'>
+                The package is browser-only and framework-agnostic. In React or
+                Next.js, mount it inside a{' '}
+                <code className='font-mono text-sm'>useEffect</code> with a
+                dynamic import so it never runs during SSR, and destroy the
+                controller on unmount.
+              </p>
+              <CheckList
+                className='mt-6'
+                items={[
+                  'ESM and CommonJS builds, plus a self-contained CDN bundle that exposes window.Ringee',
+                  'TypeScript types for every option, state, event, and error',
+                  'Shadow DOM rendering keeps your CSS and the dialer’s apart',
+                  'destroy() releases the UI, WebRTC, audio, and the call lock'
+                ]}
+              />
+              <div className='mt-8 flex flex-col gap-3 sm:flex-row'>
+                <ButtonLink href={DOCS_URL} external withArrow>
+                  Developer docs
+                </ButtonLink>
+                <ButtonLink
+                  href={GITHUB_URL}
+                  variant='secondary'
+                  external
+                  withArrow
+                >
+                  Source on GitHub
+                </ButtonLink>
+              </div>
+            </div>
+            <CodeBlock
+              code={REACT_SNIPPET}
+              label='ringee-dialer.tsx'
+              language='tsx'
+            />
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='real-ringee-calls'>
+        <Container>
+          <div className='grid items-start gap-10 lg:grid-cols-2'>
+            <div>
+              <Eyebrow>Not a side channel</Eyebrow>
+              <h2 className='mt-4 text-3xl font-bold tracking-tight text-balance'>
+                Every SDK call is a real Ringee call
+              </h2>
+              <p className='text-muted-foreground mt-5 text-lg text-pretty'>
+                The SDK is a thin front end over the same calling pipeline the
+                Ringee web app and Chrome extension use. Nothing is duplicated,
+                so nothing drifts: the same checks run before a call connects
+                and the same records come out the other side.
+              </p>
+              <CheckList className='mt-6' items={PLATFORM_POINTS} />
+            </div>
+            <div className='flex flex-col gap-5'>
+              <Card className='flex gap-4'>
+                <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'>
+                  <Wallet className='h-5 w-5' />
+                </span>
+                <div>
+                  <h3 className='font-semibold'>One balance, no SDK fee</h3>
+                  <p className='text-muted-foreground mt-1.5 text-sm text-pretty'>
+                    Calls from your app draw on the same pay-as-you-go credits
+                    as everything else in Ringee. There is no separate charge
+                    for embedding the dialer.
+                  </p>
+                </div>
+              </Card>
+              <Card className='flex gap-4'>
+                <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'>
+                  <Sparkles className='h-5 w-5' />
+                </span>
+                <div>
+                  <h3 className='font-semibold'>
+                    Recording, transcription, outcomes
+                  </h3>
+                  <p className='text-muted-foreground mt-1.5 text-sm text-pretty'>
+                    Whatever your workspace already does with a call keeps
+                    happening — recordings, real-time transcripts, outcomes, and
+                    CRM sync — for calls placed from your own interface.
+                  </p>
+                </div>
+              </Card>
+              <Card className='flex gap-4'>
+                <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'>
+                  <SquareDashedBottomCode className='h-5 w-5' />
+                </span>
+                <div>
+                  <h3 className='font-semibold'>Self-hosted friendly</h3>
+                  <p className='text-muted-foreground mt-1.5 text-sm text-pretty'>
+                    Point the SDK at your own deployment with a single option.
+                  </p>
+                  <div className='mt-3'>
+                    <CodeBlock code={SELF_HOST_SNIPPET} language='ts' />
+                  </div>
+                </div>
+              </Card>
+            </div>
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='security' className='bg-muted/20'>
+        <Container>
+          <div className='grid items-start gap-10 lg:grid-cols-2'>
+            <div>
+              <Eyebrow>Security</Eyebrow>
+              <h2 className='mt-4 text-3xl font-bold tracking-tight text-balance'>
+                Safe to ship in a browser bundle
+              </h2>
+              <p className='text-muted-foreground mt-5 text-lg text-pretty'>
+                Security here does not depend on hiding the publishable key.
+                Placing a call requires a signed key, an exact allowed origin,
+                an agent verified by email code, current workspace membership,
+                and a server-side pass on permissions, caller ID, credit, and
+                DNC.
+              </p>
+              <CheckList className='mt-6' items={SECURITY_POINTS} />
+              <div className='mt-8'>
+                <ButtonLink href='/security' variant='secondary' withArrow>
+                  How Ringee handles security
+                </ButtonLink>
+              </div>
+            </div>
+            <div className='flex flex-col gap-5'>
+              <Card>
+                <div className='flex items-center gap-3'>
+                  <span className='flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'>
+                    <KeyRound className='h-5 w-5' />
+                  </span>
+                  <h3 className='font-semibold'>Two keys, two jobs</h3>
+                </div>
+                <dl className='mt-4 flex flex-col gap-3 text-sm'>
+                  <div className='border-border/60 flex flex-col gap-1 rounded-xl border p-3'>
+                    <dt className='font-mono text-emerald-600 dark:text-emerald-400'>
+                      pk_live_…
+                    </dt>
+                    <dd className='text-muted-foreground'>
+                      Dialer SDK. Belongs in your frontend, scoped to the
+                      origins you allow.
+                    </dd>
+                  </div>
+                  <div className='border-border/60 flex flex-col gap-1 rounded-xl border p-3'>
+                    <dt className='font-mono'>cik_live_…</dt>
+                    <dd className='text-muted-foreground'>
+                      Private Custom Integrations API. Server-side only — never
+                      in browser code.
+                    </dd>
+                  </div>
+                </dl>
+              </Card>
+              <Card>
+                <div className='flex items-center gap-3'>
+                  <span className='flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'>
+                    <ShieldCheck className='h-5 w-5' />
+                  </span>
+                  <h3 className='font-semibold'>Content Security Policy</h3>
+                </div>
+                <p className='text-muted-foreground mt-3 text-sm text-pretty'>
+                  A restrictive CSP needs to allow the Ringee API and the
+                  calling WebSocket. Drop{' '}
+                  <code className='font-mono'>unpkg</code> when you install from
+                  npm.
+                </p>
+                <div className='mt-4'>
+                  <CodeBlock code={CSP_SNIPPET} label='CSP' />
+                </div>
+              </Card>
+            </div>
+          </div>
+        </Container>
+      </Section>
+
+      <Section id='get-a-key'>
+        <Container>
+          <SectionHeading
+            eyebrow='Getting started'
+            title='Get a publishable key'
+            description='Publishable keys live inside a Custom Integration in your Ringee dashboard. Organization admins and admin-level personal accounts can create one.'
+            align='left'
+          />
+          <div className='mt-10 grid gap-5 md:grid-cols-3'>
+            {[
+              {
+                step: '01',
+                title: 'Create a Custom Integration',
+                body: 'In Ringee, open Integrations → Custom Integrations and create one for your app.'
+              },
+              {
+                step: '02',
+                title: 'Add your origins',
+                body: 'Under Dialer SDK · Publishable keys, list every origin that will load the SDK — production, staging, and localhost. Origins match exactly.'
+              },
+              {
+                step: '03',
+                title: 'Generate and embed',
+                body: 'Generate the pk_live_… key, pass it as the SDK key option, and place your first call.'
+              }
+            ].map((item) => (
+              <Card key={item.step} className='flex h-full flex-col'>
+                <span className='font-mono text-sm font-semibold text-emerald-600 dark:text-emerald-400'>
+                  {item.step}
+                </span>
+                <h3 className='mt-3 font-semibold'>{item.title}</h3>
+                <p className='text-muted-foreground mt-2 text-sm text-pretty'>
+                  {item.body}
+                </p>
+              </Card>
+            ))}
+          </div>
+
+          <Card className='mt-8'>
+            <div className='flex items-center gap-3'>
+              <Code2 className='h-5 w-5 text-emerald-600 dark:text-emerald-400' />
+              <h3 className='font-semibold'>
+                Straight talk about this release
+              </h3>
+            </div>
+            <p className='text-muted-foreground mt-3 text-sm text-pretty'>
+              The SDK is young, so here is what it does not do yet — better to
+              read it now than to find out mid-integration.
+            </p>
+            <ul className='mt-4 flex flex-col gap-2'>
+              {NOT_INCLUDED.map((item) => (
+                <li
+                  key={item}
+                  className='text-muted-foreground flex gap-2 text-sm'
+                >
+                  <span
+                    className='bg-muted-foreground/50 mt-2 h-1 w-1 shrink-0 rounded-full'
+                    aria-hidden
+                  />
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <p className='text-muted-foreground mt-4 text-sm text-pretty'>
+              You can still run the SDK inside an iframe your application
+              creates, as long as that document is an allowed origin and has
+              microphone and storage access.
+            </p>
+          </Card>
+        </Container>
+      </Section>
+
+      <FaqSection
+        faqs={SDK_FAQS}
+        description='Keys, frameworks, security, and what happens to a call once it leaves your app.'
+      />
+
+      <JsonLd
+        data={softwareSourceCodeJsonLd({
+          id: `${SITE_URL}/dialer-sdk#dialer-sdk`,
+          name: '@ringee/dialer-sdk',
+          description:
+            'Universal browser SDK that embeds Ringee outbound calling into any web application, with floating, inline bar, and headless integration modes.',
+          url: SDK_NPM_URL,
+          codeRepository: GITHUB_URL
+        })}
+      />
+    </DetailLayout>
+  );
+}

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -20,6 +20,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/features', priority: 0.8 },
     { path: '/integrations', priority: 0.8 },
     { path: '/apps', priority: 0.8 },
+    { path: '/dialer-sdk', priority: 0.8 },
     { path: '/use-cases', priority: 0.8 },
     { path: '/alternatives', priority: 0.8 },
     { path: '/security', priority: 0.7 },

--- a/apps/frontend/src/features/marketing/components/code-block.tsx
+++ b/apps/frontend/src/features/marketing/components/code-block.tsx
@@ -1,0 +1,48 @@
+import { cn } from '@ringee/frontend-shared/lib/utils';
+
+/**
+ * Static, server-rendered code sample for developer-facing marketing pages.
+ *
+ * Deliberately unhighlighted: the snippet ships in the initial HTML (crawlers
+ * and AI engines read it as plain text) and costs no client JavaScript. The
+ * surface is dark in both themes, the way a terminal or editor pane reads on a
+ * light page.
+ */
+export function CodeBlock({
+  code,
+  label,
+  language,
+  className
+}: {
+  code: string;
+  /** Filename or short caption shown in the header bar. */
+  label?: string;
+  /** Language tag shown on the right of the header bar. */
+  language?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        // `min-w-0` lets the block shrink inside grid/flex tracks — without it
+        // a long code line widens the whole page instead of scrolling itself.
+        'w-full min-w-0 overflow-hidden rounded-2xl border border-slate-800 bg-slate-950 shadow-sm',
+        className
+      )}
+    >
+      {label || language ? (
+        <div className='flex items-center justify-between gap-4 border-b border-slate-800 px-4 py-2.5'>
+          <span className='font-mono text-xs text-slate-400'>{label}</span>
+          {language ? (
+            <span className='text-[10px] font-semibold tracking-wide text-slate-500 uppercase'>
+              {language}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+      <pre className='overflow-x-auto px-4 py-4 text-[13px] leading-relaxed text-slate-100'>
+        <code className='font-mono'>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/marketing/components/json-ld.tsx
+++ b/apps/frontend/src/features/marketing/components/json-ld.tsx
@@ -122,6 +122,42 @@ function planOffers() {
 }
 
 /**
+ * SoftwareSourceCode entity for a published Ringee package (the Dialer SDK).
+ * Distinct from the `#software` product entity: this describes shippable
+ * source, so it carries the repository, language, and license instead of
+ * offers.
+ */
+export function softwareSourceCodeJsonLd({
+  name,
+  description,
+  url,
+  codeRepository,
+  id
+}: {
+  name: string;
+  description: string;
+  url: string;
+  codeRepository: string;
+  id: string;
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareSourceCode',
+    '@id': id,
+    name,
+    description,
+    url,
+    codeRepository,
+    programmingLanguage: 'TypeScript',
+    runtimePlatform: 'Web browser',
+    license: 'https://opensource.org/licenses/MIT',
+    dateModified: SITE_LAST_MODIFIED,
+    isPartOf: { '@id': `${SITE_URL}/#software` },
+    publisher: { '@id': ORG_ID }
+  };
+}
+
+/**
  * SoftwareApplication structured data for the product. Declared once (homepage);
  * feature pages link back to it rather than redeclaring the whole app.
  */

--- a/apps/frontend/src/features/marketing/components/sdk-demo.tsx
+++ b/apps/frontend/src/features/marketing/components/sdk-demo.tsx
@@ -1,0 +1,486 @@
+'use client';
+
+import { type RefObject, useEffect, useRef, useState } from 'react';
+import { useTheme } from 'next-themes';
+
+import { cn } from '@ringee/frontend-shared/lib/utils';
+import type {
+  AuthState,
+  DialerState,
+  RingeeCall
+} from '@ringee/dialer-sdk/types';
+// Type-only: erased at build time, so the Telnyx-backed engine is never bundled.
+import type { RingeeDialer } from '@ringee/dialer-sdk/ringee-dialer';
+import type { DialerModel } from '@ringee/dialer-sdk/ui/dialer-model';
+import type { ShadowMount } from '@ringee/dialer-sdk/ui/shadow-root';
+
+/**
+ * Real Dialer SDK UI, running on the marketing site.
+ *
+ * These demos render the *production* components — the same `CardView`,
+ * `BarView`, Shadow DOM mount, styles, and copy that ship in
+ * `@ringee/dialer-sdk` — driven by the package's `MockDialer`, which stands in
+ * for the backend and WebRTC. Nothing here is a screenshot or a hand-built
+ * lookalike, and nothing touches the network. Same approach as
+ * `apps/sdk-playground/ui-gallery`.
+ *
+ * Only the view layer is imported (never `ui/factory`, which pulls in the
+ * headless dialer and the Telnyx engine), and the chunk is fetched lazily as
+ * the demo approaches the viewport, so a marketing visit never downloads the
+ * calling stack.
+ */
+
+type SdkUi = Awaited<ReturnType<typeof loadSdkUi>>;
+type Surface = 'floating' | 'bar';
+
+const DEMO_CONTACT = {
+  name: 'Morgan Reed',
+  number: '+13055550142',
+  contactId: 'crm-contact-294'
+};
+
+async function loadSdkUi() {
+  const [model, card, bar, shadow, strings, icons, demo] = await Promise.all([
+    import('@ringee/dialer-sdk/ui/dialer-model'),
+    import('@ringee/dialer-sdk/ui/card-view'),
+    import('@ringee/dialer-sdk/ui/bar-view'),
+    import('@ringee/dialer-sdk/ui/shadow-root'),
+    import('@ringee/dialer-sdk/ui/strings'),
+    import('@ringee/dialer-sdk/ui/icons'),
+    import('@ringee/dialer-sdk/demo/mock-dialer')
+  ]);
+  return {
+    DialerModel: model.DialerModel,
+    CardView: card.CardView,
+    BarView: bar.BarView,
+    createShadowMount: shadow.createShadowMount,
+    resolveStrings: strings.resolveStrings,
+    icon: icons.icon,
+    MockDialer: demo.MockDialer,
+    DEMO_AGENT: demo.DEMO_AGENT,
+    DEMO_CALLER_IDS: demo.DEMO_CALLER_IDS
+  };
+}
+
+/** Fetch the SDK UI chunk once the demo is within ~a screen of the viewport. */
+function useSdkUi(ref: RefObject<HTMLElement | null>): SdkUi | null {
+  const [ui, setUi] = useState<SdkUi | null>(null);
+
+  useEffect(() => {
+    if (ui) return;
+    const node = ref.current;
+    if (!node) return;
+
+    let cancelled = false;
+    const load = () => {
+      void loadSdkUi().then((loaded) => {
+        if (!cancelled) setUi(loaded);
+      });
+    };
+
+    if (typeof IntersectionObserver === 'undefined') {
+      load();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          observer.disconnect();
+          load();
+        }
+      },
+      { rootMargin: '300px' }
+    );
+    observer.observe(node);
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [ref, ui]);
+
+  return ui;
+}
+
+/** The site's resolved theme, as an SDK `colorScheme`. */
+function useSdkScheme(): 'light' | 'dark' {
+  const { resolvedTheme } = useTheme();
+  return resolvedTheme === 'dark' ? 'dark' : 'light';
+}
+
+/** Keeps a mounted surface on the site's theme without re-creating it. */
+function useMountTheme(
+  mountRef: RefObject<ShadowMount | null>,
+  mounted: boolean
+): RefObject<'light' | 'dark'> {
+  const scheme = useSdkScheme();
+  const schemeRef = useRef(scheme);
+  schemeRef.current = scheme;
+
+  useEffect(() => {
+    mountRef.current?.setTheme({ colorScheme: scheme });
+  }, [mountRef, scheme, mounted]);
+
+  return schemeRef;
+}
+
+/** Placeholder with roughly the footprint of the mounted UI, shown while loading. */
+function StageSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'border-border/60 bg-muted/40 w-full animate-pulse rounded-2xl border',
+        className
+      )}
+    />
+  );
+}
+
+/**
+ * Interactive demo: a real dialer mounted inside a stand-in CRM window. Sign in
+ * with any email and any 6-digit code, then place a simulated call.
+ */
+export function SdkLiveDemo({ className }: { className?: string }) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<ShadowMount | null>(null);
+  const [surface, setSurface] = useState<Surface>('floating');
+  const [mounted, setMounted] = useState(false);
+  const ui = useSdkUi(frameRef);
+  const schemeRef = useMountTheme(mountRef, mounted);
+
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!ui || !stage) return;
+
+    const {
+      DialerModel,
+      CardView,
+      BarView,
+      createShadowMount,
+      resolveStrings,
+      icon,
+      MockDialer
+    } = ui;
+
+    const mock = new MockDialer({ mode: 'interactive' });
+    const model = new DialerModel(mock as unknown as RingeeDialer, {
+      strings: resolveStrings('en'),
+      allowHold: true,
+      workspaceName: 'Acme CRM'
+    });
+    const mount = createShadowMount(stage, { colorScheme: schemeRef.current });
+    mount.host.style.width = '100%';
+    mountRef.current = mount;
+
+    let teardownView: () => void;
+
+    if (surface === 'bar') {
+      const bar = new BarView(model);
+      mount.root.appendChild(bar.el);
+      teardownView = () => bar.destroy();
+    } else {
+      // The same stack the floating chrome uses: panel above, launcher below.
+      const holder = document.createElement('div');
+      holder.className = 'rg-floating';
+      holder.setAttribute('data-side', 'right');
+      holder.style.position = 'static';
+      holder.style.width = '100%';
+
+      const card = new CardView(model, {});
+      card.el.style.width = '100%';
+      holder.appendChild(card.el);
+
+      const launcher = document.createElement('button');
+      launcher.type = 'button';
+      launcher.className = 'rg-launcher';
+      launcher.title = model.s.launcherClose;
+      launcher.setAttribute('aria-label', model.s.launcherClose);
+      launcher.appendChild(icon('phone', 24));
+      launcher.addEventListener('click', () => {
+        const opening = card.el.hidden;
+        card.el.hidden = !opening;
+        const label = opening ? model.s.launcherClose : model.s.launcherOpen;
+        launcher.title = label;
+        launcher.setAttribute('aria-label', label);
+      });
+      holder.appendChild(launcher);
+
+      mount.root.appendChild(holder);
+      teardownView = () => card.destroy();
+    }
+
+    void mock.initialize();
+    setMounted(true);
+
+    return () => {
+      teardownView();
+      model.destroy();
+      mount.destroy();
+      mountRef.current = null;
+      void mock.destroy();
+      setMounted(false);
+    };
+  }, [ui, surface, schemeRef]);
+
+  return (
+    <div
+      ref={frameRef}
+      className={cn(
+        'border-border/70 bg-card overflow-hidden rounded-2xl border shadow-sm',
+        className
+      )}
+    >
+      {/* Host application chrome */}
+      <div className='border-border/60 bg-muted/40 flex items-center gap-2 border-b px-4 py-3'>
+        <span className='h-2.5 w-2.5 rounded-full bg-red-400/70' />
+        <span className='h-2.5 w-2.5 rounded-full bg-amber-400/70' />
+        <span className='h-2.5 w-2.5 rounded-full bg-emerald-400/70' />
+        <span className='text-muted-foreground ml-2 font-mono text-xs'>
+          crm.example.com
+        </span>
+      </div>
+
+      <div className='border-border/60 flex items-center gap-1 border-b px-3 py-2'>
+        {(
+          [
+            ['floating', 'Floating panel'],
+            ['bar', 'Inline bar']
+          ] as const
+        ).map(([value, label]) => (
+          <button
+            key={value}
+            type='button'
+            onClick={() => setSurface(value)}
+            aria-pressed={surface === value}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+              surface === value
+                ? 'bg-accent text-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Dotted stage stands in for the host page the dialer floats over. */}
+      <div className='p-4 sm:p-5'>
+        <div
+          className={cn(
+            'flex rounded-xl bg-[radial-gradient(circle_at_1px_1px,rgba(0,0,0,0.07)_1px,transparent_0)] [background-size:16px_16px] p-4 dark:bg-[radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.06)_1px,transparent_0)]',
+            surface === 'floating'
+              ? 'justify-center sm:justify-end'
+              : 'justify-center'
+          )}
+        >
+          <div
+            ref={stageRef}
+            className={cn(
+              'flex w-full',
+              surface === 'floating' ? 'max-w-[340px]' : 'max-w-full'
+            )}
+          />
+          {!mounted ? (
+            <StageSkeleton
+              className={cn(
+                surface === 'floating' ? 'h-[24rem] max-w-[340px]' : 'h-16'
+              )}
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <p className='text-muted-foreground border-border/60 border-t px-4 py-3 text-xs text-pretty'>
+        The real SDK UI, simulated end to end — no backend, no WebRTC. Use any
+        email, then any 6-digit code, then place a call.
+      </p>
+    </div>
+  );
+}
+
+type FrozenTile = {
+  label: string;
+  note: string;
+  surface: Surface;
+  /** Dialer state the tile freezes (applied before the model is built). */
+  auth: AuthState;
+  state: DialerState;
+  /** Extra model state the screen needs (contact, active call, …). */
+  patch?: (model: DialerModel, ui: SdkUi) => void;
+};
+
+function demoCall(ui: SdkUi, answered: boolean): RingeeCall {
+  return {
+    id: 'call_demo',
+    to: DEMO_CONTACT.number,
+    from: ui.DEMO_CALLER_IDS[0]!.phoneNumber,
+    direction: 'outbound',
+    state: answered ? 'active' : 'ringing',
+    startedAt: new Date(Date.now() - 130000),
+    answeredAt: answered ? new Date(Date.now() - 125000) : null,
+    endedAt: null,
+    durationSeconds: 0,
+    muted: false,
+    held: false
+  };
+}
+
+const TILES: FrozenTile[] = [
+  {
+    label: 'Sign in',
+    note: 'The agent identifies their Ringee account',
+    surface: 'floating',
+    auth: 'anonymous',
+    state: 'uninitialized'
+  },
+  {
+    label: 'Ready to dial',
+    note: 'Contact, number, and caller ID',
+    surface: 'floating',
+    auth: 'authenticated',
+    state: 'ready',
+    patch: (model) => {
+      model.contact = DEMO_CONTACT;
+      model.number = DEMO_CONTACT.number;
+    }
+  },
+  {
+    label: 'In call',
+    note: 'Timer, mute, hold, keypad, hang up',
+    surface: 'floating',
+    auth: 'authenticated',
+    state: 'active',
+    patch: (model, ui) => {
+      model.contact = DEMO_CONTACT;
+      model.number = DEMO_CONTACT.number;
+      model.activeCall = demoCall(ui, true);
+    }
+  },
+  {
+    label: 'Inline bar, mid-call',
+    note: 'The same dialer inside a toolbar or sidebar',
+    surface: 'bar',
+    auth: 'authenticated',
+    state: 'active',
+    patch: (model, ui) => {
+      model.contact = DEMO_CONTACT;
+      model.number = DEMO_CONTACT.number;
+      model.activeCall = demoCall(ui, true);
+    }
+  }
+];
+
+/** One frozen state of the real UI, rendered into its own Shadow DOM mount. */
+function FrozenTileCard({ tile, ui }: { tile: FrozenTile; ui: SdkUi | null }) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<ShadowMount | null>(null);
+  const [mounted, setMounted] = useState(false);
+  const schemeRef = useMountTheme(mountRef, mounted);
+
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!ui || !stage) return;
+
+    const {
+      DialerModel,
+      CardView,
+      BarView,
+      createShadowMount,
+      resolveStrings,
+      MockDialer,
+      DEMO_AGENT,
+      DEMO_CALLER_IDS
+    } = ui;
+
+    // Preset the dialer before the model reads it — a static mock emits nothing.
+    const mock = new MockDialer({ mode: 'static' });
+    mock.presetAuth(tile.auth).presetState(tile.state);
+
+    const model = new DialerModel(mock as unknown as RingeeDialer, {
+      strings: resolveStrings('en'),
+      allowHold: true,
+      workspaceName: 'Acme CRM'
+    });
+    model.agent = DEMO_AGENT;
+    model.callerIds = DEMO_CALLER_IDS;
+    tile.patch?.(model, ui);
+
+    const mount = createShadowMount(stage, { colorScheme: schemeRef.current });
+    mount.host.style.width = '100%';
+    mountRef.current = mount;
+
+    let teardownView: () => void;
+    if (tile.surface === 'bar') {
+      const bar = new BarView(model);
+      mount.root.appendChild(bar.el);
+      teardownView = () => bar.destroy();
+    } else {
+      const card = new CardView(model, {});
+      card.el.style.width = '100%';
+      card.el.style.animation = 'none';
+      mount.root.appendChild(card.el);
+      teardownView = () => card.destroy();
+    }
+    setMounted(true);
+
+    return () => {
+      teardownView();
+      model.destroy();
+      mount.destroy();
+      mountRef.current = null;
+      setMounted(false);
+    };
+  }, [tile, ui, schemeRef]);
+
+  const isBar = tile.surface === 'bar';
+
+  return (
+    <figure
+      className={cn(
+        'border-border/70 bg-muted/20 m-0 flex flex-col gap-4 rounded-2xl border p-4',
+        isBar && 'sm:col-span-2'
+      )}
+    >
+      <div
+        className={cn(
+          'flex flex-1 justify-center rounded-xl bg-[radial-gradient(circle_at_1px_1px,rgba(0,0,0,0.07)_1px,transparent_0)] [background-size:16px_16px] p-3 dark:bg-[radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.06)_1px,transparent_0)]',
+          isBar ? 'items-center' : 'items-start'
+        )}
+      >
+        <div
+          ref={stageRef}
+          className={cn('flex w-full', isBar ? 'max-w-3xl' : 'max-w-[340px]')}
+        />
+        {!mounted ? (
+          <StageSkeleton
+            className={cn(isBar ? 'h-16 max-w-3xl' : 'h-72 max-w-[340px]')}
+          />
+        ) : null}
+      </div>
+      <figcaption className='flex flex-col gap-1'>
+        <span className='text-sm font-semibold'>{tile.label}</span>
+        <span className='text-muted-foreground text-xs'>{tile.note}</span>
+      </figcaption>
+    </figure>
+  );
+}
+
+/** Grid of frozen, real-UI states — the screens you get without building any. */
+export function SdkStateGallery({ className }: { className?: string }) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const ui = useSdkUi(gridRef);
+
+  return (
+    <div ref={gridRef} className={cn('grid gap-5 sm:grid-cols-2', className)}>
+      {TILES.map((tile) => (
+        <FrozenTileCard key={tile.label} tile={tile} ui={ui} />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/features/marketing/site.ts
+++ b/apps/frontend/src/features/marketing/site.ts
@@ -24,6 +24,7 @@ export const DEMO_VIDEO_URL = `https://www.youtube.com/watch?v=${DEMO_VIDEO_ID}`
 export const DOCS_URL = 'https://docs.ringee.io';
 export const BLOG_URL = 'https://blog.ringee.io';
 export const CLI_NPM_URL = 'https://www.npmjs.com/package/ringee';
+export const SDK_NPM_URL = 'https://www.npmjs.com/package/@ringee/dialer-sdk';
 export const SIGN_IN_URL = '/auth/sign-in';
 export const SIGN_UP_URL = '/auth/sign-up';
 
@@ -46,6 +47,7 @@ export const SAME_AS = [
   GITHUB_ORG_URL,
   'https://www.reddit.com/r/ringee/',
   CLI_NPM_URL,
+  SDK_NPM_URL,
   IOS_APP_URL,
   ANDROID_APP_URL,
   CHROME_EXTENSION_URL,
@@ -194,6 +196,11 @@ export const PRODUCT_MENU: ProductMenuGroup[] = [
         description: 'Keep your CRM in step'
       },
       {
+        label: 'Dialer SDK',
+        href: '/dialer-sdk',
+        description: 'Embed the dialer in your own app'
+      },
+      {
         label: 'Apollo',
         href: '/integrations/apollo',
         description: 'Pull and enrich Apollo leads'
@@ -271,6 +278,7 @@ export const FOOTER_COLUMNS: FooterColumn[] = [
       { label: 'Callbacks', href: '/features/callbacks' },
       { label: 'Meetings', href: '/features/meetings' },
       { label: 'AI call automation', href: '/features/ai-call-automation' },
+      { label: 'Dialer SDK', href: '/dialer-sdk' },
       { label: 'Apps & extensions', href: '/apps' },
       { label: 'All features', href: '/features' }
     ]
@@ -305,6 +313,7 @@ export const FOOTER_COLUMNS: FooterColumn[] = [
       { label: 'Developer docs', href: DOCS_URL },
       { label: 'Blog', href: BLOG_URL },
       { label: 'CLI on npm', href: CLI_NPM_URL },
+      { label: 'Dialer SDK on npm', href: SDK_NPM_URL },
       { label: 'Chrome extension', href: CHROME_EXTENSION_URL },
       { label: 'iOS app', href: IOS_APP_URL },
       { label: 'Android app', href: ANDROID_APP_URL },

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -22,7 +22,9 @@
       "@ringee/dialer-core/*": ["../../packages/dialer-core/src/*"],
       "@ringee/dialer-core": ["../../packages/dialer-core/src/index.ts"],
       "@ringee/dialer-ui/*": ["../../packages/dialer-ui/src/*"],
-      "@ringee/dialer-ui": ["../../packages/dialer-ui/src/index.ts"]
+      "@ringee/dialer-ui": ["../../packages/dialer-ui/src/index.ts"],
+      "@ringee/dialer-sdk/*": ["../../packages/dialer-sdk/src/*"],
+      "@ringee/dialer-sdk": ["../../packages/dialer-sdk/src/index.ts"]
     },
     "incremental": true,
     "plugins": [

--- a/apps/sdk-playground/ui-gallery/README.md
+++ b/apps/sdk-playground/ui-gallery/README.md
@@ -26,9 +26,14 @@ open apps/sdk-playground/ui-gallery/index.html
 
 ## Files
 
-| File             | What                                                        |
-| ---------------- | ----------------------------------------------------------- |
-| `index.html`     | Page shell + gallery styling                                |
-| `gallery.ts`     | Builds the frozen state tiles + the live demo               |
-| `mock-dialer.ts` | Drop-in stand-in for `RingeeDialer` (no network, no WebRTC) |
-| `build.mjs`      | esbuild bundler (wires the `@ringee/dialer-core` alias)     |
+| File         | What                                                    |
+| ------------ | ------------------------------------------------------- |
+| `index.html` | Page shell + gallery styling                            |
+| `gallery.ts` | Builds the frozen state tiles + the live demo           |
+| `build.mjs`  | esbuild bundler (wires the `@ringee/dialer-core` alias) |
+
+The fake dialer lives in the SDK itself, at
+`packages/dialer-sdk/src/demo/mock-dialer.ts` — a drop-in stand-in for
+`RingeeDialer` with no network and no WebRTC. It is shared with the public
+`/dialer-sdk` marketing demo so both show the same real UI; it is not a package
+export, so published consumers never see it.

--- a/apps/sdk-playground/ui-gallery/gallery.ts
+++ b/apps/sdk-playground/ui-gallery/gallery.ts
@@ -13,7 +13,11 @@ import { icon } from "../../../packages/dialer-sdk/src/ui/icons";
 import { createFloating, createBar } from "../../../packages/dialer-sdk/src/ui/factory";
 import type { RingeeCall } from "../../../packages/dialer-sdk/src/types";
 import type { RingeeTheme } from "../../../packages/dialer-sdk/src/ui/theme";
-import { MockDialer, DEMO_AGENT, DEMO_CALLER_IDS } from "./mock-dialer";
+import {
+  MockDialer,
+  DEMO_AGENT,
+  DEMO_CALLER_IDS,
+} from "../../../packages/dialer-sdk/src/demo/mock-dialer";
 
 const CONTACT = { name: "Morgan Reed", number: "+13055550142", contactId: "c1" };
 const strings = resolveStrings("en");

--- a/packages/dialer-sdk/src/demo/mock-dialer.ts
+++ b/packages/dialer-sdk/src/demo/mock-dialer.ts
@@ -1,10 +1,15 @@
 /**
- * A drop-in stand-in for the headless `RingeeDialer` used only by the visual
- * playground. It implements the same public method + event surface but performs
- * no network calls and no WebRTC, so every screen can be shown (and the whole
- * flow clicked through) without a backend or a real phone call. Two modes:
+ * A drop-in stand-in for the headless `RingeeDialer`, used by demos only. It
+ * implements the same public method + event surface but performs no network
+ * calls and no WebRTC, so every screen can be shown (and the whole flow clicked
+ * through) without a backend or a real phone call. Two modes:
  *   - `interactive` simulates realistic, timed transitions on each action.
  *   - `static` stays put so a gallery tile can freeze one exact state.
+ *
+ * Shared by `apps/sdk-playground/ui-gallery` and the public `/dialer-sdk`
+ * marketing demo, so both show the real UI driven by identical fake state. It
+ * is deliberately NOT a package export (no `exports` entry, no tsup target):
+ * consumers of the published package never see it.
  */
 import type {
   AuthState,
@@ -16,9 +21,16 @@ import type {
   RingeeEventHandler,
   RingeeEventName,
   RingeeEventPayloads,
-} from "../../../packages/dialer-sdk/src/types";
+} from "../types";
 
-type Handlers = { [K in RingeeEventName]?: Set<(p: RingeeEventPayloads[K]) => void> };
+/**
+ * Handlers are stored with an opaque payload type; the public `on`/`emit`
+ * signatures below re-apply the per-event payload, so callers stay type-safe
+ * while the bucket itself is uniform (a per-event mapped type can't be indexed
+ * by a generic `T` without widening errors).
+ */
+type AnyHandler = (payload: never) => void;
+type Handlers = Partial<Record<RingeeEventName, Set<AnyHandler>>>;
 
 export interface MockConfig {
   mode?: "interactive" | "static";
@@ -58,26 +70,27 @@ export class MockDialer {
   constructor(cfg: MockConfig = {}) {
     this.cfg = { mode: "interactive", ...cfg };
     this.agent = cfg.agent ?? DEMO_AGENT;
-    this.currenterIds = cfg.callerIds ?? DEMO_CALLER_IDS;
+    this.callerIds = cfg.callerIds ?? DEMO_CALLER_IDS;
   }
 
   // ── Event bus ─────────────────────────────────────────────────────────────
   on<T extends RingeeEventName>(event: T, handler: RingeeEventHandler<T>): () => void {
-    const set = (this.handlers[event] ??= new Set()) as Set<(p: RingeeEventPayloads[T]) => void>;
-    set.add(handler);
-    return () => set.delete(handler);
+    const set = (this.handlers[event] ??= new Set<AnyHandler>());
+    set.add(handler as AnyHandler);
+    return () => set.delete(handler as AnyHandler);
   }
 
   emit<T extends RingeeEventName>(event: T, payload: RingeeEventPayloads[T]): void {
-    const set = this.handlers[event] as Set<(p: RingeeEventPayloads[T]) => void> | undefined;
-    if (set) for (const fn of [...set]) fn(payload);
+    const set = this.handlers[event];
+    if (!set) return;
+    for (const fn of [...set]) (fn as (p: RingeeEventPayloads[T]) => void)(payload);
   }
 
   // ── Getters the model reads ───────────────────────────────────────────────
   getAuthState() { return this.auth; }
   getState() { return this.state; }
   getAgent() { return this.agent; }
-  getCallerIds() { return [...this.currenterIds]; }
+  getCallerIds() { return [...this.callerIds]; }
   getActiveCall() { return this.current; }
 
   private setAuth(a: AuthState) { this.auth = a; this.emit("authStateChanged", { state: a }); }
@@ -132,7 +145,7 @@ export class MockDialer {
 
   async call(input: { to: string }): Promise<RingeeCall> {
     this.current = {
-      id: "call_1", to: input.to, from: this.currenterIds[0]!.phoneNumber,
+      id: "call_1", to: input.to, from: this.callerIds[0]!.phoneNumber,
       direction: "outbound", state: "dialing", startedAt: new Date(),
       answeredAt: null, endedAt: null, durationSeconds: 0, muted: false, held: false,
     };


### PR DESCRIPTION
- Updated sitemap to include /dialer-sdk path.
- Introduced CodeBlock component for displaying code samples.
- Added softwareSourceCodeJsonLd function for structured data of the Dialer SDK.
- Implemented SdkLiveDemo component for interactive Dialer SDK demo.
- Created mock-dialer for simulating the Dialer SDK without network calls.
- Updated site constants to include SDK NPM URL and added links in the footer and product menu.
- Changed TypeScript target to ES2020 and updated path mappings for dialer-sdk.
- Enhanced README and gallery files for better documentation and usage instructions.