### PR TITLE
feat: enhance voice agent billing and call services

### DIFF
--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -100,6 +100,26 @@ Clerk (auth, orgs, webhooks) · Stripe (payments) · Telnyx (voice, numbers,
 messaging, WebRTC) · Deepgram (transcription) · Resend (email) · Firebase (push)
 · S3/R2 (storage) · OpenAI / Anthropic (AI pipelines and agents).
 
+### The address providers call Ringee back on
+
+Every URL handed to a provider — an agent's tools, its analysis callback, a call
+status callback, a calling application's event webhook — is built as
+`${PUBLIC_BACKEND_URL}/api/...`, because `api` is the backend's global prefix.
+
+**`PUBLIC_BACKEND_URL` is an origin and nothing else.** A value carrying a path
+(`https://api.example.com/public`) produces URLs the provider dutifully calls
+and Ringee answers `404` to — every one of them, at once, reporting the failure
+nowhere a person looks. What it looks like from the outside is an agent that
+says it is having a technical problem and books nothing, a call with no summary
+and no outcome, and no error anywhere. `apiConfiguration` drops the path rather
+than concatenating it and warns at boot (`PUBLIC_BACKEND_URL_PATH_IGNORED`).
+
+The URLs a provider **stores** — an assistant's tool webhooks, an insight
+group's callback — are written at save time and outlive the address they were
+built from. They are re-pointed before every dial (`ensureInsightGroup`,
+`ensureToolEndpoints`), which is the only thing that recovers an agent whose
+URLs predate the current address.
+
 ## Contract change checklist
 
 | Changing                    | Also check                                                  |

--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -111,8 +111,8 @@ status callback, a calling application's event webhook — is built as
 and Ringee answers `404` to — every one of them, at once, reporting the failure
 nowhere a person looks. What it looks like from the outside is an agent that
 says it is having a technical problem and books nothing, a call with no summary
-and no outcome, and no error anywhere. `apiConfiguration` drops the path rather
-than concatenating it and warns at boot (`PUBLIC_BACKEND_URL_PATH_IGNORED`).
+and no outcome, and no error anywhere. Deployment configuration is responsible
+for supplying the bare origin; `apiConfiguration` uses the value unchanged.
 
 The URLs a provider **stores** — an assistant's tool webhooks, an insight
 group's callback — are written at save time and outlive the address they were

--- a/docs/engineering/TELEPHONY.md
+++ b/docs/engineering/TELEPHONY.md
@@ -229,6 +229,33 @@ Consequences worth keeping:
   it, which hid every call whose webhook never arrived — permanently, and
   silently, because those are exactly the calls nothing else would price. The
   sweep now backfills the conversation id from the records themselves.
+- **The call's own timeline is reconciled too, not waited for.** Nobody is on
+  Ringee's end of an agent leg, so the status callback is the only thing that
+  would ever move `Call.status` — and an agent call that never gets one sits at
+  `pending` for the rest of its life with no duration, no answer time and no
+  outcome, while the stale-call sweep passes over it (it only reaches calls that
+  got as far as `ringing`). The `sip-trunking` record that prices the leg also
+  dates it: `started_at`, `finished_at`, and `call_sec` — time **connected**,
+  which is zero on a leg that was refused and is what tells a real conversation
+  apart from an attempt that still billed a minute. So the pass that settles the
+  money closes the row, and a call whose money is already settled is swept for
+  that reason alone (`listUnsettled`, bounded by a stalled-call window).
+  `Call.answeredAt` has to be written there as well: absent, `completeCall`
+  auto-dispositions the call as `no_answer` — on a call that just held a full
+  conversation.
+- **An agent leg's recording is found by `call_control_id`.** The session id is
+  reported only on an event Ringee may never receive, so a recordings lookup
+  keyed on it answers "none" for calls that were recorded perfectly well. The
+  control id is written down the moment the leg is placed. The session handle is
+  worth keeping when it does surface — on the recording, on a callback, or in a
+  conversation's metadata — but nothing may depend on having it.
+- **A conversation id resolves back to its call.** Post-call analysis names the
+  conversation and nothing else, and `providerConversationId` is written by the
+  conversation webhook — the one delivery that may never arrive. On a miss the
+  conversation is read from the provider (`GET /ai/conversations/{id}`), whose
+  `metadata` carries `call_control_id`, `call_session_id` and `call_leg_id`.
+  Without that second look an analysis arriving before the sweep bound the
+  conversation is dropped, and it is delivered once or lost (AGENT-009).
 - The outbound voice profile (`TELNYX_OUTBOUND_VOICE_PROFILE_ID`) is still
   Ringee's to pin on the calling application, on every save and before every
   dial — that one the provider does honour.

--- a/packages/configuration/src/api.configuration.ts
+++ b/packages/configuration/src/api.configuration.ts
@@ -8,40 +8,6 @@ const nonNegativeInteger = (name: string, fallback: number): number => {
   return Number.isInteger(value) && value >= 0 ? value : fallback;
 };
 
