### PR TITLE
feat(subscription): notify users when their organization subscription starts with Trustpilot BCC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -308,6 +308,13 @@ TRIGGERLOOP_PROJECT_KEY="ringee"
 # address configured as your sender.
 RINGEE_TEAM_EMAIL=""
 
+# ── Trustpilot review invitations (optional) ──────────────────
+# Trustpilot's BCC invitation address for this domain. Ringee blind-copies it on
+# the welcome email a customer gets the first time they subscribe to the
+# Organization plan, which makes Trustpilot invite that customer to review us.
+# Leave empty to send that email without triggering any invitation.
+TRUSTPILOT_INVITE_BCC_EMAIL=""
+
 # ── Calendar OAuth (optional) ─────────────────────────────────
 # Google / Microsoft calendar integration. When unset the feature reports a
 # clear error instead of failing at boot.

--- a/apps/backend/src/api/routes/stripe.controller.ts
+++ b/apps/backend/src/api/routes/stripe.controller.ts
@@ -779,29 +779,34 @@ export class StripeController {
             console.log(
               `🏢 Organization subscription created for user ${userId}`,
             );
+            // When this billing period ends, i.e. the renewal date. It lives on
+            // the subscription item in current API versions, the same place
+            // `getSubscriptionSummary` reads it from. NOT `ended_at`, which is
+            // when a cancelled subscription stopped and is null while it runs.
+            const item = subscription.items.data[0];
+            const periodEnd = item?.current_period_end;
+
             const { isFirstEver } =
               await this.subscriptionService.createFromStripe(
                 subscription.id,
                 subscription.customer as string,
                 userId,
-                subscription.ended_at
-                  ? new Date(subscription.ended_at * 1000)
-                  : undefined,
+                periodEnd ? new Date(periodEnd * 1000) : undefined,
               );
 
             // Only the very first subscription is welcomed. A replayed webhook
             // and a customer who cancelled and came back both report false, so
             // nobody is invited to review us twice.
             if (isFirstEver) {
-              const price = subscription.items.data[0]?.price;
               await this.billingNotifications.notifyOrganizationSubscriptionStarted(
                 {
                   userId,
                   subscriptionId: subscription.id,
                   billingInterval:
-                    metadata.billingInterval ?? price?.recurring?.interval,
+                    metadata.billingInterval ??
+                    item?.price?.recurring?.interval,
                   amount: monthlyPriceUsd || null,
-                  currency: price?.currency ?? "usd",
+                  currency: item?.price?.currency ?? "usd",
                 },
               );
             }

--- a/apps/backend/src/api/routes/stripe.controller.ts
+++ b/apps/backend/src/api/routes/stripe.controller.ts
@@ -779,14 +779,32 @@ export class StripeController {
             console.log(
               `🏢 Organization subscription created for user ${userId}`,
             );
-            await this.subscriptionService.createFromStripe(
-              subscription.id,
-              subscription.customer as string,
-              userId,
-              subscription.ended_at
-                ? new Date(subscription.ended_at * 1000)
-                : undefined,
-            );
+            const { isFirstEver } =
+              await this.subscriptionService.createFromStripe(
+                subscription.id,
+                subscription.customer as string,
+                userId,
+                subscription.ended_at
+                  ? new Date(subscription.ended_at * 1000)
+                  : undefined,
+              );
+
+            // Only the very first subscription is welcomed. A replayed webhook
+            // and a customer who cancelled and came back both report false, so
+            // nobody is invited to review us twice.
+            if (isFirstEver) {
+              const price = subscription.items.data[0]?.price;
+              await this.billingNotifications.notifyOrganizationSubscriptionStarted(
+                {
+                  userId,
+                  subscriptionId: subscription.id,
+                  billingInterval:
+                    metadata.billingInterval ?? price?.recurring?.interval,
+                  amount: monthlyPriceUsd || null,
+                  currency: price?.currency ?? "usd",
+                },
+              );
+            }
           }
           break;
         }