-/**
- * The origin the outside world reaches this backend on.
- *
- * Everything that hands a URL to a provider builds it as `<base>/api/...` —
- * `api` is this app's global prefix — so the base has to be an origin and
- * nothing more. A value carrying a path (`https://api.example.com/public`)
- * produces URLs that 404 on every single provider callback: the agent's tools,
- * the call status callback, the post-call analysis webhook and the calling
- * application's event webhook all break at once, and none of them report the
- * failure anywhere a person looks. The path is dropped here rather than
- * concatenated, and `PUBLIC_BACKEND_URL_PATH_IGNORED` says so at boot.
- */
-const publicBackendUrl = (): { origin: string; discardedPath: string } => {
-  const raw = process.env.PUBLIC_BACKEND_URL?.trim() ?? "";
-  if (!raw) return { origin: "", discardedPath: "" };
-
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    // Not a URL at all. Handed through untouched so the "is not a valid
-    // address" check below is what reports it, with the value the operator set.
-    return { origin: raw.replace(/\/+$/, ""), discardedPath: "" };
-  }
-
-  const path = `${parsed.pathname}${parsed.search}${parsed.hash}`.replace(
-    /^\/+$/,
-    "",
-  );
-  return { origin: parsed.origin, discardedPath: path };
-};
-
-const PUBLIC_BACKEND = publicBackendUrl();
-
 const apiConfiguration = {
   PORT: process.env.PORT || 3000,
   DATABASE_URL: process.env.DATABASE_URL!,
@@ -52,16 +18,7 @@ const apiConfiguration = {
   FRONTEND_URL: process.env.FRONTEND_URL!,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
-  /**
-   * Where the outside world reaches this backend. Normalized to a bare origin
-   * on the way in because it is concatenated into the webhook and tool URLs
-   * handed to providers: a stray space — or a path segment — yields a URL the
-   * provider calls and Ringee answers 404 to, and that failure surfaces far
-   * from its cause. See `publicBackendUrl`.
-   */
-  PUBLIC_BACKEND_URL: PUBLIC_BACKEND.origin,
-  /** The path `PUBLIC_BACKEND_URL` carried, if any. Reported at boot. */
-  PUBLIC_BACKEND_URL_PATH_IGNORED: PUBLIC_BACKEND.discardedPath,
+  PUBLIC_BACKEND_URL: process.env.PUBLIC_BACKEND_URL,
   REDIS_URL: process.env.REDIS_URL!,
   // ── Temporal (durable background jobs / orchestrator) ──
   // Plain gRPC address of the self-hosted Temporal frontend. For local dev,
@@ -409,14 +366,6 @@ if (!apiConfiguration.PUBLIC_BACKEND_URL) {
 } else if (!/^https?:\/\//.test(apiConfiguration.PUBLIC_BACKEND_URL)) {
   errors.push(
     `PUBLIC_BACKEND_URL is not a valid http(s) address: "${apiConfiguration.PUBLIC_BACKEND_URL}"`,
-  );
-} else if (apiConfiguration.PUBLIC_BACKEND_URL_PATH_IGNORED) {
-  // Loud, but not fatal. The value is recoverable — the origin is right and
-  // the path has already been dropped — and refusing to boot over it would
-  // turn a set of broken callback URLs into a backend that is not there at
-  // all. Every environment currently carrying a path is one this fixes.
-  console.warn(
-    `PUBLIC_BACKEND_URL must be an origin with no path — ignoring "${apiConfiguration.PUBLIC_BACKEND_URL_PATH_IGNORED}" and using ${apiConfiguration.PUBLIC_BACKEND_URL}`,
   );
 }
 

--- a/packages/configuration/src/api.configuration.ts
+++ b/packages/configuration/src/api.configuration.ts
@@ -18,7 +18,7 @@ const apiConfiguration = {
   FRONTEND_URL: process.env.FRONTEND_URL!,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
-  PUBLIC_BACKEND_URL: process.env.PUBLIC_BACKEND_URL,
+  PUBLIC_BACKEND_URL: process.env.BACKEND_URL,
   REDIS_URL: process.env.REDIS_URL!,
   // ── Temporal (durable background jobs / orchestrator) ──
   // Plain gRPC address of the self-hosted Temporal frontend. For local dev,
@@ -363,10 +363,6 @@ if (!isFiniteAtLeast(apiConfiguration.TRANSCRIPTION_CREDIT_PROFIT_MARGIN, 1)) {
 
 if (!apiConfiguration.PUBLIC_BACKEND_URL) {
   errors.push("PUBLIC_BACKEND_URL is not defined");
-} else if (!/^https?:\/\//.test(apiConfiguration.PUBLIC_BACKEND_URL)) {
-  errors.push(
-    `PUBLIC_BACKEND_URL is not a valid http(s) address: "${apiConfiguration.PUBLIC_BACKEND_URL}"`,
-  );
 }
 
 if (!apiConfiguration.WHATSAPP_VERIFY_TOKEN) {

--- a/packages/configuration/src/api.configuration.ts
+++ b/packages/configuration/src/api.configuration.ts
@@ -8,6 +8,40 @@ const nonNegativeInteger = (name: string, fallback: number): number => {
   return Number.isInteger(value) && value >= 0 ? value : fallback;
 };
 
+/**
+ * The origin the outside world reaches this backend on.
+ *
+ * Everything that hands a URL to a provider builds it as `<base>/api/...` —
+ * `api` is this app's global prefix — so the base has to be an origin and
+ * nothing more. A value carrying a path (`https://api.example.com/public`)
+ * produces URLs that 404 on every single provider callback: the agent's tools,
+ * the call status callback, the post-call analysis webhook and the calling
+ * application's event webhook all break at once, and none of them report the
+ * failure anywhere a person looks. The path is dropped here rather than
+ * concatenated, and `PUBLIC_BACKEND_URL_PATH_IGNORED` says so at boot.
+ */
+const publicBackendUrl = (): { origin: string; discardedPath: string } => {
+  const raw = process.env.PUBLIC_BACKEND_URL?.trim() ?? "";
+  if (!raw) return { origin: "", discardedPath: "" };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    // Not a URL at all. Handed through untouched so the "is not a valid
+    // address" check below is what reports it, with the value the operator set.
+    return { origin: raw.replace(/\/+$/, ""), discardedPath: "" };
+  }
+
+  const path = `${parsed.pathname}${parsed.search}${parsed.hash}`.replace(
+    /^\/+$/,
+    "",
+  );
+  return { origin: parsed.origin, discardedPath: path };
+};
+
+const PUBLIC_BACKEND = publicBackendUrl();
+
 const apiConfiguration = {
   PORT: process.env.PORT || 3000,
   DATABASE_URL: process.env.DATABASE_URL!,
@@ -19,12 +53,15 @@ const apiConfiguration = {
   OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
   /**
-   * Where the outside world reaches this backend. Trimmed on the way in
-   * because it is concatenated into the webhook and tool URLs handed to
-   * providers: a stray space in the env file yields a URL the provider
-   * rejects, and that failure surfaces far from its cause.
+   * Where the outside world reaches this backend. Normalized to a bare origin
+   * on the way in because it is concatenated into the webhook and tool URLs
+   * handed to providers: a stray space — or a path segment — yields a URL the
+   * provider calls and Ringee answers 404 to, and that failure surfaces far
+   * from its cause. See `publicBackendUrl`.
    */
-  PUBLIC_BACKEND_URL: process.env.PUBLIC_BACKEND_URL?.trim() ?? "",
+  PUBLIC_BACKEND_URL: PUBLIC_BACKEND.origin,
+  /** The path `PUBLIC_BACKEND_URL` carried, if any. Reported at boot. */
+  PUBLIC_BACKEND_URL_PATH_IGNORED: PUBLIC_BACKEND.discardedPath,
   REDIS_URL: process.env.REDIS_URL!,
   // ── Temporal (durable background jobs / orchestrator) ──
   // Plain gRPC address of the self-hosted Temporal frontend. For local dev,
@@ -369,6 +406,18 @@ if (!isFiniteAtLeast(apiConfiguration.TRANSCRIPTION_CREDIT_PROFIT_MARGIN, 1)) {
 
 if (!apiConfiguration.PUBLIC_BACKEND_URL) {
   errors.push("PUBLIC_BACKEND_URL is not defined");
+} else if (!/^https?:\/\//.test(apiConfiguration.PUBLIC_BACKEND_URL)) {
+  errors.push(
+    `PUBLIC_BACKEND_URL is not a valid http(s) address: "${apiConfiguration.PUBLIC_BACKEND_URL}"`,
+  );
+} else if (apiConfiguration.PUBLIC_BACKEND_URL_PATH_IGNORED) {
+  // Loud, but not fatal. The value is recoverable — the origin is right and
+  // the path has already been dropped — and refusing to boot over it would
+  // turn a set of broken callback URLs into a backend that is not there at
+  // all. Every environment currently carrying a path is one this fixes.
+  console.warn(
+    `PUBLIC_BACKEND_URL must be an origin with no path — ignoring "${apiConfiguration.PUBLIC_BACKEND_URL_PATH_IGNORED}" and using ${apiConfiguration.PUBLIC_BACKEND_URL}`,
+  );
 }
 
 if (!apiConfiguration.WHATSAPP_VERIFY_TOKEN) {

--- a/packages/database/src/database/repositories/ai-voice-agent-call.repository.ts
+++ b/packages/database/src/database/repositories/ai-voice-agent-call.repository.ts
@@ -146,21 +146,43 @@ export class AiVoiceAgentCallRepository {
    * `Call` row (`totalCost`), the same one the cost webhook claims, so the two
    * halves of an agent call are settled by whichever path gets there first and
    * neither can strand the other.
+   *
+   * A call still sitting in a dialing state is outstanding work as well, even
+   * once every penny of it is settled. Nobody is on Ringee's end of an agent
+   * leg, so the provider's status callback is the only thing that would ever
+   * move it — and a call whose callback never arrived is stuck at `initiating`
+   * with its money already taken, which no other list would ever pick up
+   * again. Bounded by `stalledAfter` so a call the provider will never report
+   * on stops being chased instead of holding a slot in the sweep forever.
    */
-  listUnsettled(olderThan: Date, take = 50): Promise<AiVoiceAgentCall[]> {
+  listUnsettled(
+    window: { updatedBefore: Date; stalledAfter: Date },
+    take = 50,
+  ): Promise<AiVoiceAgentCall[]> {
     return this.prisma.aiVoiceAgentCall.findMany({
       where: {
         OR: [
           { providerConversationId: { not: null } },
           { providerCallControlId: { not: null } },
         ],
-        updatedAt: { lt: olderThan },
+        updatedAt: { lt: window.updatedBefore },
         AND: [
           {
             OR: [
               { costSettledAt: null },
               { aiCostDebitedAt: null },
               { call: { is: { totalCost: null } } },
+              {
+                status: {
+                  in: [
+                    AiVoiceAgentCallStatus.created,
+                    AiVoiceAgentCallStatus.initiating,
+                    AiVoiceAgentCallStatus.ringing,
+                    AiVoiceAgentCallStatus.in_progress,
+                  ],
+                },
+                createdAt: { gte: window.stalledAfter },
+              },
             ],
           },
         ],

--- a/packages/database/src/database/repositories/call.repository.ts
+++ b/packages/database/src/database/repositories/call.repository.ts
@@ -333,8 +333,14 @@ export class CallRepository {
    */
   async completeCall(
     callControlId: string,
-    startedAt: string,
-    endedAt: string,
+    /**
+     * When the leg was placed, if the provider reported it. Null keeps the
+     * `startedAt` the row already has: a caller that substitutes "now" for a
+     * timestamp the provider never sent turns every call into a zero-second
+     * one, and the duration below is computed from exactly these two values.
+     */
+    startedAt: string | Date | null | undefined,
+    endedAt: string | Date | null | undefined,
     hangupCause?: string,
   ): Promise<Call | null> {
     const call = await this.findByControlId(callControlId);
@@ -382,9 +388,9 @@ export class CallRepository {
   }
 
   /** `null` for a missing/unparseable provider timestamp. */
-  private parseDate(value: string | null | undefined): Date | null {
+  private parseDate(value: string | Date | null | undefined): Date | null {
     if (!value) return null;
-    const parsed = new Date(value);
+    const parsed = value instanceof Date ? value : new Date(value);
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
 

--- a/packages/platform/src/voice-agents/interfaces/voice-agent.provider.ts
+++ b/packages/platform/src/voice-agents/interfaces/voice-agent.provider.ts
@@ -101,6 +101,16 @@ export interface VoiceAgentAssistant {
   callingAppId: string | null;
   /** Whether an unauthenticated browser may currently talk to this agent. */
   unauthenticatedWebCallsEnabled: boolean;
+  /**
+   * Where the assistant currently calls Ringee back for its tools.
+   *
+   * Stored provider-side at the last save, so it goes stale the moment
+   * `PUBLIC_BACKEND_URL` changes — and a stale tool URL is not a degraded
+   * agent, it is one that says "I am having a technical problem" and books
+   * nothing. The dial path compares these against the current base so it can
+   * re-sync before the call instead of after the complaint.
+   */
+  toolWebhookUrls: string[];
 }
 
 export interface VoiceAgentCallRequest {
@@ -236,8 +246,23 @@ export interface VoiceAgentUsageRecord {
   kind: "telephony" | "voice_agent" | "inference";
   conversationId: string | null;
   callControlId: string | null;
+  /**
+   * The provider's own session handle for the leg, when the record names one.
+   * It is the only place a `telephony` record reports it, and it is what the
+   * recording of the same call is filed under.
+   */
+  callSessionId: string | null;
   costUsd: number;
   billedSeconds: number | null;
+  /**
+   * Seconds the two ends were actually connected, as the provider measured
+   * them. Zero on a leg that never answered — which is what distinguishes a
+   * failed attempt from the leg that carried the conversation.
+   */
+  connectedSeconds: number | null;
+  /** When the leg was placed and when it ended, per the provider's records. */
+  startedAt: Date | null;
+  endedAt: Date | null;
   occurredAt: Date | null;
 }
 
@@ -256,6 +281,37 @@ export interface VoiceAgentUsageQuery {
  * is not a delivery Ringee can rely on. `downloadUrl` is short-lived and signed
  * by the provider — fetch it now, never store it.
  */
+/**
+ * Which call to read recordings for.
+ *
+ * Both handles are accepted because only one of them is reliably known. A
+ * provider-placed agent leg reports a call control id when it is created and a
+ * session id only later, on an event Ringee may never receive — so a lookup
+ * that insists on the session id finds nothing for calls that were recorded
+ * perfectly well.
+ */
+export interface VoiceAgentRecordingQuery {
+  callControlId?: string | null;
+  callSessionId?: string | null;
+}
+
+/**
+ * A conversation the provider ran, as Ringee needs it: the handles that tie it
+ * back to a call.
+ *
+ * Post-call analysis names the conversation and nothing else, so this is the
+ * way back from a delivered analysis to the call it belongs to when the
+ * conversation was never bound to the row — the one event that would have
+ * bound it is also the one that may never arrive.
+ */
+export interface VoiceAgentConversation {
+  conversationId: string;
+  assistantId: string | null;
+  callControlId: string | null;
+  callSessionId: string | null;
+  callLegId: string | null;
+}
+
 export interface VoiceAgentRecording {
   providerRecordingId: string;
   callControlId: string | null;
@@ -398,7 +454,19 @@ export interface VoiceAgentProvider {
    * a recording is finalized after the call ends, so an early read is not
    * proof the call went unrecorded.
    */
-  fetchRecordings(callSessionId: string): Promise<VoiceAgentRecording[]>;
+  fetchRecordings(
+    query: VoiceAgentRecordingQuery,
+  ): Promise<VoiceAgentRecording[]>;
+
+  /**
+   * One conversation's handles. Null when the provider does not know it.
+   *
+   * Read on the recovery paths only: it is what turns a conversation id — all
+   * a post-call analysis carries — back into the call that produced it.
+   */
+  fetchConversation(
+    conversationId: string,
+  ): Promise<VoiceAgentConversation | null>;
 
   // ── Knowledge bases ──
   // A store holds one agent's documents; indexing it is asynchronous, so every

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.test.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.test.ts
@@ -162,6 +162,7 @@ describe("toVoiceAgentAssistant", () => {
       assistantId: "assistant-1",
       callingAppId: "3035069911979263363",
       unauthenticatedWebCallsEnabled: true,
+      toolWebhookUrls: [],
     });
   });
 
@@ -169,6 +170,28 @@ describe("toVoiceAgentAssistant", () => {
     const assistant = toVoiceAgentAssistant({ id: "assistant-2" });
     expect(assistant.callingAppId).toBeNull();
     expect(assistant.unauthenticatedWebCallsEnabled).toBe(false);
+  });
+
+  // Where the assistant currently calls Ringee back. The dial path compares
+  // these against the configured base so an agent whose tools were written
+  // against an old address is re-synced before it dials, instead of holding a
+  // whole conversation and then failing to book.
+  it("reports the webhook tools' urls and ignores the other tool kinds", () => {
+    const assistant = toVoiceAgentAssistant({
+      id: "assistant-3",
+      tools: [
+        {
+          type: "webhook",
+          webhook: { url: "https://api.ringee.io/api/x/available-slots" },
+        },
+        { type: "hangup" },
+        { type: "retrieval" },
+        { type: "webhook", webhook: { url: null } },
+      ],
+    });
+    expect(assistant.toolWebhookUrls).toEqual([
+      "https://api.ringee.io/api/x/available-slots",
+    ]);
   });
 });
 

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.ts
@@ -22,6 +22,10 @@ import type {
 export interface TelnyxAssistantResponse {
   id: string;
   name?: string;
+  tools?: Array<{
+    type?: string | null;
+    webhook?: { url?: string | null } | null;
+  }> | null;
   telephony_settings?: {
     default_texml_app_id?: string | null;
     supports_unauthenticated_web_calls?: boolean | null;
@@ -192,6 +196,10 @@ export function toVoiceAgentAssistant(
     callingAppId: raw.telephony_settings?.default_texml_app_id ?? null,
     unauthenticatedWebCallsEnabled:
       raw.telephony_settings?.supports_unauthenticated_web_calls ?? false,
+    toolWebhookUrls: (raw.tools ?? []).flatMap((tool) => {
+      const url = str(tool?.webhook?.url);
+      return tool?.type === "webhook" && url ? [url] : [];
+    }),
   };
 }
 

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.service.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.service.ts
@@ -7,12 +7,14 @@ import type {
   VoiceAgentCallingAppSettings,
   VoiceAgentCallRequest,
   VoiceAgentConfig,
+  VoiceAgentConversation,
   VoiceAgentEmbeddingStatus,
   VoiceAgentInsightDefinition,
   VoiceAgentInsightDelivery,
   VoiceAgentInsightGroupSettings,
   VoiceAgentProvider,
   VoiceAgentRecording,
+  VoiceAgentRecordingQuery,
   VoiceAgentTranscriptTurn,
   VoiceAgentUsageQuery,
   VoiceAgentUsageRecord,
@@ -54,6 +56,13 @@ const USAGE_PAGE_SIZE = 50;
 /** Transcript paging. The provider caps a page at 100 messages. */
 const TRANSCRIPT_PAGE_SIZE = 100;
 const TRANSCRIPT_MAX_PAGES = 20;
+
+/** A provider timestamp, or null when it is absent or unparseable. */
+function toDate(raw: unknown): Date | null {
+  if (typeof raw !== "string" || !raw) return null;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
 
 interface UsageRecordType {
   recordType: string;
@@ -522,6 +531,43 @@ export class TelnyxVoiceAgentService implements VoiceAgentProvider {
     return turns;
   }
 
+  /**
+   * The handles Telnyx keeps on a conversation.
+   *
+   * Telnyx stores the call it belonged to under `metadata`, which is the only
+   * route back from a conversation id to a call — and a post-call analysis
+   * carries a conversation id and nothing else.
+   */
+  async fetchConversation(
+    conversationId: string,
+  ): Promise<VoiceAgentConversation | null> {
+    try {
+      const raw = await this.telnyxClient.get<{
+        data?: {
+          id?: string;
+          metadata?: Record<string, unknown> | null;
+        };
+      }>(`/ai/conversations/${conversationId}`);
+      const body = raw?.data;
+      if (!body?.id) return null;
+
+      const metadata = (body.metadata ?? {}) as Record<string, unknown>;
+      const text = (value: unknown): string | null =>
+        typeof value === "string" && value ? value : null;
+
+      return {
+        conversationId: body.id,
+        assistantId: text(metadata.assistant_id),
+        callControlId: text(metadata.call_control_id),
+        callSessionId: text(metadata.call_session_id),
+        callLegId: text(metadata.call_leg_id),
+      };
+    } catch (error) {
+      if (this.isNotFound(error)) return null;
+      throw error;
+    }
+  }
+
   // ── Usage ────────────────────────────────────────────────────
 
   /**
@@ -577,10 +623,21 @@ export class TelnyxVoiceAgentService implements VoiceAgentProvider {
         kind: type.kind,
         conversationId: row.conversation_id ?? null,
         callControlId: row.call_control_id ?? null,
+        // Telnyx names the call session `telnyx_session_id` on a detail record
+        // and nothing else on it names the session at all — which makes this
+        // the only place a provider-placed agent leg ever reports the handle
+        // its recording is filed under.
+        callSessionId: row.telnyx_session_id ?? row.call_session_id ?? null,
         costUsd: Number.parseFloat(row.cost ?? "0") || 0,
         billedSeconds:
           typeof row.billed_sec === "number" ? row.billed_sec : null,
-        occurredAt: row.created_at ? new Date(row.created_at) : null,
+        // `call_sec` is time on the call, not time billed: a leg that was
+        // refused reports zero here while still reporting a billed minute.
+        connectedSeconds:
+          typeof row.call_sec === "number" ? row.call_sec : null,
+        startedAt: toDate(row.started_at),
+        endedAt: toDate(row.finished_at),
+        occurredAt: toDate(row.created_at) ?? toDate(row.started_at),
       }));
     } catch (error) {
       // One record type being unavailable must not hide the others; the caller
@@ -602,9 +659,21 @@ export class TelnyxVoiceAgentService implements VoiceAgentProvider {
    * so an agent call whose recording never arrived is the normal case rather
    * than the exceptional one.
    */
-  async fetchRecordings(callSessionId: string): Promise<VoiceAgentRecording[]> {
+  async fetchRecordings(
+    query: VoiceAgentRecordingQuery,
+  ): Promise<VoiceAgentRecording[]> {
     const params = new URLSearchParams();
-    params.set("filter[call_session_id]", callSessionId);
+    // Control id first: it is the handle Ringee holds from the moment the leg
+    // is placed. The session id only ever arrives on an event, so filtering on
+    // it answers "no recordings" for calls that were recorded perfectly well —
+    // which is exactly how agent-call audio went missing.
+    if (query.callControlId) {
+      params.set("filter[call_control_id]", query.callControlId);
+    } else if (query.callSessionId) {
+      params.set("filter[call_session_id]", query.callSessionId);
+    } else {
+      return [];
+    }
 
     const raw = await this.telnyxClient.get<{ data?: Record<string, any>[] }>(
       `/recordings?${params.toString()}`,

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.usage.test.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.usage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 import { TelnyxVoiceAgentService } from "./telnyx.voice-agent.service";
 import type { TelnyxClient } from "../../telephony/telnyx/telnyx.client";
 import type { TelnyxKnowledgeStore } from "./telnyx.knowledge.store";
@@ -91,6 +91,68 @@ describe("TelnyxVoiceAgentService usage records", () => {
     expect(records[1].conversationId).toBe("conv-1");
   });
 
+  it("reads the leg's timeline off the record that has one", async () => {
+    // Live shape, from a real agent call: the voice leg is the only record
+    // that carries a start, an end and time actually connected — the engine
+    // record reports none of the three — and `created_at` comes back null, so
+    // the leg's own start is what dates it.
+    const { service } = build({
+      "sip-trunking": [
+        {
+          call_control_id: "v3:cc-1",
+          telnyx_session_id: "cb647cc6-a61b-11f1-b5a0-02420a0dfb1f",
+          cost: "0.265",
+          billed_sec: 120,
+          call_sec: 97,
+          started_at: "2026-09-01T15:42:54Z",
+          finished_at: "2026-09-01T15:44:38Z",
+          created_at: null,
+          hangup_cause: "NORMAL_CLEARING",
+        },
+      ],
+    });
+
+    const [leg] = await service.fetchUsageRecords({ callControlId: "v3:cc-1" });
+
+    assert(leg);
+    expect(leg.connectedSeconds).toBe(97);
+    // Not the billed minute: what the two ends actually spent connected is
+    // what tells a conversation apart from a leg nobody picked up.
+    expect(leg.billedSeconds).toBe(120);
+    expect(leg.startedAt).toEqual(new Date("2026-09-01T15:42:54Z"));
+    expect(leg.endedAt).toEqual(new Date("2026-09-01T15:44:38Z"));
+    expect(leg.occurredAt).toEqual(new Date("2026-09-01T15:42:54Z"));
+    // The session the recording is filed under — named here and nowhere else.
+    expect(leg.callSessionId).toBe("cb647cc6-a61b-11f1-b5a0-02420a0dfb1f");
+  });
+
+  it("reports no timeline for a record that carries none", async () => {
+    // The engine record prices the conversation and knows nothing about the
+    // leg's clock. Reading zero out of it would close the call at once.
+    const { service } = build({
+      "ai-voice-assistant": [
+        {
+          call_control_id: "v3:cc-1",
+          conversation_id: "conv-1",
+          cost: "0.1",
+          billed_sec: 120,
+          call_sec: null,
+          started_at: null,
+          finished_at: null,
+        },
+      ],
+    });
+
+    const [engine] = await service.fetchUsageRecords({
+      callControlId: "v3:cc-1",
+    });
+
+    assert(engine);
+    expect(engine.connectedSeconds).toBeNull();
+    expect(engine.startedAt).toBeNull();
+    expect(engine.endedAt).toBeNull();
+  });
+
   it("keeps the other record types when one of them fails", async () => {
     const get = vi.fn(async (path: string) => {
       if (path.includes("sip-trunking")) throw new Error("upstream is down");
@@ -140,10 +202,12 @@ describe("TelnyxVoiceAgentService recordings", () => {
       {} as TelnyxKnowledgeStore,
     );
 
-    const recordings = await service.fetchRecordings("cs-1");
+    const recordings = await service.fetchRecordings({
+      callControlId: "v3:cc-1",
+    });
 
     expect(get).toHaveBeenCalledWith(
-      "/recordings?filter%5Bcall_session_id%5D=cs-1",
+      "/recordings?filter%5Bcall_control_id%5D=v3%3Acc-1",
     );
     expect(recordings).toEqual([
       {

--- a/packages/platform/src/voice-agents/voice-agent-provider.service.ts
+++ b/packages/platform/src/voice-agents/voice-agent-provider.service.ts
@@ -5,12 +5,14 @@ import type {
   VoiceAgentCallingAppSettings,
   VoiceAgentCallRequest,
   VoiceAgentConfig,
+  VoiceAgentConversation,
   VoiceAgentEmbeddingStatus,
   VoiceAgentInsightDefinition,
   VoiceAgentInsightDelivery,
   VoiceAgentInsightGroupSettings,
   VoiceAgentProvider,
   VoiceAgentRecording,
+  VoiceAgentRecordingQuery,
   VoiceAgentTranscriptTurn,
   VoiceAgentUsageQuery,
   VoiceAgentUsageRecord,
@@ -143,8 +145,16 @@ export class VoiceAgentProviderService implements VoiceAgentProvider {
     return this.getServiceProvider().fetchUsageRecords(query);
   }
 
-  fetchRecordings(callSessionId: string): Promise<VoiceAgentRecording[]> {
-    return this.getServiceProvider().fetchRecordings(callSessionId);
+  fetchRecordings(
+    query: VoiceAgentRecordingQuery,
+  ): Promise<VoiceAgentRecording[]> {
+    return this.getServiceProvider().fetchRecordings(query);
+  }
+
+  fetchConversation(
+    conversationId: string,
+  ): Promise<VoiceAgentConversation | null> {
+    return this.getServiceProvider().fetchConversation(conversationId);
   }
 
   createKnowledgeStore(store: string): Promise<void> {

--- a/packages/services/src/services/sip-device/sip-device.service.ts
+++ b/packages/services/src/services/sip-device/sip-device.service.ts
@@ -384,7 +384,7 @@ export class SipDeviceService {
   }
 
   private deskPhoneWebhookUrl(): string {
-    const base = apiConfiguration.PUBLIC_BACKEND_URL.replace(/\/+$/, "");
+    const base = apiConfiguration.PUBLIC_BACKEND_URL!.replace(/\/+$/, "");
     return `${base}/api/webhooks/telnyx/desk-phone`;
   }
 

--- a/packages/services/src/services/voice-agents/voice-agent-billing.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-billing.service.spec.ts
@@ -52,22 +52,40 @@ function repository(row: Record<string, unknown> = AGENT_CALL) {
 
 type Kind = "telephony" | "voice_agent" | "inference";
 
+interface UsageRow {
+  costUsd: number;
+  kind?: Kind;
+  /** Seconds the two ends were connected. Zero on a leg nobody picked up. */
+  connectedSeconds?: number;
+  startedAt?: Date | null;
+  endedAt?: Date | null;
+  callSessionId?: string | null;
+}
+
 function provider(
-  records: Array<{ costUsd: number; kind?: Kind }>,
+  records: UsageRow[],
   recordings: Array<{ downloadUrl: string | null }> = [],
 ) {
+  /** What the recording lookup was filtered on. */
+  const recordingQueries: Array<Record<string, unknown>> = [];
   return {
+    recordingQueries,
     fetchUsageRecords: async () =>
       records.map((r) => ({
         kind: r.kind ?? ("voice_agent" as const),
         conversationId: "conv-1",
         callControlId: "cc-1",
+        callSessionId: r.callSessionId ?? null,
         costUsd: r.costUsd,
         billedSeconds: 60,
+        connectedSeconds: r.connectedSeconds ?? null,
+        startedAt: r.startedAt ?? null,
+        endedAt: r.endedAt ?? null,
         occurredAt: new Date(),
       })),
-    fetchRecordings: async () =>
-      recordings.map((r, index) => ({
+    fetchRecordings: async (query: Record<string, unknown>) => {
+      recordingQueries.push(query);
+      return recordings.map((r, index) => ({
         providerRecordingId: `rec-${index}`,
         callControlId: "cc-1",
         callSessionId: "cs-1",
@@ -76,7 +94,8 @@ function provider(
         startedAt: new Date(),
         endedAt: new Date(),
         durationMillis: 1000,
-      })),
+      }));
+    },
   };
 }
 
@@ -92,8 +111,15 @@ function callRepository(
   },
 ) {
   const costs: Array<{ totalCost: number; meta: Record<string, unknown> }> = [];
+  const attached: Array<Record<string, unknown>> = [];
+  const completed: Array<{
+    startedAt: Date | null | undefined;
+    endedAt: Date | null | undefined;
+  }> = [];
   return {
     costs,
+    attached,
+    completed,
     call,
     findById: async () => call,
     updateCost: async (
@@ -103,6 +129,20 @@ function callRepository(
     ) => {
       if (call) call.totalCost = totalCost;
       costs.push({ totalCost, meta });
+      return call;
+    },
+    attachTelephony: async (id: string, data: Record<string, unknown>) => {
+      Object.assign(call ?? {}, data);
+      attached.push({ id, ...data });
+      return call;
+    },
+    completeCall: async (
+      _controlId: string,
+      startedAt: Date | null | undefined,
+      endedAt: Date | null | undefined,
+    ) => {
+      if (call) call.endedAt = endedAt ?? null;
+      completed.push({ startedAt, endedAt });
       return call;
     },
   };
@@ -139,6 +179,32 @@ function build(options: {
     {
       recoverTranscript: async (agentCall: { id: string }) => {
         transcribed.push(agentCall.id);
+      },
+      // The real one writes the conversation onto the agent call and the
+      // session onto the telephony row, and hands back the row to keep
+      // working from. Both writes are what later reads are keyed on.
+      bindConversation: async (
+        agentCall: { id: string; callId: string | null },
+        conversation: {
+          conversationId: string | null;
+          callSessionId?: string | null;
+        },
+      ) => {
+        if (conversation.conversationId && !repo.state.providerConversationId) {
+          await repo.update(agentCall.id, {
+            providerConversationId: conversation.conversationId,
+          });
+        }
+        if (agentCall.callId && conversation.callSessionId) {
+          const call = await calls.findById();
+          if (call && !call.callSessionId) {
+            await calls.attachTelephony(call.id as string, {
+              callControlId: call.callControlId,
+              callSessionId: conversation.callSessionId,
+            });
+          }
+        }
+        return repo.state;
       },
     } as never,
   );
@@ -476,6 +542,246 @@ describe("VoiceAgentBillingService", () => {
     });
   });
 
+  /**
+   * An agent call has nobody on Ringee's end of the leg, so nothing but the
+   * provider's status callback ever writes its timeline — and that callback is
+   * a delivery like any other. The records that price the call also say when it
+   * started, when it ended and whether it ever connected, so the read that
+   * settles the money settles the timeline with it.
+   */
+  describe("the call's timeline", () => {
+    const STARTED = new Date("2026-09-01T11:42:00.000Z");
+    const ENDED = new Date("2026-09-01T11:43:27.000Z");
+
+    const pending = () =>
+      callRepository({
+        id: "telephony-1",
+        userId: "user-1",
+        organizationId: "org-1",
+        callControlId: "cc-1",
+        callSessionId: "cs-1",
+        status: "pending",
+        answeredAt: null,
+        endedAt: null,
+        totalCost: null,
+      });
+
+    const linked = () =>
+      repository({
+        ...AGENT_CALL,
+        callId: "telephony-1",
+        status: "initiating",
+      });
+
+    it("closes a call whose status callback never arrived", async () => {
+      const calls = pending();
+      const repo = linked();
+      const { service } = build({
+        repo,
+        calls,
+        provider: provider([
+          {
+            costUsd: 0.66,
+            kind: "telephony",
+            connectedSeconds: 87,
+            startedAt: STARTED,
+            endedAt: ENDED,
+          },
+          { costUsd: 0.1, kind: "voice_agent" },
+        ]),
+      });
+
+      await service.settle("call-1");
+
+      // Dated from the provider's own record of the leg, not from the moment
+      // the sweep happened to run — which is what made every agent call read
+      // as a zero-second one.
+      assert.deepEqual(calls.completed, [
+        { startedAt: STARTED, endedAt: ENDED },
+      ]);
+      // The answer has to be dated too: an absent `answeredAt` is exactly what
+      // `completeCall` reads to file a call as one nobody picked up.
+      const answered = calls.attached.find((write) => write.answeredAt);
+      assert.ok(answered);
+      assert.deepEqual(
+        answered.answeredAt,
+        new Date(ENDED.getTime() - 87 * 1000),
+      );
+      assert.equal(answered.status, "answered");
+      // And the agent call leaves its dialing state, which is what the
+      // artifact sweep looks for.
+      assert.equal(repo.state.status, "completed");
+    });
+
+    it("files a leg nobody picked up as a no-answer", async () => {
+      // A refused leg reports an end time and a charge like any other. What
+      // tells it apart is that the two ends were never connected.
+      const calls = pending();
+      const repo = linked();
+      const { service } = build({
+        repo,
+        calls,
+        provider: provider([
+          {
+            costUsd: 0.02,
+            kind: "telephony",
+            connectedSeconds: 0,
+            startedAt: STARTED,
+            endedAt: ENDED,
+          },
+        ]),
+      });
+
+      await service.settle("call-1");
+
+      assert.deepEqual(calls.completed, [
+        { startedAt: STARTED, endedAt: ENDED },
+      ]);
+      assert.equal(
+        calls.attached.find((write) => write.answeredAt),
+        undefined,
+      );
+      assert.equal(repo.state.status, "no_answer");
+    });
+
+    it("leaves a call the callback already closed exactly as it is", async () => {
+      // The callback saw the leg; this only reads about it afterwards.
+      const calls = callRepository({
+        id: "telephony-1",
+        userId: "user-1",
+        organizationId: "org-1",
+        callControlId: "cc-1",
+        callSessionId: "cs-1",
+        status: "completed",
+        answeredAt: STARTED,
+        endedAt: ENDED,
+        totalCost: null,
+      });
+      const { service } = build({
+        repo: repository({
+          ...AGENT_CALL,
+          callId: "telephony-1",
+          status: "completed",
+        }),
+        calls,
+        provider: provider([
+          {
+            costUsd: 0.66,
+            kind: "telephony",
+            connectedSeconds: 87,
+            startedAt: STARTED,
+            endedAt: ENDED,
+          },
+        ]),
+      });
+
+      await service.settle("call-1");
+
+      assert.deepEqual(calls.completed, []);
+      assert.deepEqual(calls.attached, []);
+    });
+
+    it("waits rather than closing a call the provider has not finished", async () => {
+      // A leg still in progress is published without an end. Closing it from
+      // that would freeze the duration at whatever the sweep saw.
+      const calls = pending();
+      const repo = linked();
+      const { service } = build({
+        repo,
+        calls,
+        provider: provider([
+          { costUsd: 0.66, kind: "telephony", connectedSeconds: 12 },
+        ]),
+      });
+
+      await service.settle("call-1");
+
+      assert.deepEqual(calls.completed, []);
+      assert.equal(repo.state.status, "initiating");
+    });
+
+    it("closes a call whose money was already fully settled", async () => {
+      // The state the reported call was in: priced, debited, and still
+      // reading `pending` — because the two are settled by different things
+      // and only one of them ever ran. A pass that stopped at "nothing is
+      // owed" would leave it that way for good.
+      const calls = callRepository({
+        id: "telephony-1",
+        userId: "user-1",
+        organizationId: "org-1",
+        callControlId: "cc-1",
+        callSessionId: "cs-1",
+        status: "pending",
+        answeredAt: null,
+        endedAt: null,
+        totalCost: 0.66,
+      });
+      const repo = repository({
+        ...AGENT_CALL,
+        callId: "telephony-1",
+        status: "initiating",
+        costSettledAt: new Date(),
+        aiCostDebitedAt: new Date(),
+        aiCostUsd: 0.1,
+        aiChargedCredits: 0.2,
+      });
+      const { service } = build({
+        repo,
+        calls,
+        provider: provider([
+          {
+            costUsd: 0.265,
+            kind: "telephony",
+            connectedSeconds: 97,
+            startedAt: STARTED,
+            endedAt: ENDED,
+          },
+        ]),
+      });
+
+      await service.settle("call-1");
+
+      assert.deepEqual(calls.completed, [
+        { startedAt: STARTED, endedAt: ENDED },
+      ]);
+      assert.equal(repo.state.status, "completed");
+    });
+
+    it("takes the connected leg's answer when an earlier attempt failed", async () => {
+      // Two records, one call: the attempt that was refused and the one that
+      // carried the conversation.
+      const calls = pending();
+      const { service } = build({
+        repo: linked(),
+        calls,
+        provider: provider([
+          {
+            costUsd: 0.02,
+            kind: "telephony",
+            connectedSeconds: 0,
+            startedAt: STARTED,
+            endedAt: new Date(STARTED.getTime() + 8000),
+          },
+          {
+            costUsd: 0.66,
+            kind: "telephony",
+            connectedSeconds: 87,
+            startedAt: new Date(STARTED.getTime() + 10000),
+            endedAt: ENDED,
+          },
+        ]),
+      });
+
+      await service.settle("call-1");
+
+      // The whole span of the call, and the answer that actually happened.
+      assert.deepEqual(calls.completed, [
+        { startedAt: STARTED, endedAt: ENDED },
+      ]);
+      assert.ok(calls.attached.find((write) => write.answeredAt));
+    });
+  });
+
   describe("the recording", () => {
     const linked = () => repository({ ...AGENT_CALL, callId: "telephony-1" });
 
@@ -495,6 +801,55 @@ describe("VoiceAgentBillingService", () => {
         (processed[0] as { recording: { publicUrl: string } }).recording
           .publicUrl,
         "https://provider.example/rec.mp3",
+      );
+    });
+
+    it("looks the recording up by the handle the dial path wrote down", async () => {
+      // A provider-placed agent leg reports its session only on an event
+      // Ringee may never receive. Filtering on the session answered "no
+      // recording" for every agent call ever made, while the audio sat on the
+      // provider under the control id.
+      const providerDouble = provider(
+        [{ costUsd: 0.1, kind: "voice_agent" }],
+        [{ downloadUrl: "https://provider.example/rec.mp3" }],
+      );
+      const { service } = build({
+        repo: linked(),
+        provider: providerDouble,
+      });
+
+      await service.settle("call-1");
+
+      assert.equal(providerDouble.recordingQueries.length, 1);
+      assert.equal(providerDouble.recordingQueries[0]!.callControlId, "cc-1");
+    });
+
+    it("writes down the session the recording is filed under", async () => {
+      // The recording is one of the few places the session handle is ever
+      // reported. Keeping it is what makes every session-keyed read of this
+      // call find it.
+      const calls = callRepository({
+        id: "telephony-1",
+        userId: "user-1",
+        organizationId: "org-1",
+        callControlId: "cc-1",
+        callSessionId: null,
+        totalCost: null,
+      });
+      const { service } = build({
+        repo: linked(),
+        calls,
+        provider: provider(
+          [{ costUsd: 0.1, kind: "voice_agent" }],
+          [{ downloadUrl: "https://provider.example/rec.mp3" }],
+        ),
+      });
+
+      await service.settle("call-1");
+
+      assert.ok(
+        calls.attached.some((write) => write.callSessionId === "cs-1"),
+        "the session handle the recording reported was not kept",
       );
     });
 

--- a/packages/services/src/services/voice-agents/voice-agent-billing.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-billing.service.ts
@@ -3,7 +3,9 @@ import { apiConfiguration } from "@ringee/configuration";
 import {
   AiVoiceAgentCall,
   AiVoiceAgentCallRepository,
+  AiVoiceAgentCallStatus,
   CallRepository,
+  CallStatus,
   RecordingRepository,
 } from "@ringee/database";
 import {
@@ -27,6 +29,16 @@ const USD_PRECISION = 1e6;
  */
 const ARTIFACT_RETRY_WINDOW_MS = 6 * 60 * 60 * 1000;
 const ARTIFACT_SETTLE_DELAY_MS = 2 * 60 * 1000;
+
+/**
+ * How far back the sweep goes for a call still sitting in a dialing state.
+ *
+ * Its money can be entirely settled while its status never moved — the status
+ * callback is the only thing that would have moved it — so it needs a reason
+ * to be revisited that is not "something is still owed". Bounded so a call the
+ * provider will never publish anything about stops being carried forever.
+ */
+const STALLED_CALL_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 export interface VoiceAgentSettlement {
   settled: boolean;
@@ -118,7 +130,11 @@ export class VoiceAgentBillingService {
     // The engine records name the conversation even when no webhook ever did.
     // Writing it down is what lets the token records — which carry no other
     // handle — be found on the next sweep, and what binds insights to the call.
-    const current = await this.bindConversation(agentCall, records);
+    let current = await this.bindConversation(agentCall, records);
+    // The same records say when the call started, when it ended and whether it
+    // ever connected. Closing the row from them is what stops an agent call
+    // whose status callback never arrived from reading as "pending" forever.
+    current = await this.settleCallLifecycle(current, records);
 
     const ai = await this.settleAiUsage(current, records);
     const telephonyCostUsd = await this.settleTelephonyLeg(current, records);
@@ -214,8 +230,116 @@ export class VoiceAgentBillingService {
    * enough to guarantee they were there.
    */
   listPending(olderThanMinutes = 5, take = 50): Promise<AiVoiceAgentCall[]> {
-    const cutoff = new Date(Date.now() - olderThanMinutes * 60_000);
-    return this.agentCalls.listUnsettled(cutoff, take);
+    const now = Date.now();
+    return this.agentCalls.listUnsettled(
+      {
+        updatedBefore: new Date(now - olderThanMinutes * 60_000),
+        stalledAfter: new Date(now - STALLED_CALL_WINDOW_MS),
+      },
+      take,
+    );
+  }
+
+  // ── The call's own timeline ──────────────────────────────────
+
+  /**
+   * Closes the telephony row from the provider's own records.
+   *
+   * The call status callback is a delivery like any other, and an agent call
+   * that never gets one sits at `pending` for the rest of its life: nobody is
+   * on Ringee's end of the leg, so no other event writes `Call.status`, and the
+   * stale-call sweep only reaches calls that made it as far as `ringing`. The
+   * records that price the call also say when it started, when it ended and how
+   * long the two ends were connected — so the read that settles the money
+   * settles the timeline too, and neither one waits on a webhook.
+   *
+   * Idempotent: a row that already has its ending is left exactly as the
+   * callback wrote it, because the callback saw the leg and this only reads
+   * about it.
+   */
+  private async settleCallLifecycle(
+    agentCall: AiVoiceAgentCall,
+    records: VoiceAgentUsageRecord[],
+  ): Promise<AiVoiceAgentCall> {
+    if (!agentCall.callId) return agentCall;
+
+    // Only the voice leg has a timeline; the engine and token records are
+    // aggregates with no start or end of their own.
+    const legs = records.filter(
+      (record) => record.kind === "telephony" && record.endedAt,
+    );
+    if (legs.length === 0) return agentCall;
+
+    const call = await this.calls.findById(agentCall.callId);
+    if (!call?.callControlId) return agentCall;
+
+    // A call can produce several legs — an attempt the far end refused before
+    // the one that connected. `connectedSeconds` is what tells them apart: it
+    // is zero on a refusal, which still reports an end time and still bills.
+    const connectedSeconds = Math.max(
+      0,
+      ...legs.map((leg) => leg.connectedSeconds ?? 0),
+    );
+    const endedAt = this.latest(legs.map((leg) => leg.endedAt));
+    const startedAt = this.earliest(legs.map((leg) => leg.startedAt));
+
+    // The answer is dated before the call is closed, and it has to be: an
+    // absent `answeredAt` is exactly what `completeCall` reads to disposition a
+    // call as a no-answer, which is how conversations that plainly happened
+    // were being filed as calls nobody picked up.
+    if (connectedSeconds > 0 && !call.answeredAt && endedAt) {
+      await this.calls.attachTelephony(call.id, {
+        callControlId: call.callControlId,
+        answeredAt: new Date(endedAt.getTime() - connectedSeconds * 1000),
+        ...(call.status === CallStatus.pending ||
+        call.status === CallStatus.ringing
+          ? { status: CallStatus.answered }
+          : {}),
+      });
+    }
+
+    if (!call.endedAt) {
+      await this.calls.completeCall(call.callControlId, startedAt, endedAt);
+      this.logger.log(
+        `⏱️ Agent call ${agentCall.id} closed from provider records (${connectedSeconds}s connected)`,
+      );
+    }
+
+    return this.settleAgentCallStatus(agentCall, connectedSeconds > 0);
+  }
+
+  /**
+   * Moves the agent call itself out of its dialing state, for the same reason:
+   * the status callback is what normally does it, and the artifact sweep only
+   * looks at calls that reached `completed`. One left at `initiating` is a call
+   * whose recording nothing ever goes back for.
+   */
+  private async settleAgentCallStatus(
+    agentCall: AiVoiceAgentCall,
+    answered: boolean,
+  ): Promise<AiVoiceAgentCall> {
+    const inFlight =
+      agentCall.status === AiVoiceAgentCallStatus.created ||
+      agentCall.status === AiVoiceAgentCallStatus.initiating ||
+      agentCall.status === AiVoiceAgentCallStatus.ringing ||
+      agentCall.status === AiVoiceAgentCallStatus.in_progress;
+    if (!inFlight) return agentCall;
+
+    return this.agentCalls.update(agentCall.id, {
+      status: answered
+        ? AiVoiceAgentCallStatus.completed
+        : AiVoiceAgentCallStatus.no_answer,
+    });
+  }
+
+  private earliest(dates: Array<Date | null>): Date | null {
+    const times = dates.flatMap((date) => (date ? [date.getTime()] : []));
+    return times.length ? new Date(Math.min(...times)) : null;
+  }
+
+  private latest(dates: Array<Date | null>): Date | null {
+    const times = dates.flatMap((date) => (date ? [date.getTime()] : []));
+    return times.length ? new Date(Math.max(...times)) : null;
   }
 
   // ── The AI half ──────────────────────────────────────────────
@@ -412,12 +536,29 @@ export class VoiceAgentBillingService {
       }
 
       const call = await this.calls.findById(agentCall.callId);
-      if (!call?.callSessionId || !call.callControlId) return;
+      if (!call?.callControlId) return;
 
-      const available = await this.provider.fetchRecordings(call.callSessionId);
+      // By control id, not session id. A provider-placed agent leg reports its
+      // session only on an event Ringee may never receive, so a lookup keyed on
+      // the session answered "no recording" for every agent call ever made —
+      // while the audio sat on the provider, findable by the handle the dial
+      // path already wrote down.
+      const available = await this.provider.fetchRecordings({
+        callControlId: call.callControlId,
+        callSessionId: call.callSessionId,
+      });
       const recording = available.find((item) => item.downloadUrl);
       // Finalized after the call ends, so "none yet" is not "never recorded".
       if (!recording?.downloadUrl) return;
+
+      // The recording is the other place the session handle is reported. Worth
+      // writing down: it is how every session-keyed read of this call finds it.
+      if (!call.callSessionId && recording.callSessionId) {
+        await this.calls.attachTelephony(call.id, {
+          callControlId: call.callControlId,
+          callSessionId: recording.callSessionId,
+        });
+      }
 
       await this.recordingProcessing.processCallRecording({
         callControlId: call.callControlId,
@@ -442,35 +583,26 @@ export class VoiceAgentBillingService {
 
   /**
    * Writes down the conversation the provider's own records name, for a call
-   * whose conversation webhook never arrived. Returns the row to keep working
-   * from — the caller's copy is stale once this writes.
+   * whose conversation webhook never arrived, along with the session handle
+   * they carry. Returns the row to keep working from — the caller's copy is
+   * stale once this writes.
    */
   private async bindConversation(
     agentCall: AiVoiceAgentCall,
     records: VoiceAgentUsageRecord[],
   ): Promise<AiVoiceAgentCall> {
-    if (agentCall.providerConversationId) return agentCall;
+    const conversationId =
+      agentCall.providerConversationId ??
+      records.find((record) => record.conversationId)?.conversationId ??
+      null;
+    const callSessionId =
+      records.find((record) => record.callSessionId)?.callSessionId ?? null;
+    if (!conversationId && !callSessionId) return agentCall;
 
-    const conversationId = records.find(
-      (record) => record.conversationId,
-    )?.conversationId;
-    if (!conversationId) return agentCall;
-
-    try {
-      return await this.agentCalls.update(agentCall.id, {
-        providerConversationId: conversationId,
-      });
-    } catch (error) {
-      // `providerConversationId` is unique. Another row already claiming it
-      // means this call is not the one that conversation belongs to — worth
-      // knowing about, never worth failing the settlement over.
-      this.logger.warn(
-        `Could not bind conversation ${conversationId} to agent call ${agentCall.id}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      return agentCall;
-    }
+    return this.results.bindConversation(agentCall, {
+      conversationId,
+      callSessionId,
+    });
   }
 
   private sum(

--- a/packages/services/src/services/voice-agents/voice-agent-call.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-call.service.spec.ts
@@ -56,7 +56,7 @@ function build(options: {
 
   const configured: string[] = [];
   const analysisEnsured: string[] = [];
-  const toolsEnsured: string[] = [];
+  const deliveryEvents: string[] = [];
   const service = new VoiceAgentCallService(
     {
       require: async () => agent,
@@ -69,7 +69,8 @@ function build(options: {
       },
       ensureToolEndpoints: async (_ctx: unknown, target: { id: string }) => {
         if (options.toolSyncError) throw options.toolSyncError;
-        toolsEnsured.push(target.id);
+        await Promise.resolve();
+        deliveryEvents.push(`tools:${target.id}`);
       },
     } as never,
     { require: () => ({ variables: options.variables ?? [] }) } as never,
@@ -87,6 +88,7 @@ function build(options: {
     } as never,
     {
       startCall: async (input: { from: string }) => {
+        deliveryEvents.push("call:placed");
         placed.push({ from: input.from });
         return { providerCallId: "prov-1", callControlId: "cc-1" };
       },
@@ -115,7 +117,7 @@ function build(options: {
     contacts,
     configured,
     analysisEnsured,
-    toolsEnsured,
+    deliveryEvents,
   };
 }
 
@@ -286,11 +288,11 @@ describe("VoiceAgentCallService calling application", () => {
     // they outlive the address they were built from. An agent still calling
     // the old one does not book the meeting — it tells the person it is
     // having a technical problem, on a call the workspace paid for.
-    const { service, toolsEnsured } = build({ usable: [NUMBERS.miami] });
+    const { service, deliveryEvents } = build({ usable: [NUMBERS.miami] });
 
     await service.startCall(CTX as never, "agent-1", { to: TO });
 
-    assert.deepEqual(toolsEnsured, ["agent-1"]);
+    assert.deepEqual(deliveryEvents, ["tools:agent-1", "call:placed"]);
   });
 
   it("places the call even when the tool check itself fails", async () => {

--- a/packages/services/src/services/voice-agents/voice-agent-call.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-call.service.spec.ts
@@ -40,6 +40,8 @@ function build(options: {
   usable: Array<{ id: string; phoneNumber: string }>;
   /** The agent type's dynamic variables, when a test supplies any. */
   variables?: Array<{ key: string; required: boolean }>;
+  /** What the tool re-sync throws, for the test that it is best-effort. */
+  toolSyncError?: Error;
 }) {
   const placed: Array<{ from: string }> = [];
   const contacts: ResolvedContact[] = [];
@@ -54,6 +56,7 @@ function build(options: {
 
   const configured: string[] = [];
   const analysisEnsured: string[] = [];
+  const toolsEnsured: string[] = [];
   const service = new VoiceAgentCallService(
     {
       require: async () => agent,
@@ -63,6 +66,10 @@ function build(options: {
       },
       ensureInsightGroup: async (target: { id: string }) => {
         analysisEnsured.push(target.id);
+      },
+      ensureToolEndpoints: async (_ctx: unknown, target: { id: string }) => {
+        if (options.toolSyncError) throw options.toolSyncError;
+        toolsEnsured.push(target.id);
       },
     } as never,
     { require: () => ({ variables: options.variables ?? [] }) } as never,
@@ -102,7 +109,14 @@ function build(options: {
     } as never,
   );
 
-  return { service, placed, contacts, configured, analysisEnsured };
+  return {
+    service,
+    placed,
+    contacts,
+    configured,
+    analysisEnsured,
+    toolsEnsured,
+  };
 }
 
 const TO = "+13055559999";
@@ -265,5 +279,30 @@ describe("VoiceAgentCallService calling application", () => {
     await service.startCall(CTX as never, "agent-1", { to: TO });
 
     assert.deepEqual(analysisEnsured, ["agent-1"]);
+  });
+
+  it("points the agent's tools at Ringee before placing the call", async () => {
+    // Tool URLs are written when the agent is saved and never revisited, so
+    // they outlive the address they were built from. An agent still calling
+    // the old one does not book the meeting — it tells the person it is
+    // having a technical problem, on a call the workspace paid for.
+    const { service, toolsEnsured } = build({ usable: [NUMBERS.miami] });
+
+    await service.startCall(CTX as never, "agent-1", { to: TO });
+
+    assert.deepEqual(toolsEnsured, ["agent-1"]);
+  });
+
+  it("places the call even when the tool check itself fails", async () => {
+    // Best-effort, like the two beside it: a re-sync Ringee could not run is
+    // worth a call with stale tools, never worth refusing the call.
+    const { service, placed } = build({
+      usable: [NUMBERS.miami],
+      toolSyncError: new Error("provider unavailable"),
+    });
+
+    await service.startCall(CTX as never, "agent-1", { to: TO });
+
+    assert.deepEqual(placed, [{ from: NUMBERS.miami.phoneNumber }]);
   });
 });

--- a/packages/services/src/services/voice-agents/voice-agent-call.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-call.service.ts
@@ -152,6 +152,7 @@ export class VoiceAgentCallService {
     let legPlaced = false;
     try {
       await this.ensureInsightDelivery(agent);
+      await this.ensureToolDelivery(ctx, agent);
       const handle = await this.provider.startCall({
         assistantId: agent.providerAssistantId!,
         callingAppId: await this.requireCallingApp(agent),
@@ -391,6 +392,30 @@ export class VoiceAgentCallService {
         }`,
       );
     });
+  }
+
+  /**
+   * Makes sure the tools this agent is about to use still reach Ringee.
+   *
+   * Same shape and same reasoning as the two beside it, and the same failure it
+   * exists to prevent: an assistant whose tool URLs were written against an
+   * address this backend no longer answers on holds the whole conversation and
+   * then tells the person it is having a technical problem — after the call was
+   * placed, dialed, answered and paid for.
+   */
+  private async ensureToolDelivery(
+    ctx: OwnershipContext,
+    agent: AiVoiceAgent,
+  ): Promise<void> {
+    await this.agents
+      .ensureToolEndpoints(ctx, agent)
+      .catch((error: unknown) => {
+        this.logger.warn(
+          `Could not verify the tool endpoints for agent ${agent.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
   }
 
   private async requireCallingApp(agent: AiVoiceAgent): Promise<string> {

--- a/packages/services/src/services/voice-agents/voice-agent-call.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-call.service.ts
@@ -470,7 +470,7 @@ export class VoiceAgentCallService {
   }
 
   private publicBase(): string {
-    return apiConfiguration.PUBLIC_BACKEND_URL.replace(/\/+$/, "");
+    return apiConfiguration.PUBLIC_BACKEND_URL!.replace(/\/+$/, "");
   }
 
   // ── Reads ────────────────────────────────────────────────────

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
@@ -7,6 +7,7 @@ import "reflect-metadata";
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { CallStatus } from "@ringee/database";
 import { voiceAgentInsightsToken } from "@ringee/platform";
 import { VoiceAgentResultService } from "./voice-agent-result.service";
 
@@ -42,6 +43,7 @@ function build(
     byControlId?: Record<string, unknown> | null;
     /** What the provider knows about the conversation, when asked directly. */
     conversation?: Record<string, unknown> | null;
+    conversationError?: Error;
     call?: Record<string, unknown> | null;
     turns?: Array<{ role: string; text: string; at: Date | null }>;
     transcriptError?: Error;
@@ -93,7 +95,10 @@ function build(
               ],
             }
           : null,
-      fetchConversation: async () => over.conversation ?? null,
+      fetchConversation: async () => {
+        if (over.conversationError) throw over.conversationError;
+        return over.conversation ?? null;
+      },
       fetchTranscript: async () => {
         if (over.transcriptError) throw over.transcriptError;
         return (
@@ -178,6 +183,21 @@ describe("VoiceAgentResultService analysis callback", () => {
     assert.deepEqual(updates, []);
   });
 
+  it("propagates a transient conversation lookup failure for retry", async () => {
+    const { service, updates } = build({
+      agentCall: null,
+      conversationError: new Error("provider unavailable"),
+    });
+
+    await assert.rejects(
+      service.applyInsightCallback(AGENT_ID, TOKEN, {
+        conversation_id: "conv-1",
+      }),
+      /provider unavailable/,
+    );
+    assert.deepEqual(updates, []);
+  });
+
   it("finds the call when nothing ever bound the conversation to it", async () => {
     // `providerConversationId` is written by the conversation webhook — the
     // one delivery an agent call cannot count on. Dropping the analysis
@@ -218,6 +238,51 @@ describe("VoiceAgentResultService analysis callback", () => {
       summary: "Booked a demo.",
       outcome: "appointment_booked",
     });
+  });
+});
+
+describe("VoiceAgentResultService call status", () => {
+  it("answers a non-terminal call when the provider reports it connected", async () => {
+    const { service, attached } = build({
+      call: {
+        id: "telephony-1",
+        callControlId: "cc-1",
+        callSessionId: null,
+        status: CallStatus.ringing,
+      },
+    });
+
+    await service.applyStatus(AGENT_CALL as never, {
+      providerStatus: "in-progress",
+      callControlId: "cc-1",
+      callSessionId: "session-1",
+    });
+
+    assert.equal(attached[0]!.status, CallStatus.answered);
+    assert.ok(attached[0]!.answeredAt instanceof Date);
+  });
+
+  it("does not reopen terminal calls on a late connected callback", async () => {
+    for (const status of [CallStatus.completed, CallStatus.failed]) {
+      const { service, attached } = build({
+        call: {
+          id: "telephony-1",
+          callControlId: "cc-1",
+          callSessionId: null,
+          status,
+        },
+      });
+
+      await service.applyStatus(AGENT_CALL as never, {
+        providerStatus: "in-progress",
+        callControlId: "cc-1",
+        callSessionId: "session-late",
+      });
+
+      assert.equal(attached[0]!.callSessionId, "session-late");
+      assert.equal(attached[0]!.status, undefined);
+      assert.equal(attached[0]!.answeredAt, undefined);
+    }
   });
 });
 

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
@@ -38,6 +38,11 @@ const ANALYSIS = {
 function build(
   over: {
     agentCall?: Record<string, unknown> | null;
+    /** The row the control id on a provider-read conversation leads to. */
+    byControlId?: Record<string, unknown> | null;
+    /** What the provider knows about the conversation, when asked directly. */
+    conversation?: Record<string, unknown> | null;
+    call?: Record<string, unknown> | null;
     turns?: Array<{ role: string; text: string; at: Date | null }>;
     transcriptError?: Error;
     alreadyTranscribed?: boolean;
@@ -45,11 +50,13 @@ function build(
 ) {
   const updates: Array<Record<string, unknown>> = [];
   const transcripts: Array<Record<string, unknown>> = [];
+  const attached: Array<Record<string, unknown>> = [];
 
   const service = new VoiceAgentResultService(
     {
       findByConversationId: async () =>
         over.agentCall === undefined ? AGENT_CALL : over.agentCall,
+      findByCallControlId: async () => over.byControlId ?? null,
       update: async (_id: string, data: Record<string, unknown>) => {
         updates.push(data);
         return AGENT_CALL;
@@ -60,7 +67,14 @@ function build(
     } as never,
     { readAnalysis: () => ANALYSIS } as never,
     {
-      findById: async () => ({ id: "telephony-1", userId: "user-1" }),
+      findById: async () =>
+        over.call === undefined
+          ? { id: "telephony-1", userId: "user-1", callControlId: "cc-1" }
+          : over.call,
+      attachTelephony: async (id: string, data: Record<string, unknown>) => {
+        attached.push({ id, ...data });
+        return { id };
+      },
     } as never,
     {
       // The real adapter's parser, in miniature: the domain never sees the
@@ -79,6 +93,7 @@ function build(
               ],
             }
           : null,
+      fetchConversation: async () => over.conversation ?? null,
       fetchTranscript: async () => {
         if (over.transcriptError) throw over.transcriptError;
         return (
@@ -102,7 +117,7 @@ function build(
     } as never,
   );
 
-  return { service, updates, transcripts };
+  return { service, updates, transcripts, attached };
 }
 
 describe("VoiceAgentResultService analysis callback", () => {
@@ -161,6 +176,48 @@ describe("VoiceAgentResultService analysis callback", () => {
       true,
     );
     assert.deepEqual(updates, []);
+  });
+
+  it("finds the call when nothing ever bound the conversation to it", async () => {
+    // `providerConversationId` is written by the conversation webhook — the
+    // one delivery an agent call cannot count on. Dropping the analysis
+    // because of that loses it for good: there is no endpoint to read a
+    // finished conversation's results back (AGENT-009). So the conversation
+    // is read from the provider, which knows the call it ran on.
+    const { service, updates, attached } = build({
+      agentCall: null,
+      byControlId: { ...AGENT_CALL, providerConversationId: null },
+      conversation: {
+        conversationId: "conv-1",
+        assistantId: "assistant-1",
+        callControlId: "cc-1",
+        callSessionId: "cs-1",
+        callLegId: "leg-1",
+      },
+      call: {
+        id: "telephony-1",
+        userId: "user-1",
+        callControlId: "cc-1",
+        callSessionId: null,
+      },
+    });
+
+    const accepted = await service.applyInsightCallback(AGENT_ID, TOKEN, {
+      conversation_id: "conv-1",
+    });
+
+    assert.equal(accepted, true);
+    // The conversation is written down on the way past, so the next read of
+    // this call finds it without asking the provider again...
+    assert.deepEqual(updates[0], { providerConversationId: "conv-1" });
+    // ...and so is the session the recording is filed under.
+    assert.equal(attached.length, 1);
+    assert.equal(attached[0]!.callSessionId, "cs-1");
+    // And the analysis lands on the call, which is the point of all of it.
+    assert.deepEqual(updates[1], {
+      summary: "Booked a demo.",
+      outcome: "appointment_booked",
+    });
   });
 });
 

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.ts
@@ -103,9 +103,7 @@ export class VoiceAgentResultService {
     const delivery = this.provider.parseInsightWebhook(body);
     if (!delivery?.conversationId) return true;
 
-    const agentCall = await this.agentCalls.findByConversationId(
-      delivery.conversationId,
-    );
+    const agentCall = await this.locateByConversation(delivery.conversationId);
     // The token proves which agent asked for the analysis; the row has to
     // agree. A conversation belonging to another agent is not this agent's to
     // write to, however valid the token is.
@@ -231,12 +229,18 @@ export class VoiceAgentResultService {
         : {}),
     });
 
-    // Bind the telephony row too: this is the first event that names the leg.
+    // Bind the telephony row too. The control id is already on it — the dial
+    // path writes it down — but the session and leg handles are not, and this
+    // event is one of the few places they are ever reported. The recording of
+    // this call is filed under the session id, so a row that never learns it is
+    // a call whose audio nothing can find.
     if (agentCall.callId) {
       const call = await this.callRepository.findById(agentCall.callId);
-      if (call && !call.callControlId) {
+      const missingControlId = call && !call.callControlId;
+      const missingSession = call && !call.callSessionId && event.callSessionId;
+      if (call && (missingControlId || missingSession)) {
         await this.callRepository.attachTelephony(call.id, {
-          callControlId: event.callControlId,
+          callControlId: call.callControlId ?? event.callControlId,
           callSessionId: event.callSessionId,
           callLegId: event.callLegId,
         });
@@ -350,21 +354,28 @@ export class VoiceAgentResultService {
       // that never connects it is `busy` or `failed`. Calling any of those
       // "answered" both misreports the call and, if the terminal callback never
       // arrives, leaves it parked in a connected state it never reached.
-      // Leaving the status alone lets `completeCall` settle it, where an absent
-      // `answeredAt` is what auto-dispositions the call as no-answer.
       const connected = status === AiVoiceAgentCallStatus.in_progress;
-      // The identifiers are written when the row is still missing them, and the
-      // answer is recorded whenever the leg connects — two separate reasons to
-      // write, because the row is now bound when the call is placed and would
-      // otherwise never be marked answered at all.
+      // Three separate reasons to write, because the row is bound when the call
+      // is placed: the control id when it is still missing, the session and leg
+      // handles the moment a callback names them — the recording is filed under
+      // the session — and the answer whenever the leg connects.
       const binds = call && !call.callControlId;
+      const learnsSession =
+        call && !call.callSessionId && !!input.callSessionId;
       const answers = call && connected && call.status !== CallStatus.answered;
-      if (call && (binds || answers)) {
+      if (call && (binds || learnsSession || answers)) {
         await this.callRepository.attachTelephony(call.id, {
           callControlId,
           callSessionId: input.callSessionId,
           callLegId: input.callLegId,
-          answeredAt: input.answeredAt,
+          // The provider's telephony-markup callback carries a status and no
+          // timestamps at all, so a connected leg has to be dated here. Left
+          // unset, the row looks like a call nobody picked up and `completeCall`
+          // dispositions it as a no-answer — on a call that just held a full
+          // conversation.
+          answeredAt: connected
+            ? (input.answeredAt ?? new Date())
+            : input.answeredAt,
           ...(connected ? { status: CallStatus.answered } : {}),
         });
       }
@@ -375,7 +386,11 @@ export class VoiceAgentResultService {
       // hangup cause and auto-dispositions a call that never connected.
       await this.callRepository.completeCall(
         callControlId,
-        input.startedAt ?? new Date().toISOString(),
+        // Not "now". The row already knows when the call was placed, and
+        // substituting the moment this callback arrived — which is what the
+        // provider forces, since it sends no start time — made every agent call
+        // last zero seconds.
+        input.startedAt,
         input.endedAt ?? new Date().toISOString(),
         input.hangupCause ?? undefined,
       );
@@ -456,6 +471,93 @@ export class VoiceAgentResultService {
   }
 
   // ── Helpers ──────────────────────────────────────────────────
+
+  /**
+   * The call a conversation belongs to, for a delivery that names only the
+   * conversation.
+   *
+   * `providerConversationId` is written by the conversation webhook, and that
+   * webhook is exactly the delivery an agent call cannot count on — so on a
+   * miss the conversation is read from the provider, whose record of it carries
+   * the call it ran on. Without this second look an analysis that arrives
+   * before the sweep has bound the conversation is dropped, and post-call
+   * analysis is delivered once or it is lost (AGENT-009).
+   */
+  async locateByConversation(
+    conversationId: string,
+  ): Promise<AiVoiceAgentCall | null> {
+    const bound = await this.agentCalls.findByConversationId(conversationId);
+    if (bound) return bound;
+
+    const conversation = await this.provider
+      .fetchConversation(conversationId)
+      .catch((error: unknown) => {
+        this.logger.warn(
+          `Could not read conversation ${conversationId} from the provider: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return null;
+      });
+    if (!conversation?.callControlId) return null;
+
+    const agentCall = await this.agentCalls.findByCallControlId(
+      conversation.callControlId,
+    );
+    if (!agentCall) return null;
+
+    return this.bindConversation(agentCall, conversation);
+  }
+
+  /**
+   * Writes a conversation's handles onto the call it belongs to, and returns
+   * the row to keep working from.
+   *
+   * Two rows learn something here: the agent call gets the conversation id that
+   * every later analysis and transcript read is keyed on, and the telephony row
+   * gets the session and leg the provider files this call's recording under.
+   */
+  async bindConversation(
+    agentCall: AiVoiceAgentCall,
+    conversation: {
+      conversationId: string | null;
+      callSessionId?: string | null;
+      callLegId?: string | null;
+    },
+  ): Promise<AiVoiceAgentCall> {
+    let current = agentCall;
+    const conversationId = conversation.conversationId;
+
+    if (conversationId && !current.providerConversationId) {
+      current = await this.agentCalls
+        .update(current.id, {
+          providerConversationId: conversationId,
+        })
+        .catch((error: unknown) => {
+          // `providerConversationId` is unique: another row already holding it
+          // means this call is not the one that conversation belongs to.
+          this.logger.warn(
+            `Could not bind conversation ${conversationId} to agent call ${current.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          return current;
+        });
+    }
+
+    if (current.callId && conversation.callSessionId) {
+      const call = await this.callRepository.findById(current.callId);
+      if (call?.callControlId && !call.callSessionId) {
+        await this.callRepository.attachTelephony(call.id, {
+          callControlId: call.callControlId,
+          callSessionId: conversation.callSessionId,
+          callLegId: conversation.callLegId,
+        });
+      }
+    }
+
+    return current;
+  }
 
   private async locate(
     callControlId: string,

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.ts
@@ -362,7 +362,12 @@ export class VoiceAgentResultService {
       const binds = call && !call.callControlId;
       const learnsSession =
         call && !call.callSessionId && !!input.callSessionId;
-      const answers = call && connected && call.status !== CallStatus.answered;
+      const answers =
+        call &&
+        connected &&
+        call.status !== CallStatus.answered &&
+        call.status !== CallStatus.completed &&
+        call.status !== CallStatus.failed;
       if (call && (binds || learnsSession || answers)) {
         await this.callRepository.attachTelephony(call.id, {
           callControlId,
@@ -373,10 +378,10 @@ export class VoiceAgentResultService {
           // unset, the row looks like a call nobody picked up and `completeCall`
           // dispositions it as a no-answer — on a call that just held a full
           // conversation.
-          answeredAt: connected
+          answeredAt: answers
             ? (input.answeredAt ?? new Date())
             : input.answeredAt,
-          ...(connected ? { status: CallStatus.answered } : {}),
+          ...(answers ? { status: CallStatus.answered } : {}),
         });
       }
     }
@@ -489,16 +494,7 @@ export class VoiceAgentResultService {
     const bound = await this.agentCalls.findByConversationId(conversationId);
     if (bound) return bound;
 
-    const conversation = await this.provider
-      .fetchConversation(conversationId)
-      .catch((error: unknown) => {
-        this.logger.warn(
-          `Could not read conversation ${conversationId} from the provider: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-        return null;
-      });
+    const conversation = await this.provider.fetchConversation(conversationId);
     if (!conversation?.callControlId) return null;
 
     const agentCall = await this.agentCalls.findByCallControlId(

--- a/packages/services/src/services/voice-agents/voice-agent.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent.service.ts
@@ -1006,6 +1006,6 @@ export class VoiceAgentService {
   }
 
   private publicBase(): string {
-    return apiConfiguration.PUBLIC_BACKEND_URL.replace(/\/+$/, "");
+    return apiConfiguration.PUBLIC_BACKEND_URL!.replace(/\/+$/, "");
   }
 }

--- a/packages/services/src/services/voice-agents/voice-agent.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent.service.ts
@@ -687,6 +687,43 @@ export class VoiceAgentService {
   }
 
   /**
+   * Makes sure the agent's tools still call this backend, before it dials.
+   *
+   * Tool URLs are written onto the assistant when the agent is saved and never
+   * looked at again, so they outlive the address they were built from: change
+   * `PUBLIC_BACKEND_URL` and every agent in the workspace keeps pointing at the
+   * old one until somebody happens to open and re-save it. That is not a
+   * degraded agent — it is one that answers "I am having a technical problem
+   * with the calendar" and books nothing, on a call the workspace paid for.
+   *
+   * Best-effort, like `ensureCallingApp` and `ensureInsightGroup` beside it: a
+   * re-sync that fails is worth a call with stale tools, never worth refusing
+   * the call the user asked for.
+   */
+  async ensureToolEndpoints(
+    ctx: OwnershipContext,
+    agent: AiVoiceAgent,
+  ): Promise<void> {
+    if (!agent.providerAssistantId) return;
+
+    const assistant = await this.provider.getAssistant(
+      agent.providerAssistantId,
+    );
+    if (!assistant) return;
+
+    const base = this.toolBaseUrl();
+    const stale = assistant.toolWebhookUrls.filter(
+      (url) => !url.startsWith(base),
+    );
+    if (stale.length === 0) return;
+
+    this.logger.warn(
+      `Agent ${agent.id} has ${stale.length} tool(s) pointing somewhere else (${stale[0]}); re-syncing against ${base}`,
+    );
+    await this.syncToProvider(ctx, agent.id);
+  }
+
+  /**
    * Creates, updates or removes each analysis so the provider's insight group
    * matches the user's post-call configuration exactly — no orphans left
    * running and billing after a field is deleted.


### PR DESCRIPTION
- Introduced new methods for fetching recordings and conversations in the VoiceAgentProviderService.
- Updated VoiceAgentBillingService to handle call lifecycle management, ensuring calls are settled correctly even without status callbacks.
- Improved handling of telephony records, including attaching session IDs and managing call statuses based on provider records.
- Added tests to verify the correct binding of conversations and handling of tool endpoints in VoiceAgentCallService and VoiceAgentResultService.
- Implemented best-effort checks for tool endpoint validity before placing calls to prevent technical issues during agent interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Behaviour changes

- Billing settles calls from provider usage records when callbacks are missing.
- Stalled dialing calls remain eligible for reconciliation for up to 24 hours.
- Provider records update call status, answer time, start time, end time, and connected duration.
- Recording recovery uses `callControlId` and can persist a discovered session ID.
- Conversation callbacks can recover missing call and session bindings from provider metadata.
- Provider lookup failures propagate so callbacks can retry.
- Late callbacks do not reopen terminal calls.
- Tool endpoints are checked before dialing. Validation failures do not block the call.
- Callback URL configuration now uses `BACKEND_URL` as the public backend origin.

## Architectural impact

- `@ringee/platform` adds provider conversation and recording-query contracts, usage timeline fields, tool webhook metadata, and `fetchConversation`.
- `@ringee/services` owns conversation binding, telephony association, lifecycle reconciliation, and tool endpoint synchronization.
- `@ringee/database` changes unsettled-call query windows and accepts nullable or `Date` call timestamps.
- Provider call-control, session, leg, conversation, and timeline identifiers now cross the platform adapter boundary.
- `fetchRecordings` changes from a session ID to `VoiceAgentRecordingQuery`.
- `apiConfiguration.PUBLIC_BACKEND_URL` now reads `BACKEND_URL` and no longer validates the URL scheme.

## Risk areas

- Incorrect provider timing or status data can produce incorrect debit settlement or leave calls active.
- Missing, duplicate, late, or inconsistent callbacks can corrupt lifecycle state and timestamps.
- Conversation and telephony binding failures can block post-call analysis or trigger retries.
- A provider failure during insight processing now causes callback retry.
- `fetchConversation`, `fetchRecordings`, `completeCall`, and `listUnsettled` changed public contracts.
- Incorrect `BACKEND_URL` values can generate invalid provider callback URLs.
- Tool synchronization can modify provider assistant configuration immediately before a call.
- No migration or REST/MCP schema change is indicated.

## Files to review first

- `packages/services/src/services/voice-agents/voice-agent-billing.service.ts`
- `packages/services/src/services/voice-agents/voice-agent-result.service.ts`
- `packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.service.ts`
- `packages/platform/src/voice-agents/interfaces/voice-agent.provider.ts`
- `packages/database/src/database/repositories/ai-voice-agent-call.repository.ts`
- `packages/database/src/database/repositories/call.repository.ts`
- `packages/services/src/services/voice-agents/voice-agent-call.service.ts`
- `packages/services/src/services/voice-agents/voice-agent.service.ts`
- `packages/configuration/src/api.configuration.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->