--- a/packages/configuration/src/api.configuration.ts
+++ b/packages/configuration/src/api.configuration.ts
@@ -99,6 +99,11 @@ const apiConfiguration = {
   // Destination for internal free-trial / credit request notifications.
   RINGEE_TEAM_EMAIL:
     process.env.RINGEE_TEAM_EMAIL || process.env.EMAIL_FROM_ADDRESS,
+  // Trustpilot's BCC invitation address. Any transactional email blind-copied
+  // to it turns into a review invitation for that recipient, so it is only ever
+  // added to mail the customer already expects. Optional: unset means no
+  // invitation is triggered and the email is sent exactly as it is.
+  TRUSTPILOT_INVITE_BCC_EMAIL: process.env.TRUSTPILOT_INVITE_BCC_EMAIL,
   // ── Call Recording & Transcription (Deepgram) ──
   // Optional: when unset, recording still works but transcription is disabled
   // and the service surfaces a clear error instead of crashing at boot.

--- a/packages/database/src/database/repositories/subscription.repository.ts
+++ b/packages/database/src/database/repositories/subscription.repository.ts
@@ -32,6 +32,15 @@ export class SubscriptionRepository {
     });
   }
 
+  /**
+   * How many subscriptions this user has ever had, cancelled ones included.
+   * Only the organization plan is stored here, so zero means the user has
+   * never subscribed before.
+   */
+  async countByUserId(userId: string): Promise<number> {
+    return this.prisma.subscription.count({ where: { userId } });
+  }
+
   async findUnassignedByUserId(userId: string): Promise<Subscription | null> {
     return this.prisma.subscription.findFirst({
       where: {

--- a/packages/database/src/database/repositories/subscription.repository.ts
+++ b/packages/database/src/database/repositories/subscription.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { Subscription, SubscriptionStatus } from "@prisma/client";
+import { Prisma, Subscription, SubscriptionStatus } from "@prisma/client";
 import { PrismaService } from "../prisma.service";
 
 @Injectable()
@@ -39,6 +39,19 @@ export class SubscriptionRepository {
    */
   async countByUserId(userId: string): Promise<number> {
     return this.prisma.subscription.count({ where: { userId } });
+  }
+
+  /**
+   * True when `create` lost a race to another writer inserting the same
+   * `stripeSubscriptionId` — two deliveries of one Stripe event. The unique
+   * index is what actually serializes them; this just lets the caller tell that
+   * conflict apart from a real failure.
+   */
+  isUniqueViolation(err: unknown): boolean {
+    return (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    );
   }
 
   async findUnassignedByUserId(userId: string): Promise<Subscription | null> {

--- a/packages/platform/src/email/email.interface.ts
+++ b/packages/platform/src/email/email.interface.ts
@@ -9,5 +9,6 @@ export interface EmailInterface {
     emailFromAddress?: string,
     replyTo?: string,
     cc?: string | string[],
+    bcc?: string | string[],
   ): Promise<any>;
 }

--- a/packages/platform/src/email/resend.provider.ts
+++ b/packages/platform/src/email/resend.provider.ts
@@ -16,6 +16,7 @@ export class ResendProvider implements EmailInterface {
     // @ts-ignore
     replyTo?: string,
     cc?: string | string[],
+    bcc?: string | string[],
   ) {
     try {
       const sendReplyEmail = !emailFromAddress?.includes("no-reply")
@@ -28,6 +29,7 @@ export class ResendProvider implements EmailInterface {
         subject,
         html,
         ...(cc ? { cc } : {}),
+        ...(bcc ? { bcc } : {}),
         ...(sendReplyEmail && sendReplyEmail),
       });
 

--- a/packages/services/src/services/billing-notification.service.ts
+++ b/packages/services/src/services/billing-notification.service.ts
@@ -6,6 +6,13 @@ import { apiConfiguration } from "@ringee/configuration";
 /** Long enough to cover Stripe's webhook retry window for a single attempt. */
 const FAILED_PAYMENT_DEDUP_SECONDS = 3 * 24 * 60 * 60;
 
+/**
+ * Race guard only. "First ever" is decided from the subscription table, so this
+ * exists to stop two subscriptions created for the same user in the same
+ * instant from both being welcomed.
+ */
+const SUBSCRIPTION_WELCOME_DEDUP_SECONDS = 30 * 24 * 60 * 60;
+
 /** What the declined subscription pays for, so the email names what is at risk. */
 export type FailedSubscriptionKind =
   | "credit_funding"
@@ -34,13 +41,26 @@ export interface SubscriptionPaymentFailedParams {
   billingEmail?: string | null;
 }
 
+export interface OrganizationSubscriptionStartedParams {
+  /** Owner from the subscription metadata. */
+  userId: string;
+  /** Stripe subscription id — the dedupe key for this welcome. */
+  subscriptionId: string;
+  /** Cadence chosen at checkout; anything else is treated as monthly. */
+  billingInterval?: string | null;
+  /** Price per cycle in major units (dollars), not cents. */
+  amount?: number | null;
+  currency?: string;
+}
+
 type UserWithEmails = User & { emails?: UserEmail[] };
 
 /**
- * Billing emails that are not tied to a single domain service — today, the
- * "your subscription renewal was declined" notice fired from the Stripe
- * webhook. Everything here is best-effort: a mail failure must never make the
- * webhook handler fail, or Stripe would retry the whole event.
+ * Billing emails that are not tied to a single domain service: the "your
+ * subscription renewal was declined" notice and the welcome a customer gets the
+ * first time they subscribe to the Organization plan — both fired from the
+ * Stripe webhook. Everything here is best-effort: a mail failure must never make
+ * the webhook handler fail, or Stripe would retry the whole event.
  */
 @Injectable()
 export class BillingNotificationService {
@@ -109,6 +129,81 @@ export class BillingNotificationService {
   }
 
   /**
+   * Welcomes a customer the first time they subscribe to the Organization plan.
+   * The caller decides what "first time" means (no prior subscription row); this
+   * only guards the race, so a user who cancels and comes back is never
+   * welcomed twice.
+   *
+   * The mail is blind-copied to Trustpilot's invitation address when one is
+   * configured, which is what turns it into a review invitation for this
+   * customer. That is also why it goes to a single recipient: Trustpilot invites
+   * the address in `To`.
+   */
+  async notifyOrganizationSubscriptionStarted(
+    params: OrganizationSubscriptionStartedParams,
+  ): Promise<void> {
+    try {
+      if (!(await this.isFirstWelcome(params.userId))) {
+        this.logger.log(
+          `↩️ Duplicate organization-subscription welcome suppressed for user ${params.userId}`,
+        );
+        return;
+      }
+
+      const user = (await this.userRepository.findById(
+        params.userId,
+      )) as UserWithEmails | null;
+      const recipient = (
+        user?.emails?.find((e) => e.isPrimary)?.email ??
+        user?.emails?.[0]?.email
+      )
+        ?.trim()
+        .toLowerCase();
+
+      if (!recipient) {
+        this.logger.warn(
+          `No email address to welcome user ${params.userId} to the Organization plan`,
+        );
+        return;
+      }
+
+      const bcc = apiConfiguration.TRUSTPILOT_INVITE_BCC_EMAIL?.trim();
+
+      const result = await this.email.sendEmail(
+        recipient,
+        "Welcome to Ringee — your organization is ready to set up",
+        this.buildWelcomeHtml(params, user?.firstName ?? null),
+        "Ringee",
+        apiConfiguration.EMAIL_FROM_ADDRESS,
+        undefined,
+        undefined,
+        bcc || undefined,
+      );
+
+      if (
+        result &&
+        typeof result === "object" &&
+        "sent" in result &&
+        result.sent === false
+      ) {
+        this.logger.warn(
+          `Organization-subscription welcome for user ${params.userId} was not sent`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `📧 Organization-subscription welcome sent to user ${params.userId} for subscription ${params.subscriptionId}` +
+          (bcc ? " (Trustpilot invitation requested)" : ""),
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to send the organization-subscription welcome for user ${params.userId}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /**
    * False when this (invoice, attempt) pair was already emailed. Redis being
    * down must not silence a genuine dunning notice, so failures allow the send.
    */
@@ -129,6 +224,59 @@ export class BillingNotificationService {
       );
       return true;
     }
+  }
+
+  /**
+   * False when this user was already welcomed. Redis being down must not cost a
+   * genuine customer their welcome, so failures allow the send — the caller's
+   * "no prior subscription" check is what actually keeps this to once.
+   */
+  private async isFirstWelcome(userId: string): Promise<boolean> {
+    const key = `billing:org-subscription-welcome:${userId}`;
+    try {
+      return await this.redis.setIfAbsent(
+        key,
+        new Date().toISOString(),
+        SUBSCRIPTION_WELCOME_DEDUP_SECONDS,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Dedupe check failed for ${key}: ${(err as Error).message}`,
+      );
+      return true;
+    }
+  }
+
+  /**
+   * Same plain house style as the dunning email: a short note and one link.
+   * Creating the organization is the step the customer still has to take after
+   * paying, so that is the only thing this asks them to do.
+   */
+  private buildWelcomeHtml(
+    params: OrganizationSubscriptionStartedParams,
+    firstName: string | null,
+  ): string {
+    const greeting = firstName?.trim()
+      ? `Hi ${escapeHtml(firstName.trim())},`
+      : "Hi,";
+    const price =
+      params.amount != null
+        ? ` (${this.formatAmount(params.amount, params.currency ?? "usd")}${
+            params.billingInterval === "year" ? " a year" : " a month"
+          })`
+        : "";
+    const dashboardUrl = `${apiConfiguration.FRONTEND_URL?.replace(/\/+$/, "")}/dashboard/overview`;
+
+    return `
+      <div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;font-size:15px;line-height:1.6;color:#171717;max-width:520px;">
+        <p>${greeting}</p>
+        <p>Your Ringee Organization plan${price} is active. Thanks for subscribing.</p>
+        <p>The next step is creating your organization — that unlocks unlimited team members, campaigns and outreach, cheaper per-minute rates and advanced analytics.</p>
+        <p><a href="${escapeHtml(dashboardUrl)}">Create your organization</a></p>
+        <p>You can cancel any time from Billing.</p>
+        <p style="color:#737373;">Reply to this email if you need a hand getting set up.</p>
+      </div>
+    `;
   }
 
   /**

--- a/packages/services/src/services/subscription.service.ts
+++ b/packages/services/src/services/subscription.service.ts
@@ -49,15 +49,32 @@ export class SubscriptionService {
       await this.subscriptionRepository.countByUserId(userId);
 
     this.logger.log(`Creating subscription for user ${userId}`);
-    const subscription = await this.subscriptionRepository.create({
-      stripeSubscriptionId,
-      stripeCustomerId,
-      userId,
-      status: SubscriptionStatus.active,
-      currentPeriodEnd,
-    });
+    try {
+      const subscription = await this.subscriptionRepository.create({
+        stripeSubscriptionId,
+        stripeCustomerId,
+        userId,
+        status: SubscriptionStatus.active,
+        currentPeriodEnd,
+      });
 
-    return { subscription, isFirstEver: priorSubscriptions === 0 };
+      return { subscription, isFirstEver: priorSubscriptions === 0 };
+    } catch (err) {
+      // Two deliveries of the same event raced past the lookup above. The
+      // unique index on `stripeSubscriptionId` let exactly one of them insert,
+      // so the loser reports the winner's row — and does NOT claim the welcome,
+      // which the winner has already taken.
+      if (!this.subscriptionRepository.isUniqueViolation(err)) throw err;
+
+      const winner =
+        await this.subscriptionRepository.findByStripeId(stripeSubscriptionId);
+      if (!winner) throw err;
+
+      this.logger.log(
+        `↩️ Subscription ${stripeSubscriptionId} was recorded concurrently for user ${userId}`,
+      );
+      return { subscription: winner, isFirstEver: false };
+    }
   }
 
   async findUnassignedByUserId(userId: string) {

--- a/packages/services/src/services/subscription.service.ts
+++ b/packages/services/src/services/subscription.service.ts
@@ -1,5 +1,19 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { SubscriptionRepository, SubscriptionStatus } from "@ringee/database";
+import {
+  Subscription,
+  SubscriptionRepository,
+  SubscriptionStatus,
+} from "@ringee/database";
+
+export interface CreatedSubscription {
+  subscription: Subscription;
+  /**
+   * True only on the insert that gave this user their very first subscription.
+   * A replayed Stripe webhook and a re-subscribe both report `false`, so it is
+   * safe to hang a one-time welcome off it.
+   */
+  isFirstEver: boolean;
+}
 
 @Injectable()
 export class SubscriptionService {
@@ -9,20 +23,41 @@ export class SubscriptionService {
     private readonly subscriptionRepository: SubscriptionRepository,
   ) {}
 
+  /**
+   * Records an organization subscription Stripe has just created. Safe to
+   * replay: Stripe redelivers `customer.subscription.created`, and the second
+   * delivery must return the existing row rather than insert a duplicate or
+   * re-announce the subscription as new.
+   */
   async createFromStripe(
     stripeSubscriptionId: string,
     stripeCustomerId: string,
     userId: string,
     currentPeriodEnd?: Date,
-  ) {
+  ): Promise<CreatedSubscription> {
+    const existing =
+      await this.subscriptionRepository.findByStripeId(stripeSubscriptionId);
+    if (existing) {
+      this.logger.log(
+        `↩️ Subscription ${stripeSubscriptionId} already recorded for user ${userId}`,
+      );
+      return { subscription: existing, isFirstEver: false };
+    }
+
+    // Read before the insert: afterwards this user always has at least one.
+    const priorSubscriptions =
+      await this.subscriptionRepository.countByUserId(userId);
+
     this.logger.log(`Creating subscription for user ${userId}`);
-    return this.subscriptionRepository.create({
+    const subscription = await this.subscriptionRepository.create({
       stripeSubscriptionId,
       stripeCustomerId,
       userId,
       status: SubscriptionStatus.active,
       currentPeriodEnd,
     });
+
+    return { subscription, isFirstEver: priorSubscriptions === 0 };
   }
 
   async findUnassignedByUserId(userId: string) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Behaviour changes

- Stripe subscription webhooks now record the subscription item renewal end and notify the organization for a first-ever subscription.
- Webhook replays and returning customers do not receive duplicate welcome notifications.
- Welcome emails can include an optional Trustpilot BCC recipient.
- Redis deduplication limits repeated welcome notifications for 30 days.

## Architectural impact

- `@ringee/services` now owns first-subscription detection and welcome-notification orchestration.
- `@ringee/database` adds subscription counting and Prisma unique-violation detection.
- `@ringee/platform` extends the email contract with an optional `bcc` parameter and passes it to Resend.
- `apiConfiguration` exposes the optional `TRUSTPILOT_INVITE_BCC_EMAIL` environment value.
- `SubscriptionService.createFromStripe` now returns `CreatedSubscription` instead of `Subscription`.

## Risk areas

- Review concurrent first-subscription creation in `subscription.service.ts`. Count-before-insert logic can classify concurrent subscriptions incorrectly without suitable uniqueness or transaction guarantees.
- Review webhook persistence and notification ordering in `stripe.controller.ts`. A successful persistence followed by notification failure must not lose the welcome notification, while retries must not send duplicates.
- Review Redis deduplication failure and atomicity in `billing-notification.service.ts`. The flow can suppress required email delivery or permit duplicates if reservation and delivery are not coordinated.
- Review the positional `sendEmail` contract. Existing callers can misroute `cc` and `bcc` values when optional arguments are omitted.
- Review Trustpilot BCC validation and recipient exposure. An invalid or shared address can cause provider rejection or expose customer email metadata.
- Review the changed renewal-period source. Incorrect subscription-item selection can record the wrong entitlement end date.

## Files to review first

1. `apps/backend/src/api/routes/stripe.controller.ts`
2. `packages/services/src/services/subscription.service.ts`
3. `packages/services/src/services/billing-notification.service.ts`
4. `packages/database/src/database/repositories/subscription.repository.ts`
5. `packages/platform/src/email/email.interface.ts`
6. `packages/platform/src/email/resend.provider.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->