### PR TITLE
feat: enhance table actions with dropdown menus and pinning

### DIFF
--- a/apps/frontend/src/features/ai-pipeline/components/follow-up-recommendations.tsx
+++ b/apps/frontend/src/features/ai-pipeline/components/follow-up-recommendations.tsx
@@ -12,6 +12,12 @@ import {
   CardTitle
 } from '@ringee/frontend-shared/components/ui/card';
 import { Switch } from '@ringee/frontend-shared/components/ui/switch';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import {
   Select,
   SelectContent,
@@ -74,6 +80,7 @@ const RESULT_FILTERS: {
 export function FollowUpRecommendations() {
   const api = useApi();
   const t = useTranslations('ai.followUp');
+  const tCommon = useTranslations('common');
   // `?mock=1` renders the demo dataset and keeps every mutation local.
   const searchParams = useSearchParams();
   const mock = isMockParam(searchParams.get('mock'));
@@ -348,9 +355,9 @@ export function FollowUpRecommendations() {
                 <TableHead className='hidden sm:table-cell'>
                   {t('activation.pending')}
                 </TableHead>
-                <TableHead className='text-right'>
-                  {t('activation.run')}
-                </TableHead>
+                <TableActionHead>
+                  <span className='sr-only'>{tCommon('actions')}</span>
+                </TableActionHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -381,19 +388,20 @@ export function FollowUpRecommendations() {
                   <TableCell className='hidden sm:table-cell'>
                     {r.pendingActionCount}
                   </TableCell>
-                  <TableCell
-                    className='text-right'
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Button
-                      variant='outline'
-                      size='sm'
-                      disabled={!r.enabled}
-                      onClick={() => openRun(r)}
+                  <TableActionCell onClick={(e) => e.stopPropagation()}>
+                    <TableRowActions
+                      label={tCommon('openActions')}
+                      menuLabel={tCommon('actions')}
                     >
-                      <Play className='mr-1 h-3 w-3' /> {t('run.analysis')}
-                    </Button>
-                  </TableCell>
+                      <DropdownMenuItem
+                        disabled={!r.enabled}
+                        onClick={() => openRun(r)}
+                      >
+                        <Play className='h-4 w-4' />
+                        {t('run.analysis')}
+                      </DropdownMenuItem>
+                    </TableRowActions>
+                  </TableActionCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/apps/frontend/src/features/backoffice/components/accounts-table.tsx
+++ b/apps/frontend/src/features/backoffice/components/accounts-table.tsx
@@ -18,6 +18,13 @@ import {
 import { Input } from '@ringee/frontend-shared/components/ui/input';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
+import { Eye } from 'lucide-react';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import {
   Table,
   TableBody,
@@ -155,13 +162,16 @@ export function AccountsTable() {
                   <TableHead className='text-right'>Calls</TableHead>
                   <TableHead>Recording</TableHead>
                   <TableHead>AI</TableHead>
+                  <TableActionHead>
+                    <span className='sr-only'>Actions</span>
+                  </TableActionHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {loading && items.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={7}
+                      colSpan={8}
                       className='text-muted-foreground py-8 text-center'
                     >
                       Loading…
@@ -170,7 +180,7 @@ export function AccountsTable() {
                 ) : items.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={7}
+                      colSpan={8}
                       className='text-muted-foreground py-8 text-center'
                     >
                       No accounts found.
@@ -213,6 +223,25 @@ export function AccountsTable() {
                           {item.aiPipelineEnabled ? 'On' : 'Off'}
                         </Badge>
                       </TableCell>
+                      <TableActionCell
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <TableRowActions
+                          label='Open actions menu'
+                          menuLabel='Actions'
+                        >
+                          <DropdownMenuItem
+                            onClick={() =>
+                              router.push(
+                                `/backoffice/accounts/${item.type}/${item.id}`
+                              )
+                            }
+                          >
+                            <Eye className='size-4' />
+                            View
+                          </DropdownMenuItem>
+                        </TableRowActions>
+                      </TableActionCell>
                     </TableRow>
                   ))
                 )}

--- a/apps/frontend/src/features/backoffice/components/backoffice-dashboard.tsx
+++ b/apps/frontend/src/features/backoffice/components/backoffice-dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { Eye } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   Card,
@@ -18,6 +19,12 @@ import {
   TableHeader,
   TableRow
 } from '@ringee/frontend-shared/components/ui/table';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import { DateRangeBar } from './date-range-bar';
 import {
   useBackofficeApi,
@@ -105,6 +112,9 @@ function ActivityTable({ rows }: { rows: CallerActivityRow[] }) {
               <TableHead className='text-right'>Duration</TableHead>
               <TableHead className='text-right'>Cost</TableHead>
               <TableHead className='text-right'>Last call</TableHead>
+              <TableActionHead>
+                <span className='sr-only'>Actions</span>
+              </TableActionHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -138,6 +148,19 @@ function ActivityTable({ rows }: { rows: CallerActivityRow[] }) {
                 <TableCell className='text-muted-foreground text-right text-xs'>
                   {formatDateTime(r.lastCallAt)}
                 </TableCell>
+                <TableActionCell>
+                  <TableRowActions
+                    label='Open actions menu'
+                    menuLabel='Actions'
+                  >
+                    <DropdownMenuItem asChild>
+                      <Link href={`/backoffice/accounts/${r.type}/${r.id}`}>
+                        <Eye className='size-4' />
+                        View
+                      </Link>
+                    </DropdownMenuItem>
+                  </TableRowActions>
+                </TableActionCell>
               </TableRow>
             ))}
           </TableBody>

--- a/apps/frontend/src/features/backoffice/components/campaign-detail-analytics.tsx
+++ b/apps/frontend/src/features/backoffice/components/campaign-detail-analytics.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { Eye } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   Bar,
@@ -35,6 +36,12 @@ import {
   TableHeader,
   TableRow
 } from '@ringee/frontend-shared/components/ui/table';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
@@ -577,6 +584,9 @@ export function CampaignDetailAnalytics({ id }: { id: string }) {
                     <TableHead className='text-right'>Talk</TableHead>
                     <TableHead className='text-right'>AHT</TableHead>
                     <TableHead className='text-right'>Cost</TableHead>
+                    <TableActionHead>
+                      <span className='sr-only'>Actions</span>
+                    </TableActionHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -616,6 +626,21 @@ export function CampaignDetailAnalytics({ id }: { id: string }) {
                       <TableCell className='text-right'>
                         {formatMoney(a.cost)}
                       </TableCell>
+                      <TableActionCell>
+                        <TableRowActions
+                          label='Open actions menu'
+                          menuLabel='Actions'
+                        >
+                          <DropdownMenuItem asChild>
+                            <Link
+                              href={`/backoffice/accounts/user/${a.agentUserId}`}
+                            >
+                              <Eye className='size-4' />
+                              View
+                            </Link>
+                          </DropdownMenuItem>
+                        </TableRowActions>
+                      </TableActionCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -742,6 +767,9 @@ export function CampaignDetailAnalytics({ id }: { id: string }) {
                       <TableHead>Agent</TableHead>
                       <TableHead>Role</TableHead>
                       <TableHead className='text-right'>Since</TableHead>
+                      <TableActionHead>
+                        <span className='sr-only'>Actions</span>
+                      </TableActionHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -766,6 +794,21 @@ export function CampaignDetailAnalytics({ id }: { id: string }) {
                         <TableCell className='text-muted-foreground text-right text-xs'>
                           {formatDate(m.assignedAt)}
                         </TableCell>
+                        <TableActionCell>
+                          <TableRowActions
+                            label='Open actions menu'
+                            menuLabel='Actions'
+                          >
+                            <DropdownMenuItem asChild>
+                              <Link
+                                href={`/backoffice/accounts/user/${m.userId}`}
+                              >
+                                <Eye className='size-4' />
+                                View
+                              </Link>
+                            </DropdownMenuItem>
+                          </TableRowActions>
+                        </TableActionCell>
                       </TableRow>
                     ))}
                   </TableBody>

--- a/apps/frontend/src/features/backoffice/components/campaigns-table.tsx
+++ b/apps/frontend/src/features/backoffice/components/campaigns-table.tsx
@@ -26,6 +26,13 @@ import {
 import { Input } from '@ringee/frontend-shared/components/ui/input';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
+import { Eye } from 'lucide-react';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import {
   Table,
   TableBody,
@@ -343,13 +350,16 @@ export function CampaignsTable() {
                   <TableHead className='text-right'>Talk</TableHead>
                   <TableHead className='text-right'>Cost</TableHead>
                   <TableHead className='text-right'>Last activity</TableHead>
+                  <TableActionHead>
+                    <span className='sr-only'>Actions</span>
+                  </TableActionHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {loading && items.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={10}
+                      colSpan={11}
                       className='text-muted-foreground py-8 text-center'
                     >
                       Loading…
@@ -358,7 +368,7 @@ export function CampaignsTable() {
                 ) : items.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={10}
+                      colSpan={11}
                       className='text-muted-foreground py-8 text-center'
                     >
                       No campaigns match these filters.
@@ -415,6 +425,23 @@ export function CampaignsTable() {
                       <TableCell className='text-muted-foreground text-right text-xs'>
                         {formatDateTime(item.lastActivityAt)}
                       </TableCell>
+                      <TableActionCell
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <TableRowActions
+                          label='Open actions menu'
+                          menuLabel='Actions'
+                        >
+                          <DropdownMenuItem
+                            onClick={() =>
+                              router.push(`/backoffice/campaigns/${item.id}`)
+                            }
+                          >
+                            <Eye className='size-4' />
+                            View
+                          </DropdownMenuItem>
+                        </TableRowActions>
+                      </TableActionCell>
                     </TableRow>
                   ))
                 )}

--- a/apps/frontend/src/features/backoffice/components/offer-detail.tsx
+++ b/apps/frontend/src/features/backoffice/components/offer-detail.tsx
@@ -7,8 +7,10 @@ import { toast } from 'sonner';
 import {
   IconArrowLeft,
   IconExternalLink,
+  IconCheck,
   IconPencil,
-  IconTrash
+  IconTrash,
+  IconX
 } from '@tabler/icons-react';
 import {
   Card,
@@ -18,6 +20,15 @@ import {
   CardTitle
 } from '@ringee/frontend-shared/components/ui/card';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import {
   Select,
   SelectContent,
@@ -413,7 +424,9 @@ export function OfferDetail({ offerId }: { offerId: string }) {
                   <TableHead>Submission</TableHead>
                   <TableHead className='text-right'>Reward</TableHead>
                   <TableHead>Submitted at</TableHead>
-                  <TableHead className='text-right'>Actions</TableHead>
+                  <TableActionHead>
+                    <span className='sr-only'>Actions</span>
+                  </TableActionHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -462,44 +475,55 @@ export function OfferDetail({ offerId }: { offerId: string }) {
                       <TableCell className='text-xs'>
                         {formatDateTime(row.submittedAt)}
                       </TableCell>
-                      <TableCell className='text-right'>
-                        <div className='flex justify-end gap-1'>
-                          {link && (
-                            <Button variant='outline' size='sm' asChild>
-                              <a
-                                href={link}
-                                target='_blank'
-                                rel='noopener noreferrer'
-                              >
-                                <IconExternalLink className='size-3.5' />
-                                Open
-                              </a>
-                            </Button>
-                          )}
-                          {actionable && (
-                            <>
-                              <Button
-                                size='sm'
-                                disabled={busyId === row.id}
-                                onClick={() => setApproving(row)}
-                              >
-                                Approve
-                              </Button>
-                              <Button
-                                size='sm'
-                                variant='outline'
-                                disabled={busyId === row.id}
-                                onClick={() => {
-                                  setRejectReason('');
-                                  setRejecting(row);
-                                }}
-                              >
-                                Reject
-                              </Button>
-                            </>
-                          )}
-                        </div>
-                      </TableCell>
+                      <TableActionCell>
+                        {link || actionable ? (
+                          <TableRowActions
+                            label='Open actions menu'
+                            menuLabel='Actions'
+                            loading={busyId === row.id}
+                          >
+                            {link && (
+                              <DropdownMenuItem asChild>
+                                <a
+                                  href={link}
+                                  target='_blank'
+                                  rel='noopener noreferrer'
+                                >
+                                  <IconExternalLink className='size-3.5' />
+                                  Open
+                                </a>
+                              </DropdownMenuItem>
+                            )}
+                            {link && actionable ? (
+                              <DropdownMenuSeparator />
+                            ) : null}
+                            {actionable && (
+                              <>
+                                <DropdownMenuItem
+                                  disabled={busyId === row.id}
+                                  onClick={() => setApproving(row)}
+                                >
+                                  <IconCheck className='size-3.5' />
+                                  Approve
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  variant='destructive'
+                                  disabled={busyId === row.id}
+                                  onClick={() => {
+                                    setRejectReason('');
+                                    setRejecting(row);
+                                  }}
+                                >
+                                  <IconX className='size-3.5' />
+                                  Reject
+                                </DropdownMenuItem>
+                              </>
+                            )}
+                          </TableRowActions>
+                        ) : (
+                          <span className='text-muted-foreground'>—</span>
+                        )}
+                      </TableActionCell>
                     </TableRow>
                   );
                 })}

--- a/apps/frontend/src/features/backoffice/components/offers-table.tsx
+++ b/apps/frontend/src/features/backoffice/components/offers-table.tsx
@@ -18,6 +18,13 @@ import { Input } from '@ringee/frontend-shared/components/ui/input';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { IconPlus } from '@tabler/icons-react';
+import { Eye } from 'lucide-react';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import {
   Table,
   TableBody,
@@ -147,7 +154,9 @@ export function OffersTable() {
                   <TableHead className='text-right'>Completed</TableHead>
                   <TableHead className='text-right'>Rewards</TableHead>
                   <TableHead className='text-right'>Credits</TableHead>
-                  <TableHead />
+                  <TableActionHead>
+                    <span className='sr-only'>Actions</span>
+                  </TableActionHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -186,6 +195,14 @@ export function OffersTable() {
                     </TableCell>
                     <TableCell>
                       <OfferStatusBadge status={offer.status} />
+                      {offer.pendingApproval > 0 && (
+                        <Badge
+                          variant='outline'
+                          className='mt-1 block w-fit text-amber-600'
+                        >
+                          {offer.pendingApproval} pending
+                        </Badge>
+                      )}
                     </TableCell>
                     <TableCell className='text-xs'>{offer.placement}</TableCell>
                     <TableCell className='text-xs'>
@@ -209,13 +226,19 @@ export function OffersTable() {
                     <TableCell className='text-right'>
                       ${formatMoney(offer.creditsIssued)}
                     </TableCell>
-                    <TableCell className='text-right'>
-                      {offer.pendingApproval > 0 && (
-                        <Badge variant='outline' className='text-amber-600'>
-                          {offer.pendingApproval} pending
-                        </Badge>
-                      )}
-                    </TableCell>
+                    <TableActionCell>
+                      <TableRowActions
+                        label='Open actions menu'
+                        menuLabel='Actions'
+                      >
+                        <DropdownMenuItem asChild>
+                          <Link href={`/backoffice/offers/${offer.id}`}>
+                            <Eye className='size-4' />
+                            View
+                          </Link>
+                        </DropdownMenuItem>
+                      </TableRowActions>
+                    </TableActionCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/frontend/src/features/callbacks/components/callback-list.tsx
+++ b/apps/frontend/src/features/callbacks/components/callback-list.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from 'react';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import {
   Card,
   CardContent,
@@ -59,6 +64,7 @@ const STATUS_COLORS: Record<string, string> = {
 export function CallbackList() {
   const api = useApi();
   const t = useTranslations('calls.callbacks.list');
+  const tCommon = useTranslations('common');
   const [callbacks, setCallbacks] = useState<CallbackEntry[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -121,7 +127,9 @@ export function CallbackList() {
                 <TableHead className='hidden sm:table-cell'>
                   {t('columns.note')}
                 </TableHead>
-                <TableHead className='w-[60px]'></TableHead>
+                <TableActionHead>
+                  <span className='sr-only'>{tCommon('actions')}</span>
+                </TableActionHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -156,18 +164,19 @@ export function CallbackList() {
                       {cb.note || '—'}
                     </span>
                   </TableCell>
-                  <TableCell>
+                  <TableActionCell>
                     {(cb.status === 'scheduled' || cb.status === 'due') && (
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        onClick={() => handleCancel(cb.id)}
-                        title={t('cancel')}
+                      <TableRowActions
+                        label={tCommon('openActions')}
+                        menuLabel={tCommon('actions')}
                       >
-                        <X className='text-muted-foreground h-4 w-4' />
-                      </Button>
+                        <DropdownMenuItem onClick={() => handleCancel(cb.id)}>
+                          <X className='h-4 w-4' />
+                          {t('cancel')}
+                        </DropdownMenuItem>
+                      </TableRowActions>
                     )}
-                  </TableCell>
+                  </TableActionCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/apps/frontend/src/features/calls/components/call-list-row-actions.tsx
+++ b/apps/frontend/src/features/calls/components/call-list-row-actions.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Link from 'next/link';
+import { Download, Eye, PhoneCall } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import { CallTranscriptionActions } from '@/features/transcription';
+import { RecordingPlayButton } from '@/features/recordings/components/recordings.tables/recording-play-button';
+import { useQuickDialerCall } from '@/features/calls/hooks/use.quick.dialer.call';
+
+interface CallListRowActionsProps {
+  callId: string;
+  recordingUrl?: string | null;
+  callFrom?: string;
+  callTo?: string;
+  phoneNumber?: string;
+}
+
+export function CallListRowActions({
+  callId,
+  recordingUrl,
+  callFrom,
+  callTo,
+  phoneNumber
+}: CallListRowActionsProps) {
+  const t = useTranslations('common');
+  const tHistory = useTranslations('calls.history.table');
+  const tRecordings = useTranslations('calls.recordings.table');
+  const { handleRecall } = useQuickDialerCall();
+
+  return (
+    <TableRowActions label={t('openActions')} menuLabel={t('actions')}>
+      <DropdownMenuItem asChild>
+        <Link href={`/dashboard/call/${callId}`}>
+          <Eye className='h-4 w-4' />
+          {t('view')}
+        </Link>
+      </DropdownMenuItem>
+
+      {phoneNumber ? (
+        <DropdownMenuItem onClick={() => handleRecall(phoneNumber)}>
+          <PhoneCall className='h-4 w-4' />
+          {tHistory('callAgain')}
+        </DropdownMenuItem>
+      ) : null}
+
+      <CallTranscriptionActions callId={callId} asMenuItem />
+
+      {recordingUrl && callFrom && callTo ? (
+        <>
+          <DropdownMenuSeparator />
+          <RecordingPlayButton
+            recordingUrl={recordingUrl}
+            callFrom={callFrom}
+            callTo={callTo}
+            asMenuItem
+          />
+          <DropdownMenuItem asChild>
+            <a href={recordingUrl} download>
+              <Download className='h-4 w-4' />
+              {tRecordings('downloadRecording')}
+            </a>
+          </DropdownMenuItem>
+        </>
+      ) : null}
+    </TableRowActions>
+  );
+}

--- a/apps/frontend/src/features/calls/components/call-list-row-actions.tsx
+++ b/apps/frontend/src/features/calls/components/call-list-row-actions.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { Download, Eye, PhoneCall } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -8,8 +9,12 @@ import {
   DropdownMenuSeparator
 } from '@ringee/frontend-shared/components/ui/dropdown-menu';
 import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
-import { CallTranscriptionActions } from '@/features/transcription';
+import {
+  CallTranscriptionActions,
+  TranscriptDialog
+} from '@/features/transcription';
 import { RecordingPlayButton } from '@/features/recordings/components/recordings.tables/recording-play-button';
+import { AudioPlayerModal } from '@/features/recordings/components/audio-player-modal';
 import { useQuickDialerCall } from '@/features/calls/hooks/use.quick.dialer.call';
 
 interface CallListRowActionsProps {
@@ -30,43 +35,68 @@ export function CallListRowActions({
   const t = useTranslations('common');
   const tHistory = useTranslations('calls.history.table');
   const tRecordings = useTranslations('calls.recordings.table');
+  const tPlayer = useTranslations('calls.recordings.player');
   const { handleRecall } = useQuickDialerCall();
+  const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [playerOpen, setPlayerOpen] = useState(false);
 
   return (
-    <TableRowActions label={t('openActions')} menuLabel={t('actions')}>
-      <DropdownMenuItem asChild>
-        <Link href={`/dashboard/call/${callId}`}>
-          <Eye className='h-4 w-4' />
-          {t('view')}
-        </Link>
-      </DropdownMenuItem>
-
-      {phoneNumber ? (
-        <DropdownMenuItem onClick={() => handleRecall(phoneNumber)}>
-          <PhoneCall className='h-4 w-4' />
-          {tHistory('callAgain')}
+    <>
+      <TableRowActions label={t('openActions')} menuLabel={t('actions')}>
+        <DropdownMenuItem asChild>
+          <Link href={`/dashboard/call/${callId}`}>
+            <Eye className='h-4 w-4' />
+            {t('view')}
+          </Link>
         </DropdownMenuItem>
-      ) : null}
 
-      <CallTranscriptionActions callId={callId} asMenuItem />
+        {phoneNumber ? (
+          <DropdownMenuItem onClick={() => handleRecall(phoneNumber)}>
+            <PhoneCall className='h-4 w-4' />
+            {tHistory('callAgain')}
+          </DropdownMenuItem>
+        ) : null}
+
+        <CallTranscriptionActions
+          callId={callId}
+          asMenuItem
+          onView={() => setTranscriptOpen(true)}
+        />
+
+        {recordingUrl && callFrom && callTo ? (
+          <>
+            <DropdownMenuSeparator />
+            <RecordingPlayButton
+              recordingUrl={recordingUrl}
+              callFrom={callFrom}
+              callTo={callTo}
+              asMenuItem
+              onPlay={() => setPlayerOpen(true)}
+            />
+            <DropdownMenuItem asChild>
+              <a href={recordingUrl} download>
+                <Download className='h-4 w-4' />
+                {tRecordings('downloadRecording')}
+              </a>
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </TableRowActions>
+
+      <TranscriptDialog
+        open={transcriptOpen}
+        onOpenChange={setTranscriptOpen}
+        callId={callId}
+      />
 
       {recordingUrl && callFrom && callTo ? (
-        <>
-          <DropdownMenuSeparator />
-          <RecordingPlayButton
-            recordingUrl={recordingUrl}
-            callFrom={callFrom}
-            callTo={callTo}
-            asMenuItem
-          />
-          <DropdownMenuItem asChild>
-            <a href={recordingUrl} download>
-              <Download className='h-4 w-4' />
-              {tRecordings('downloadRecording')}
-            </a>
-          </DropdownMenuItem>
-        </>
+        <AudioPlayerModal
+          isOpen={playerOpen}
+          onClose={() => setPlayerOpen(false)}
+          audioUrl={recordingUrl}
+          title={tPlayer('callTitle', { from: callFrom, to: callTo })}
+        />
       ) : null}
-    </TableRowActions>
+    </>
   );
 }

--- a/apps/frontend/src/features/campaigns/components/campaign-dispositions-tab.tsx
+++ b/apps/frontend/src/features/campaigns/components/campaign-dispositions-tab.tsx
@@ -37,6 +37,22 @@ import {
   DialogTrigger
 } from '@ringee/frontend-shared/components/ui/dialog';
 import { Checkbox } from '@ringee/frontend-shared/components/ui/checkbox';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@ringee/frontend-shared/components/ui/alert-dialog';
 import { Plus, Trash2, Loader2 } from 'lucide-react';
 import type { Disposition, DispositionCategory } from '../types/campaign.types';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
@@ -62,10 +78,12 @@ export function CampaignDispositionsTab({
 }: Props) {
   const api = useApi();
   const t = useTranslations('campaigns');
+  const tCommon = useTranslations('common');
   const [dispositions, setDispositions] = useState<Disposition[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Disposition | null>(null);
 
   const [newDispo, setNewDispo] = useState({
     code: '',
@@ -126,6 +144,7 @@ export function CampaignDispositionsTab({
   async function deleteDisposition(id: string) {
     try {
       await api.delete(`/campaigns/${campaignId}/dispositions/${id}`);
+      setDeleteTarget(null);
       await loadDispositions();
       toast.success(t('dispositions.toasts.removed'));
     } catch (err: any) {
@@ -236,7 +255,10 @@ export function CampaignDispositionsTab({
                       <Checkbox
                         checked={newDispo.triggersCompletion}
                         onCheckedChange={(v) =>
-                          setNewDispo({ ...newDispo, triggersCompletion: !!v })
+                          setNewDispo({
+                            ...newDispo,
+                            triggersCompletion: !!v
+                          })
                         }
                       />
                       {t('dispositions.triggers.completion')}
@@ -316,7 +338,9 @@ export function CampaignDispositionsTab({
                 <TableHead className='hidden md:table-cell'>
                   {t('dispositions.table.triggers')}
                 </TableHead>
-                <TableHead className='w-[60px]'></TableHead>
+                <TableActionHead>
+                  <span className='sr-only'>{tCommon('actions')}</span>
+                </TableActionHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -366,23 +390,54 @@ export function CampaignDispositionsTab({
                       )}
                     </div>
                   </TableCell>
-                  <TableCell>
+                  <TableActionCell>
                     {canManage && !d.isSystem && (
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        onClick={() => deleteDisposition(d.id)}
+                      <TableRowActions
+                        label={tCommon('openActions')}
+                        menuLabel={tCommon('actions')}
                       >
-                        <Trash2 className='text-muted-foreground h-4 w-4' />
-                      </Button>
+                        <DropdownMenuItem
+                          variant='destructive'
+                          onClick={() => setDeleteTarget(d)}
+                        >
+                          <Trash2 className='h-4 w-4' />
+                          {tCommon('delete')}
+                        </DropdownMenuItem>
+                      </TableRowActions>
                     )}
-                  </TableCell>
+                  </TableActionCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         )}
       </CardContent>
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{tCommon('areYouSure')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {tCommon('cannotBeUndone')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{tCommon('cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+              onClick={(event) => {
+                event.preventDefault();
+                if (deleteTarget) void deleteDisposition(deleteTarget.id);
+              }}
+            >
+              {tCommon('delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 }

--- a/apps/frontend/src/features/campaigns/components/campaign-leads-tab.tsx
+++ b/apps/frontend/src/features/campaigns/components/campaign-leads-tab.tsx
@@ -35,9 +35,14 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger
+  AlertDialogTitle
 } from '@ringee/frontend-shared/components/ui/alert-dialog';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import { Upload, UserPlus, Plus, Trash2, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
@@ -104,6 +109,7 @@ export function CampaignLeadsTab({
 }: Props) {
   const api = useApi();
   const t = useTranslations('campaigns');
+  const tCommon = useTranslations('common');
   const [leads, setLeads] = useState<CampaignLead[]>([]);
   const [loading, setLoading] = useState(true);
   const [total, setTotal] = useState(0);
@@ -112,6 +118,7 @@ export function CampaignLeadsTab({
   const [importOpen, setImportOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CampaignLead | null>(null);
   const limit = 20;
 
   useEffect(() => {
@@ -160,6 +167,7 @@ export function CampaignLeadsTab({
         await loadLeads();
       }
       onLeadsChanged?.();
+      setDeleteTarget(null);
     } catch (err: any) {
       toast.error(err?.message || t('leads.toasts.removeError'));
     } finally {
@@ -278,11 +286,11 @@ export function CampaignLeadsTab({
                       {t('leads.table.lastCall')}
                     </TableHead>
                     {canManageLeads && (
-                      <TableHead className='w-[60px] text-right'>
+                      <TableActionHead>
                         <span className='sr-only'>
                           {t('leads.table.actions')}
                         </span>
-                      </TableHead>
+                      </TableActionHead>
                     )}
                   </TableRow>
                 </TableHeader>
@@ -327,65 +335,29 @@ export function CampaignLeadsTab({
                           : '—'}
                       </TableCell>
                       {canManageLeads && (
-                        <TableCell className='text-right'>
-                          {IN_FLIGHT_STATUSES.includes(lead.status) ? (
-                            <Button
-                              variant='ghost'
-                              size='icon'
-                              disabled
-                              title={t('leads.inFlightHint')}
+                        <TableActionCell>
+                          <TableRowActions
+                            label={tCommon('openActions')}
+                            menuLabel={t('leads.table.actions')}
+                            loading={deletingId === lead.id}
+                          >
+                            <DropdownMenuItem
+                              variant='destructive'
+                              disabled={IN_FLIGHT_STATUSES.includes(
+                                lead.status
+                              )}
+                              title={
+                                IN_FLIGHT_STATUSES.includes(lead.status)
+                                  ? t('leads.inFlightHint')
+                                  : undefined
+                              }
+                              onClick={() => setDeleteTarget(lead)}
                             >
-                              <Trash2 className='text-muted-foreground/40 h-4 w-4' />
-                            </Button>
-                          ) : (
-                            <AlertDialog>
-                              <AlertDialogTrigger asChild>
-                                <Button
-                                  variant='ghost'
-                                  size='icon'
-                                  disabled={deletingId === lead.id}
-                                  aria-label={t('leads.removeAria', {
-                                    name:
-                                      lead.contact.name ||
-                                      t('leads.fallbackName')
-                                  })}
-                                >
-                                  {deletingId === lead.id ? (
-                                    <Loader2 className='h-4 w-4 animate-spin' />
-                                  ) : (
-                                    <Trash2 className='text-muted-foreground hover:text-destructive h-4 w-4' />
-                                  )}
-                                </Button>
-                              </AlertDialogTrigger>
-                              <AlertDialogContent>
-                                <AlertDialogHeader>
-                                  <AlertDialogTitle>
-                                    {t('leads.removeDialog.title')}
-                                  </AlertDialogTitle>
-                                  <AlertDialogDescription>
-                                    {t('leads.removeDialog.description', {
-                                      name:
-                                        lead.contact.name ||
-                                        t('leads.fallbackName'),
-                                      phone: lead.contact.phoneNumber
-                                    })}
-                                  </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                  <AlertDialogCancel>
-                                    {t('leads.removeDialog.cancel')}
-                                  </AlertDialogCancel>
-                                  <AlertDialogAction
-                                    onClick={() => handleDelete(lead)}
-                                    className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
-                                  >
-                                    {t('leads.removeDialog.confirm')}
-                                  </AlertDialogAction>
-                                </AlertDialogFooter>
-                              </AlertDialogContent>
-                            </AlertDialog>
-                          )}
-                        </TableCell>
+                              <Trash2 className='h-4 w-4' />
+                              {t('leads.removeDialog.confirm')}
+                            </DropdownMenuItem>
+                          </TableRowActions>
+                        </TableActionCell>
                       )}
                     </TableRow>
                   ))}
@@ -421,6 +393,41 @@ export function CampaignLeadsTab({
           )}
         </CardContent>
       </Card>
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('leads.removeDialog.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('leads.removeDialog.description', {
+                name: deleteTarget?.contact.name || t('leads.fallbackName'),
+                phone: deleteTarget?.contact.phoneNumber || ''
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t('leads.removeDialog.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={!deleteTarget || deletingId === deleteTarget?.id}
+              onClick={(event) => {
+                event.preventDefault();
+                if (deleteTarget) void handleDelete(deleteTarget);
+              }}
+              className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+            >
+              {deletingId === deleteTarget?.id ? (
+                <Loader2 className='h-4 w-4 animate-spin' />
+              ) : null}
+              {t('leads.removeDialog.confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <ImportLeadsModal
         campaignId={campaignId}

--- a/apps/frontend/src/features/contact/components/contact-table-client.tsx
+++ b/apps/frontend/src/features/contact/components/contact-table-client.tsx
@@ -15,7 +15,11 @@ export function ContactTableClient({
   totalItems
 }: ContactTableClientProps) {
   const t = useTranslations('contacts.table');
-  const columns = useMemo(() => getContactColumns(t), [t]);
+  const tHeaders = useTranslations('tables.headers');
+  const columns = useMemo(
+    () => getContactColumns(t, tHeaders('actions')),
+    [t, tHeaders]
+  );
 
   return <ContactTable data={data} totalItems={totalItems} columns={columns} />;
 }

--- a/apps/frontend/src/features/contact/components/contact.tables/cell-action.tsx
+++ b/apps/frontend/src/features/contact/components/contact.tables/cell-action.tsx
@@ -1,19 +1,15 @@
 'use client';
 import { AlertModal } from '@ringee/frontend-shared/components/modal/alert-modal';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger
+  DropdownMenuSeparator
 } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
 import { CreateNoteModal } from '@/features/contact/components/create.note.modal';
 import { ManageContactTagsModal } from '@/features/contact/components/manage-contact-tags-popover';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import {
   IconEdit,
-  IconDotsVertical,
   IconTrash,
   IconPhoneCall,
   IconPlus,
@@ -44,6 +40,7 @@ interface CellActionProps {
 
 export const CellAction: React.FC<CellActionProps> = ({ data }) => {
   const t = useTranslations('contacts.rowActions');
+  const tCommon = useTranslations('common');
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const router = useRouter();
@@ -89,49 +86,40 @@ export const CellAction: React.FC<CellActionProps> = ({ data }) => {
         onConfirm={onConfirm}
         loading={loading}
       />
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button variant='ghost' className='h-8 w-8 p-0'>
-            <span className='sr-only'>{t('openMenu')}</span>
-            <IconDotsVertical className='h-4 w-4' />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='end'>
-          <DropdownMenuLabel>{t('menu')}</DropdownMenuLabel>
+      <TableRowActions label={tCommon('openActions')} menuLabel={t('menu')}>
+        <DropdownMenuItem
+          onClick={() => router.push(`/dashboard/contact/${data.id}`)}
+        >
+          <IconEye className='mr-2 h-4 w-4' /> {t('view')}
+        </DropdownMenuItem>
 
-          <DropdownMenuItem
-            onClick={() => router.push(`/dashboard/contact/${data.id}`)}
-          >
-            <IconEye className='mr-2 h-4 w-4' /> {t('view')}
-          </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() =>
+            router.push(`/dashboard/call?phoneNumber=${data.phoneNumber}`)
+          }
+        >
+          <IconPhoneCall className='mr-2 h-4 w-4' /> {t('call')}
+        </DropdownMenuItem>
 
-          <DropdownMenuItem
-            onClick={() =>
-              router.push(`/dashboard/call?phoneNumber=${data.phoneNumber}`)
-            }
-          >
-            <IconPhoneCall className='mr-2 h-4 w-4' /> {t('call')}
-          </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setNoteModalOpen(true)}>
+          <IconPlus className='mr-2 h-4 w-4' /> {t('addNote')}
+        </DropdownMenuItem>
 
-          <DropdownMenuItem onClick={() => setNoteModalOpen(true)}>
-            <IconPlus className='mr-2 h-4 w-4' /> {t('addNote')}
-          </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTagsModalOpen(true)}>
+          <IconTag className='mr-2 h-4 w-4' /> {t('manageTags')}
+        </DropdownMenuItem>
 
-          <DropdownMenuItem onClick={() => setTagsModalOpen(true)}>
-            <IconTag className='mr-2 h-4 w-4' /> {t('manageTags')}
-          </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => router.push(`/dashboard/contact/${data.id}/edit`)}
+        >
+          <IconEdit className='mr-2 h-4 w-4' /> {t('edit')}
+        </DropdownMenuItem>
 
-          <DropdownMenuItem
-            onClick={() => router.push(`/dashboard/contact/${data.id}/edit`)}
-          >
-            <IconEdit className='mr-2 h-4 w-4' /> {t('edit')}
-          </DropdownMenuItem>
-
-          <DropdownMenuItem onClick={() => setOpen(true)}>
-            <IconTrash className='mr-2 h-4 w-4' /> {t('delete')}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant='destructive' onClick={() => setOpen(true)}>
+          <IconTrash className='mr-2 h-4 w-4' /> {t('delete')}
+        </DropdownMenuItem>
+      </TableRowActions>
     </>
   );
 };

--- a/apps/frontend/src/features/contact/components/contact.tables/columns.tsx
+++ b/apps/frontend/src/features/contact/components/contact.tables/columns.tsx
@@ -2,12 +2,9 @@
 
 import { DataTableColumnHeader } from '@ringee/frontend-shared/components/ui/table/data-table-column-header';
 import { Column, ColumnDef } from '@tanstack/react-table';
-import { PhoneCall, Text } from 'lucide-react';
+import { Text } from 'lucide-react';
 import { CellAction } from './cell-action';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
-import { useRouter } from 'next/navigation';
-import { useDialerStore } from '@/features/calls/store/dialer.store';
 
 interface ContactTag {
   tag: {
@@ -37,7 +34,8 @@ export interface ContactRow {
 }
 
 export const getContactColumns = (
-  t: (key: string) => string
+  t: (key: string) => string,
+  actionsLabel: string
 ): ColumnDef<ContactRow>[] => [
   {
     id: 'name',
@@ -52,13 +50,9 @@ export const getContactColumns = (
         [contact.firstName, contact.lastName].filter(Boolean).join(' ') ||
         t('unknown');
       const initial = displayName.charAt(0)?.toUpperCase() || '?';
-      const router = useRouter();
 
       return (
-        <button
-          className='flex cursor-pointer items-center gap-2 text-left hover:underline'
-          onClick={() => router.push(`/dashboard/contact/${contact.id}`)}
-        >
+        <div className='flex items-center gap-2'>
           <div className='flex items-center justify-center'>
             <div className='bg-primary flex h-10 w-10 items-center justify-center rounded-full font-semibold text-white'>
               {initial}
@@ -72,7 +66,7 @@ export const getContactColumns = (
               </div>
             )}
           </div>
-        </button>
+        </div>
       );
     },
     meta: {
@@ -163,35 +157,18 @@ export const getContactColumns = (
   },
   {
     accessorKey: 'phoneNumber',
-    header: t('call'),
-    cell: ({ cell }) => {
-      const phoneNumber = cell.getValue<string>();
-      const router = useRouter();
-      const dialer = useDialerStore();
-
-      return (
-        <div>
-          <Button
-            variant='secondary'
-            size='sm'
-            className='cursor-pointer gap-1'
-            onClick={() =>
-              dialer.quickDialState === 'open'
-                ? dialer.setNumber(phoneNumber)
-                : router.push(`/dashboard/call?phoneNumber=${phoneNumber}`)
-            }
-          >
-            <PhoneCall className='h-4 w-4' />
-            <span className='hidden sm:inline'>{phoneNumber}</span>
-            <span className='sm:hidden'>{t('call')}</span>
-          </Button>
-        </div>
-      );
-    }
+    header: t('phone'),
+    cell: ({ cell }) => (
+      <span className='text-muted-foreground font-mono text-sm'>
+        {cell.getValue<string>()}
+      </span>
+    )
   },
   {
-    accessorKey: 'actions',
     id: 'actions',
+    size: 160,
+    minSize: 160,
+    header: () => <span className='sr-only'>{actionsLabel}</span>,
     cell: ({ row }) => <CellAction data={row.original as any} />
   }
 ];

--- a/apps/frontend/src/features/contact/components/contact.tables/index.tsx
+++ b/apps/frontend/src/features/contact/components/contact.tables/index.tsx
@@ -28,7 +28,8 @@ export function ContactTable<TData, TValue>({
     columns,
     pageCount: pageCount,
     shallow: false,
-    debounceMs: 500
+    debounceMs: 500,
+    initialState: { columnPinning: { right: ['actions'] } }
   });
 
   return (

--- a/apps/frontend/src/features/desk-phones/components/desk-phones-view.tsx
+++ b/apps/frontend/src/features/desk-phones/components/desk-phones-view.tsx
@@ -13,6 +13,10 @@ import {
   TableHeader,
   TableRow
 } from '@ringee/frontend-shared/components/ui/table';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import { format } from 'date-fns';
 import { useDeskPhones } from '../hooks/use-desk-phones';
 import type { CreatedSipDevice, SipDevice, SipDeviceStatus } from '../types';
@@ -67,9 +71,9 @@ export function DeskPhonesView() {
                 <TableHead>{t('columns.outbound')}</TableHead>
                 <TableHead>{t('columns.status')}</TableHead>
                 <TableHead>{t('columns.lastSeen')}</TableHead>
-                <TableHead className='text-right'>
-                  {t('columns.actions')}
-                </TableHead>
+                <TableActionHead>
+                  <span className='sr-only'>{t('columns.actions')}</span>
+                </TableActionHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -130,7 +134,7 @@ export function DeskPhonesView() {
                         ? format(new Date(d.lastRegisteredAt), 'dd MMM, HH:mm')
                         : '—'}
                     </TableCell>
-                    <TableCell className='text-right'>
+                    <TableActionCell>
                       <DeviceActions
                         device={d}
                         otherDevices={dp.devices.filter((x) => x.id !== d.id)}
@@ -142,7 +146,7 @@ export function DeskPhonesView() {
                         onRemove={dp.remove}
                         onCredentials={showCredentials}
                       />
-                    </TableCell>
+                    </TableActionCell>
                   </TableRow>
                 ))
               )}

--- a/apps/frontend/src/features/desk-phones/components/device-actions.tsx
+++ b/apps/frontend/src/features/desk-phones/components/device-actions.tsx
@@ -3,12 +3,10 @@
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
+  DropdownMenuSeparator
 } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -44,6 +42,14 @@ import type {
   SipDevice
 } from '../types';
 import { useTranslations } from 'next-intl';
+import {
+  KeyRound,
+  Phone,
+  Power,
+  PowerOff,
+  RefreshCw,
+  Trash2
+} from 'lucide-react';
 
 interface Props {
   device: SipDevice;
@@ -77,6 +83,7 @@ export function DeviceActions({
   onCredentials
 }: Props) {
   const t = useTranslations('calls.deskPhones.actions');
+  const tCommon = useTranslations('common');
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [regenOpen, setRegenOpen] = useState(false);
   const [changeOpen, setChangeOpen] = useState(false);
@@ -106,53 +113,55 @@ export function DeviceActions({
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant='ghost' size='sm'>
-            {t('menu')}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='end'>
-          <DropdownMenuItem
-            onClick={() =>
-              run(
-                () => onCheckRegistration(device.id),
-                t('toasts.registrationRefreshed'),
-                t('toasts.checkFailed')
-              )
-            }
-          >
-            {t('checkRegistration')}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setChangeOpen(true)}>
-            {t('changeNumber')}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setRegenOpen(true)}>
-            {t('regeneratePassword')}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() =>
-              run(
-                () => onSetEnabled(device.id, disabled),
-                disabled ? t('toasts.enabled') : t('toasts.disabled'),
-                t('toasts.updateFailed')
-              )
-            }
-          >
-            {disabled ? t('enable') : t('disable')}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            className='text-destructive'
-            onClick={() => {
-              setReroute('ringee');
-              setDeleteOpen(true);
-            }}
-          >
-            {t('delete')}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <TableRowActions label={tCommon('openActions')} menuLabel={t('menu')}>
+        <DropdownMenuItem
+          onClick={() =>
+            run(
+              () => onCheckRegistration(device.id),
+              t('toasts.registrationRefreshed'),
+              t('toasts.checkFailed')
+            )
+          }
+        >
+          <RefreshCw className='h-4 w-4' />
+          {t('checkRegistration')}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setChangeOpen(true)}>
+          <Phone className='h-4 w-4' />
+          {t('changeNumber')}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setRegenOpen(true)}>
+          <KeyRound className='h-4 w-4' />
+          {t('regeneratePassword')}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() =>
+            run(
+              () => onSetEnabled(device.id, disabled),
+              disabled ? t('toasts.enabled') : t('toasts.disabled'),
+              t('toasts.updateFailed')
+            )
+          }
+        >
+          {disabled ? (
+            <Power className='h-4 w-4' />
+          ) : (
+            <PowerOff className='h-4 w-4' />
+          )}
+          {disabled ? t('enable') : t('disable')}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant='destructive'
+          onClick={() => {
+            setReroute('ringee');
+            setDeleteOpen(true);
+          }}
+        >
+          <Trash2 className='h-4 w-4' />
+          {t('delete')}
+        </DropdownMenuItem>
+      </TableRowActions>
 
       {/* Regenerate password */}
       <AlertDialog open={regenOpen} onOpenChange={setRegenOpen}>

--- a/apps/frontend/src/features/dnc/components/dnc-list.tsx
+++ b/apps/frontend/src/features/dnc/components/dnc-list.tsx
@@ -29,6 +29,22 @@ import {
 } from '@ringee/frontend-shared/components/ui/dialog';
 import { Label } from '@ringee/frontend-shared/components/ui/label';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@ringee/frontend-shared/components/ui/alert-dialog';
 import { Plus, Trash2, Upload, Search, ShieldBan, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -53,6 +69,7 @@ interface DNCListResponse {
 export function DNCList() {
   const api = useApi();
   const t = useTranslations('calls.dnc.list');
+  const tCommon = useTranslations('common');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [entries, setEntries] = useState<DNCEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -64,6 +81,7 @@ export function DNCList() {
   const [newReason, setNewReason] = useState('');
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<DNCEntry | null>(null);
   const limit = 20;
 
   useEffect(() => {
@@ -111,9 +129,11 @@ export function DNCList() {
     }
   }
 
-  async function handleDelete(id: string) {
+  async function handleDelete() {
+    if (!deleteTarget) return;
     try {
-      await api.delete(`/dnc/${id}`);
+      await api.delete(`/dnc/${deleteTarget.id}`);
+      setDeleteTarget(null);
       await loadEntries();
     } catch {
       // handled
@@ -266,7 +286,9 @@ export function DNCList() {
                   <TableHead className='hidden sm:table-cell'>
                     {t('columns.added')}
                   </TableHead>
-                  <TableHead className='w-[60px]'></TableHead>
+                  <TableActionHead>
+                    <span className='sr-only'>{tCommon('actions')}</span>
+                  </TableActionHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -282,15 +304,20 @@ export function DNCList() {
                     <TableCell className='hidden sm:table-cell'>
                       {new Date(entry.createdAt).toLocaleDateString()}
                     </TableCell>
-                    <TableCell>
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        onClick={() => handleDelete(entry.id)}
+                    <TableActionCell>
+                      <TableRowActions
+                        label={tCommon('openActions')}
+                        menuLabel={tCommon('actions')}
                       >
-                        <Trash2 className='text-muted-foreground h-4 w-4' />
-                      </Button>
-                    </TableCell>
+                        <DropdownMenuItem
+                          variant='destructive'
+                          onClick={() => setDeleteTarget(entry)}
+                        >
+                          <Trash2 className='h-4 w-4' />
+                          {tCommon('delete')}
+                        </DropdownMenuItem>
+                      </TableRowActions>
+                    </TableActionCell>
                   </TableRow>
                 ))}
               </TableBody>
@@ -324,6 +351,29 @@ export function DNCList() {
           </>
         )}
       </CardContent>
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{tCommon('areYouSure')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {tCommon('cannotBeUndone')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{tCommon('cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+              onClick={() => void handleDelete()}
+            >
+              {tCommon('delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 }

--- a/apps/frontend/src/features/history/components/call.history.tables/cell-action.tsx
+++ b/apps/frontend/src/features/history/components/call.history.tables/cell-action.tsx
@@ -1,13 +1,10 @@
 'use client';
 import { AlertModal } from '@ringee/frontend-shared/components/modal/alert-modal';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger
+  DropdownMenuSeparator
 } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
 import { CreateNoteModal } from '@/features/contact/components/create.note.modal';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import {
@@ -19,7 +16,6 @@ import {
 import { FinalTranscript } from '@/features/transcription';
 import {
   IconEdit,
-  IconDotsVertical,
   IconTrash,
   IconPhoneCall,
   IconPlus,
@@ -50,6 +46,7 @@ interface CellActionProps {
 
 export const CellAction: React.FC<CellActionProps> = ({ data }) => {
   const t = useTranslations('calls.history.rowActions');
+  const tCommon = useTranslations('common');
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const api = useApi();
@@ -102,41 +99,32 @@ export const CellAction: React.FC<CellActionProps> = ({ data }) => {
           </div>
         </DialogContent>
       </Dialog>
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button variant='ghost' className='h-8 w-8 p-0'>
-            <span className='sr-only'>{t('openMenu')}</span>
-            <IconDotsVertical className='h-4 w-4' />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='end'>
-          <DropdownMenuLabel>{t('menu')}</DropdownMenuLabel>
+      <TableRowActions label={tCommon('openActions')} menuLabel={t('menu')}>
+        <DropdownMenuItem onClick={() => handleRecall(data.phoneNumber)}>
+          <IconPhoneCall className='mr-2 h-4 w-4' /> {t('call')}
+        </DropdownMenuItem>
 
-          <DropdownMenuItem onClick={() => handleRecall(data.phoneNumber)}>
-            <IconPhoneCall className='mr-2 h-4 w-4' /> {t('call')}
+        <DropdownMenuItem onClick={() => setNoteModalOpen(true)}>
+          <IconPlus className='mr-2 h-4 w-4' /> {t('addNote')}
+        </DropdownMenuItem>
+
+        {latestCallId && (
+          <DropdownMenuItem onClick={() => setTranscriptOpen(true)}>
+            <IconFileText className='mr-2 h-4 w-4' /> {t('transcript')}
           </DropdownMenuItem>
+        )}
 
-          <DropdownMenuItem onClick={() => setNoteModalOpen(true)}>
-            <IconPlus className='mr-2 h-4 w-4' /> {t('addNote')}
-          </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => router.push(`/dashboard/contact/${data.id}`)}
+        >
+          <IconEdit className='mr-2 h-4 w-4' /> {t('update')}
+        </DropdownMenuItem>
 
-          {latestCallId && (
-            <DropdownMenuItem onClick={() => setTranscriptOpen(true)}>
-              <IconFileText className='mr-2 h-4 w-4' /> {t('transcript')}
-            </DropdownMenuItem>
-          )}
-
-          <DropdownMenuItem
-            onClick={() => router.push(`/dashboard/contact/${data.id}`)}
-          >
-            <IconEdit className='mr-2 h-4 w-4' /> {t('update')}
-          </DropdownMenuItem>
-
-          <DropdownMenuItem onClick={() => setOpen(true)}>
-            <IconTrash className='mr-2 h-4 w-4' /> {t('delete')}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant='destructive' onClick={() => setOpen(true)}>
+          <IconTrash className='mr-2 h-4 w-4' /> {t('delete')}
+        </DropdownMenuItem>
+      </TableRowActions>
     </>
   );
 };

--- a/apps/frontend/src/features/history/components/call.history.tables/columns.tsx
+++ b/apps/frontend/src/features/history/components/call.history.tables/columns.tsx
@@ -6,26 +6,13 @@ import {
   Clock,
   PhoneIncoming,
   PhoneOutgoing,
-  PlayCircle,
-  Phone,
-  Download,
   Loader2,
   AlertCircle,
-  CheckCircle2,
-  ChevronRight
+  CheckCircle2
 } from 'lucide-react';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { cn } from '@ringee/frontend-shared/lib/utils';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
-} from '@ringee/frontend-shared/components/ui/tooltip';
-import { useQuickDialerCall } from '@/features/calls/hooks/use.quick.dialer.call';
-import { RecordingPlayButton } from '@/features/recordings/components/recordings.tables/recording-play-button';
 import { useTranslations } from 'next-intl';
-import { CallTranscriptionActions } from '@/features/transcription';
 // Imported from the modules themselves, not the feature barrel: the barrel
 // re-exports the detail screen, and pulling that into the history bundle would
 // ship the whole page to a route that only renders a badge.
@@ -34,7 +21,7 @@ import type {
   CallListAgentRef,
   CallSource
 } from '@/features/call-detail/types';
-import Link from 'next/link';
+import { CallListRowActions } from '@/features/calls/components/call-list-row-actions';
 
 type RecordingData = {
   id: string;
@@ -97,44 +84,19 @@ export const columns: ColumnDef<Call>[] = [
       return <DataTableColumnHeader column={column} title={t('type')} />;
     },
     cell: ({ row }) => {
-      const t = useTranslations('calls.history.table');
       const direction = row.original.direction;
       const Icon = direction === 'inbound' ? PhoneIncoming : PhoneOutgoing;
-      const phoneNumber =
-        direction === 'inbound'
-          ? row.original.fromNumber
-          : row.original.toNumber;
-
-      const { isQuickDialerOpen, handleRecall } = useQuickDialerCall();
 
       return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant='ghost'
-              className='border-b border-blue-500'
-              onClick={() => handleRecall(phoneNumber)}
-            >
-              <div className='flex w-full items-center gap-2 sm:w-[50%]'>
-                <Icon
-                  className={cn(
-                    'h-4 w-4',
-                    direction === 'inbound' ? 'text-green-500' : 'text-blue-500'
-                  )}
-                />
-                <span className='capitalize'>{direction}</span>
-              </div>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent
-            side='top'
-            align='center'
-            className='flex items-center gap-2'
-          >
-            <Phone className='h-4 w-4' />
-            <span>{t('callAgain')}</span>
-          </TooltipContent>
-        </Tooltip>
+        <div className='flex items-center gap-2'>
+          <Icon
+            className={cn(
+              'h-4 w-4',
+              direction === 'inbound' ? 'text-green-500' : 'text-blue-500'
+            )}
+          />
+          <span className='capitalize'>{direction}</span>
+        </div>
       );
     }
   },
@@ -147,20 +109,9 @@ export const columns: ColumnDef<Call>[] = [
     cell: ({ row }) => {
       const t = useTranslations('calls.history.table');
       const name = row.original.contact?.name || t('unknown');
-      const phoneNumber =
-        row.original.direction === 'inbound'
-          ? row.original.fromNumber
-          : row.original.toNumber;
-      const { handleRecall } = useQuickDialerCall();
 
       return name !== t('unknown') ? (
-        <Button
-          variant='link'
-          className='text-foreground p-0 font-medium'
-          onClick={() => handleRecall(phoneNumber)}
-        >
-          {name}
-        </Button>
+        <span className='text-foreground font-medium'>{name}</span>
       ) : (
         <span className='text-muted-foreground font-medium'>{name}</span>
       );
@@ -318,48 +269,38 @@ export const columns: ColumnDef<Call>[] = [
         );
       }
 
+      const config = statusConfig.completed;
+      const StatusIcon = config.icon;
       return (
-        <div className='flex items-center gap-2'>
-          <RecordingPlayButton
-            recordingUrl={recordingUrl}
-            callFrom={row.original.fromNumber}
-            callTo={row.original.toNumber}
-          />
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button size='sm' variant='ghost' asChild>
-                <a href={recordingUrl} download>
-                  <Download className='h-4 w-4' />
-                </a>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('downloadRecording')}</TooltipContent>
-          </Tooltip>
-        </div>
+        <Badge variant={config.variant} className='gap-1'>
+          <StatusIcon className='h-3 w-3' />
+          {tStatus('completed' as any) || config.label}
+        </Badge>
       );
     }
   },
   {
-    id: 'transcript',
+    id: 'actions',
+    size: 160,
+    minSize: 160,
     header: () => {
-      const t = useTranslations('calls.history.table');
-      return <>{t('transcript')}</>;
+      const t = useTranslations('tables.headers');
+      return <span className='sr-only'>{t('actions')}</span>;
     },
-    cell: ({ row }) => <CallTranscriptionActions callId={row.original.id} />
-  },
-  {
-    id: 'details',
-    header: () => null,
     cell: ({ row }) => {
-      const t = useTranslations('calls.history.table');
+      const recordingUrl = row.original.recordings?.[0]?.url;
+      const phoneNumber =
+        row.original.direction === 'inbound'
+          ? row.original.fromNumber
+          : row.original.toNumber;
       return (
-        <Button asChild size='sm' variant='ghost' className='rounded-lg'>
-          <Link href={`/dashboard/call/${row.original.id}`}>
-            {t('details')}
-            <ChevronRight className='h-4 w-4' />
-          </Link>
-        </Button>
+        <CallListRowActions
+          callId={row.original.id}
+          recordingUrl={recordingUrl}
+          callFrom={row.original.fromNumber}
+          callTo={row.original.toNumber}
+          phoneNumber={phoneNumber}
+        />
       );
     }
   }

--- a/apps/frontend/src/features/history/components/call.history.tables/index.tsx
+++ b/apps/frontend/src/features/history/components/call.history.tables/index.tsx
@@ -44,7 +44,10 @@ export function CallTable<TData, TValue>({
     pageCount: pageCount,
     shallow: false,
     debounceMs: 500,
-    initialState: { columnVisibility: { memberId: false } }
+    initialState: {
+      columnVisibility: { memberId: false },
+      columnPinning: { right: ['actions'] }
+    }
   });
 
   const memberTableColumn = memberColumn

--- a/apps/frontend/src/features/meetings/components/meetings-list.tsx
+++ b/apps/frontend/src/features/meetings/components/meetings-list.tsx
@@ -22,6 +22,8 @@ import {
 import { DataTable } from '@ringee/frontend-shared/components/ui/table/data-table';
 import { DataTableSkeleton } from '@ringee/frontend-shared/components/ui/table/data-table-skeleton';
 import { Input } from '@ringee/frontend-shared/components/ui/input';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
 import {
   useReactTable,
   getCoreRowModel,
@@ -61,7 +63,8 @@ import {
   List,
   ChevronLeft,
   ChevronRight,
-  Link2
+  Link2,
+  Eye
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { CalendarIntegrations } from './calendar-integrations';
@@ -101,6 +104,7 @@ interface MeetingsResponse {
 
 export function MeetingsList() {
   const t = useTranslations('meetings');
+  const tCommon = useTranslations('common');
   const api = useApi();
   const [meetings, setMeetings] = useState<Meeting[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -223,6 +227,7 @@ export function MeetingsList() {
               meetings={upcoming}
               onSelect={setSelectedMeeting}
               t={t}
+              tCommon={tCommon}
             />
           )}
         </TabsContent>
@@ -248,6 +253,7 @@ export function MeetingsList() {
                     meetings={upcoming}
                     onSelect={setSelectedMeeting}
                     t={t}
+                    tCommon={tCommon}
                   />
                 </div>
               )}
@@ -260,6 +266,7 @@ export function MeetingsList() {
                     meetings={past}
                     onSelect={setSelectedMeeting}
                     t={t}
+                    tCommon={tCommon}
                   />
                 </div>
               )}
@@ -459,7 +466,8 @@ function MeetingDetail({
 
 function getColumns(
   onSelect: (m: Meeting) => void,
-  t: TFunc
+  t: TFunc,
+  tCommon: TFunc
 ): ColumnDef<Meeting>[] {
   return [
     {
@@ -546,18 +554,20 @@ function getColumns(
     },
     {
       id: 'actions',
+      size: 160,
+      minSize: 160,
+      header: () => <span className='sr-only'>{tCommon('actions')}</span>,
       cell: ({ row }) => (
-        <div className='flex justify-end'>
-          <Button
-            variant='ghost'
-            size='sm'
-            onClick={() => onSelect(row.original)}
-          >
+        <TableRowActions
+          label={tCommon('openActions')}
+          menuLabel={tCommon('actions')}
+        >
+          <DropdownMenuItem onClick={() => onSelect(row.original)}>
+            <Eye className='h-4 w-4' />
             {t('viewDetails')}
-          </Button>
-        </div>
-      ),
-      meta: { className: 'w-[100px]' }
+          </DropdownMenuItem>
+        </TableRowActions>
+      )
     }
   ];
 }
@@ -565,15 +575,18 @@ function getColumns(
 function MeetingRows({
   meetings,
   onSelect,
-  t
+  t,
+  tCommon
 }: {
   meetings: Meeting[];
   onSelect: (m: Meeting) => void;
   t: TFunc;
+  tCommon: TFunc;
 }) {
   const table = useReactTable({
     data: meetings,
-    columns: getColumns(onSelect, t),
+    columns: getColumns(onSelect, t, tCommon),
+    initialState: { columnPinning: { right: ['actions'] } },
     getCoreRowModel: getCoreRowModel()
   });
 

--- a/apps/frontend/src/features/number/components/caller-id.listing.tsx
+++ b/apps/frontend/src/features/number/components/caller-id.listing.tsx
@@ -12,6 +12,15 @@ import {
 } from '@tabler/icons-react';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { Switch } from '@ringee/frontend-shared/components/ui/switch';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
@@ -53,6 +62,7 @@ const STATUS_CLASS: Record<CallerIdStatus, string> = {
 
 export function CallerIdListing() {
   const t = useTranslations('settings.numbers.callerIds');
+  const tCommon = useTranslations('common');
   const api = useApi();
 
   const [loading, setLoading] = useState(true);
@@ -174,9 +184,9 @@ export function CallerIdListing() {
                 <TableHead>{t('table.status')}</TableHead>
                 <TableHead>{t('table.active')}</TableHead>
                 <TableHead>{t('table.addedOn')}</TableHead>
-                <TableHead className='text-right'>
-                  {t('table.actions')}
-                </TableHead>
+                <TableActionHead>
+                  <span className='sr-only'>{t('table.actions')}</span>
+                </TableActionHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -216,31 +226,31 @@ export function CallerIdListing() {
                         ? format(new Date(callerId.createdAt), 'dd MMM yyyy')
                         : '—'}
                     </TableCell>
-                    <TableCell>
-                      <div className='flex items-center justify-end gap-2'>
+                    <TableActionCell>
+                      <TableRowActions
+                        label={tCommon('openActions')}
+                        menuLabel={t('table.actions')}
+                      >
                         {needsVerify && (
-                          <Button
-                            size='sm'
-                            variant='outline'
+                          <DropdownMenuItem
                             onClick={() => setVerifyTarget(callerId)}
                           >
-                            <IconShieldCheck className='mr-1.5 h-4 w-4' />
+                            <IconShieldCheck className='h-4 w-4' />
                             {status === 'failed'
                               ? t('actions.verify')
                               : t('actions.enterCode')}
-                          </Button>
+                          </DropdownMenuItem>
                         )}
-                        <Button
-                          size='icon'
-                          variant='ghost'
-                          className='text-muted-foreground hover:text-red-600'
+                        {needsVerify && <DropdownMenuSeparator />}
+                        <DropdownMenuItem
+                          variant='destructive'
                           onClick={() => setDeleteTarget(callerId)}
-                          aria-label={t('actions.delete')}
                         >
                           <IconTrash className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </TableCell>
+                          {t('actions.delete')}
+                        </DropdownMenuItem>
+                      </TableRowActions>
+                    </TableActionCell>
                   </TableRow>
                 );
               })}

--- a/apps/frontend/src/features/number/components/tables/buy.number.cell.action.tsx
+++ b/apps/frontend/src/features/number/components/tables/buy.number.cell.action.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Button } from '@ringee/frontend-shared/components/ui/button';
-import { IconLoader2, IconShoppingCart } from '@tabler/icons-react';
+import { IconShoppingCart } from '@tabler/icons-react';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
 import { toast } from 'sonner';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { useState } from 'react';
@@ -20,6 +21,7 @@ interface RequirementsResponse {
 
 export const CellActionBuy = ({ data }: { data: AvailableNumber }) => {
   const t = useTranslations('settings.numbers.buy');
+  const tCommon = useTranslations('common');
   const [loading, setLoading] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -82,20 +84,16 @@ export const CellActionBuy = ({ data }: { data: AvailableNumber }) => {
 
   return (
     <>
-      <Button
-        size='sm'
-        onClick={handleBuy}
-        disabled={busy}
-        variant='default'
-        className='cursor-pointer'
+      <TableRowActions
+        label={tCommon('openActions')}
+        menuLabel={tCommon('actions')}
+        loading={busy}
       >
-        {busy ? (
-          <IconLoader2 className='mr-2 h-4 w-4 animate-spin' />
-        ) : (
-          <IconShoppingCart className='mr-2 h-4 w-4' />
-        )}
-        {t('table.buy')}
-      </Button>
+        <DropdownMenuItem disabled={busy} onClick={() => void handleBuy()}>
+          <IconShoppingCart className='h-4 w-4' />
+          {t('table.buy')}
+        </DropdownMenuItem>
+      </TableRowActions>
 
       <PurchaseConfirmModal
         open={modalOpen}

--- a/apps/frontend/src/features/number/components/tables/buy.number.columns.tsx
+++ b/apps/frontend/src/features/number/components/tables/buy.number.columns.tsx
@@ -322,9 +322,11 @@ export const columns: ColumnDef<AvailableNumber>[] = [
   },
   {
     id: 'actions',
+    size: 160,
+    minSize: 160,
     header: () => {
       const t = useTranslations('settings.numbers.buy.table');
-      return <>{t('actions')}</>;
+      return <span className='sr-only'>{t('actions')}</span>;
     },
     cell: ({ row }) => <CellActionBuy data={row.original} />
   }

--- a/apps/frontend/src/features/number/components/tables/buy.number.table.tsx
+++ b/apps/frontend/src/features/number/components/tables/buy.number.table.tsx
@@ -25,7 +25,8 @@ export function BuyNumberTable<TData, TValue>({
     columns,
     pageCount,
     shallow: false,
-    debounceMs: 500
+    debounceMs: 500,
+    initialState: { columnPinning: { right: ['actions'] } }
   });
 
   return (

--- a/apps/frontend/src/features/number/components/tables/my.number.columns.tsx
+++ b/apps/frontend/src/features/number/components/tables/my.number.columns.tsx
@@ -174,10 +174,12 @@ export const columns: ColumnDef<NumberPurchased>[] = [
     }
   },
   {
-    id: 'verify',
+    id: 'actions',
+    size: 160,
+    minSize: 160,
     header: () => {
       const t = useTranslations('settings.numbers.my.table');
-      return <>{t('actions')}</>;
+      return <span className='sr-only'>{t('actions')}</span>;
     },
     cell: ({ row }) => <NumberActionsCell data={row.original} />
   }

--- a/apps/frontend/src/features/number/components/tables/my.number.table.tsx
+++ b/apps/frontend/src/features/number/components/tables/my.number.table.tsx
@@ -25,7 +25,8 @@ export function MyNumberTable<TData, TValue>({
     columns,
     pageCount,
     shallow: false,
-    debounceMs: 400
+    debounceMs: 400,
+    initialState: { columnPinning: { right: ['actions'] } }
   });
 
   return (

--- a/apps/frontend/src/features/number/components/tables/number.actions.cell.tsx
+++ b/apps/frontend/src/features/number/components/tables/number.actions.cell.tsx
@@ -2,12 +2,15 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowRightLeft, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { ArrowRightLeft, Loader2, ShieldCheck } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
 import { useOrgRole } from '@ringee/frontend-shared/hooks/use-org-role';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
 import {
   Dialog,
   DialogContent,
@@ -23,7 +26,6 @@ import {
   SelectTrigger,
   SelectValue
 } from '@ringee/frontend-shared/components/ui/select';
-import { VerifyNumberCell } from './verify.number.cell';
 import type { NumberPurchased } from './my.number.columns';
 
 type TransferTarget = {
@@ -55,6 +57,8 @@ export function NumberActionsCell({ data }: { data: NumberPurchased }) {
   const api = useApi();
   const router = useRouter();
   const t = useTranslations('settings.numbers.my');
+  const tVerify = useTranslations('settings.numbers.verify');
+  const tCommon = useTranslations('common');
   const copy = t.has('transfer')
     ? ({ ...FALLBACK, ...(t.raw('transfer') as object) } as typeof FALLBACK)
     : FALLBACK;
@@ -115,19 +119,28 @@ export function NumberActionsCell({ data }: { data: NumberPurchased }) {
 
   return (
     <>
-      <div className='flex items-center gap-2'>
-        {canVerify && <VerifyNumberCell data={data} />}
-        {canMove && (
-          <Button
-            size='sm'
-            variant='outline'
-            onClick={() => void showTransfer()}
-          >
-            <ArrowRightLeft className='mr-1.5 size-3.5' />
+      <TableRowActions
+        label={tCommon('openActions')}
+        menuLabel={tCommon('actions')}
+        loading={moving}
+      >
+        {canVerify ? (
+          <DropdownMenuItem asChild>
+            <Link href={`/dashboard/buy-number/${data.id}/verification`}>
+              <ShieldCheck className='size-4' />
+              {status === 'rejected' || status === 'expired'
+                ? tVerify('ctaFix')
+                : tVerify('cta')}
+            </Link>
+          </DropdownMenuItem>
+        ) : null}
+        {canMove ? (
+          <DropdownMenuItem onClick={() => void showTransfer()}>
+            <ArrowRightLeft className='size-4' />
             {copy.action}
-          </Button>
-        )}
-      </div>
+          </DropdownMenuItem>
+        ) : null}
+      </TableRowActions>
 
       <Dialog
         open={open}

--- a/apps/frontend/src/features/pending-actions/components/pending-actions-table.tsx
+++ b/apps/frontend/src/features/pending-actions/components/pending-actions-table.tsx
@@ -2,7 +2,15 @@
 
 import Link from 'next/link';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@ringee/frontend-shared/components/ui/dropdown-menu';
+import { TableRowActions } from '@ringee/frontend-shared/components/ui/table/table-row-actions';
+import {
+  TableActionCell,
+  TableActionHead
+} from '@ringee/frontend-shared/components/ui/table/table-action-column';
 import {
   Table,
   TableBody,
@@ -36,6 +44,7 @@ export function PendingActionsTable({
   showContext = true
 }: Props) {
   const t = useTranslations('ai.pendingActions');
+  const tCommon = useTranslations('common');
   const copy = (text: string) => {
     navigator.clipboard?.writeText(text).catch(() => {});
   };
@@ -61,7 +70,9 @@ export function PendingActionsTable({
             {t('columns.source')}
           </TableHead>
           <TableHead>{t('columns.status')}</TableHead>
-          <TableHead className='text-right'>{t('columns.actions')}</TableHead>
+          <TableActionHead>
+            <span className='sr-only'>{t('columns.actions')}</span>
+          </TableActionHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -132,60 +143,46 @@ export function PendingActionsTable({
                 </Badge>
               </TableCell>
 
-              <TableCell>
-                <div className='flex items-center justify-end gap-1'>
+              <TableActionCell>
+                <TableRowActions
+                  label={tCommon('openActions')}
+                  menuLabel={t('columns.actions')}
+                >
                   {a.suggestedMessage && (
-                    <Button
-                      variant='ghost'
-                      size='icon'
-                      title={t('actions.copyMessage')}
-                      onClick={() => copy(a.suggestedMessage!)}
-                    >
+                    <DropdownMenuItem onClick={() => copy(a.suggestedMessage!)}>
                       <Copy className='h-4 w-4' />
-                    </Button>
+                      {t('actions.copyMessage')}
+                    </DropdownMenuItem>
                   )}
                   {a.contactId && (
-                    <Button
-                      asChild
-                      variant='ghost'
-                      size='icon'
-                      title={t('actions.openContact')}
-                    >
+                    <DropdownMenuItem asChild>
                       <Link href={`/dashboard/contact/${a.contactId}`}>
                         <ExternalLink className='h-4 w-4' />
+                        {t('actions.openContact')}
                       </Link>
-                    </Button>
+                    </DropdownMenuItem>
                   )}
                   {isOpen && (
                     <>
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        title={t('actions.snooze')}
-                        onClick={() => onSnooze(a.id)}
-                      >
+                      {(a.suggestedMessage || a.contactId) && (
+                        <DropdownMenuSeparator />
+                      )}
+                      <DropdownMenuItem onClick={() => onSnooze(a.id)}>
                         <Clock className='h-4 w-4' />
-                      </Button>
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        title={t('actions.dismiss')}
-                        onClick={() => onDismiss(a.id)}
-                      >
+                        {t('actions.snooze')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => onDismiss(a.id)}>
                         <X className='h-4 w-4' />
-                      </Button>
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        title={t('actions.complete')}
-                        onClick={() => onComplete(a.id)}
-                      >
+                        {t('actions.dismiss')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => onComplete(a.id)}>
                         <Check className='h-4 w-4 text-emerald-600' />
-                      </Button>
+                        {t('actions.complete')}
+                      </DropdownMenuItem>
                     </>
                   )}
-                </div>
-              </TableCell>
+                </TableRowActions>
+              </TableActionCell>
             </TableRow>
           );
         })}

--- a/apps/frontend/src/features/recordings/components/recordings.tables/columns.tsx
+++ b/apps/frontend/src/features/recordings/components/recordings.tables/columns.tsx
@@ -6,7 +6,6 @@ import {
   Clock,
   PhoneIncoming,
   PhoneOutgoing,
-  Download,
   Calendar,
   Loader2,
   AlertCircle,
@@ -14,16 +13,8 @@ import {
 } from 'lucide-react';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { cn } from '@ringee/frontend-shared/lib/utils';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
-import Link from 'next/link';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
-} from '@ringee/frontend-shared/components/ui/tooltip';
-import { RecordingPlayButton } from './recording-play-button';
 import { useTranslations } from 'next-intl';
-import { CallTranscriptionActions } from '@/features/transcription';
+import { CallListRowActions } from '@/features/calls/components/call-list-row-actions';
 
 type RecordingData = {
   id: string;
@@ -95,12 +86,7 @@ export const columns: ColumnDef<CallWithRecordings>[] = [
       const unknown = t('unknown');
       const name = row.original.contact?.name || unknown;
       return name !== unknown ? (
-        <Link
-          href={`/dashboard/call?tab=contact&name=${row.original.toNumber}`}
-          className='text-foreground font-medium'
-        >
-          {name}
-        </Link>
+        <span className='text-foreground font-medium'>{name}</span>
       ) : (
         <span className='text-muted-foreground font-medium'>{name}</span>
       );
@@ -208,60 +194,20 @@ export const columns: ColumnDef<CallWithRecordings>[] = [
     }
   },
   {
-    id: 'recording',
+    id: 'actions',
+    size: 160,
+    minSize: 160,
     header: () => {
-      const t = useTranslations('calls.recordings.table');
-      return <>{t('recording')}</>;
+      const t = useTranslations('tables.headers');
+      return <span className='sr-only'>{t('actions')}</span>;
     },
-    cell: ({ row }) => {
-      const t = useTranslations('calls.recordings.table');
-      const recordings = row.original.recordings || [];
-      if (recordings.length === 0) {
-        return <span className='text-muted-foreground text-xs'>—</span>;
-      }
-
-      const recording = recordings[0];
-      const recordingUrl = recording.url;
-      const status = recording.status || 'started';
-
-      if (status !== 'completed' || !recordingUrl) {
-        return (
-          <span className='text-muted-foreground text-xs'>
-            {status === 'started' || status === 'processing'
-              ? t('processingShort')
-              : t('unavailable')}
-          </span>
-        );
-      }
-
-      return (
-        <div className='flex items-center gap-2'>
-          <RecordingPlayButton
-            recordingUrl={recordingUrl}
-            callFrom={row.original.fromNumber}
-            callTo={row.original.toNumber}
-          />
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button size='sm' variant='ghost' asChild>
-                <a href={recordingUrl} download>
-                  <Download className='h-4 w-4' />
-                </a>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('downloadRecording')}</TooltipContent>
-          </Tooltip>
-        </div>
-      );
-    }
-  },
-  {
-    id: 'transcript',
-    header: () => {
-      const t = useTranslations('calls.recordings.table');
-      return <>{t('transcript')}</>;
-    },
-    cell: ({ row }) => <CallTranscriptionActions callId={row.original.id} />
+    cell: ({ row }) => (
+      <CallListRowActions
+        callId={row.original.id}
+        recordingUrl={row.original.recordings?.[0]?.url}
+        callFrom={row.original.fromNumber}
+        callTo={row.original.toNumber}
+      />
+    )
   }
 ];

--- a/apps/frontend/src/features/recordings/components/recordings.tables/index.tsx
+++ b/apps/frontend/src/features/recordings/components/recordings.tables/index.tsx
@@ -45,7 +45,10 @@ export function RecordingsTable<TData, TValue>({
     pageCount: pageCount,
     shallow: false,
     debounceMs: 500,
-    initialState: { columnVisibility: { memberId: false } }
+    initialState: {
+      columnVisibility: { memberId: false },
+      columnPinning: { right: ['actions'] }
+    }
   });
 
   const memberTableColumn = memberColumn

--- a/apps/frontend/src/features/recordings/components/recordings.tables/recording-play-button.tsx
+++ b/apps/frontend/src/features/recordings/components/recordings.tables/recording-play-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
 import { PlayCircle } from 'lucide-react';
 import {
   Tooltip,
@@ -16,12 +17,14 @@ interface RecordingPlayButtonProps {
   recordingUrl: string;
   callFrom: string;
   callTo: string;
+  asMenuItem?: boolean;
 }
 
 export function RecordingPlayButton({
   recordingUrl,
   callFrom,
-  callTo
+  callTo,
+  asMenuItem = false
 }: RecordingPlayButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { completeStep } = useOnboardingComplete();
@@ -35,20 +38,27 @@ export function RecordingPlayButton({
 
   return (
     <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            size='sm'
-            variant='ghost'
-            className='text-emerald-500 hover:text-emerald-400'
-            onClick={handlePlay}
-          >
-            <PlayCircle className='mr-1 h-4 w-4' />
-            {t('play')}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{t('playRecording')}</TooltipContent>
-      </Tooltip>
+      {asMenuItem ? (
+        <DropdownMenuItem onClick={handlePlay}>
+          <PlayCircle className='h-4 w-4' />
+          {t('playRecording')}
+        </DropdownMenuItem>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size='sm'
+              variant='ghost'
+              className='text-emerald-500 hover:text-emerald-400'
+              onClick={handlePlay}
+            >
+              <PlayCircle className='mr-1 h-4 w-4' />
+              {t('play')}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('playRecording')}</TooltipContent>
+        </Tooltip>
+      )}
 
       <AudioPlayerModal
         isOpen={isModalOpen}

--- a/apps/frontend/src/features/recordings/components/recordings.tables/recording-play-button.tsx
+++ b/apps/frontend/src/features/recordings/components/recordings.tables/recording-play-button.tsx
@@ -18,13 +18,15 @@ interface RecordingPlayButtonProps {
   callFrom: string;
   callTo: string;
   asMenuItem?: boolean;
+  onPlay?: () => void;
 }
 
 export function RecordingPlayButton({
   recordingUrl,
   callFrom,
   callTo,
-  asMenuItem = false
+  asMenuItem = false,
+  onPlay
 }: RecordingPlayButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { completeStep } = useOnboardingComplete();
@@ -32,7 +34,11 @@ export function RecordingPlayButton({
   const tPlayer = useTranslations('calls.recordings.player');
 
   const handlePlay = () => {
-    setIsModalOpen(true);
+    if (onPlay) {
+      onPlay();
+    } else {
+      setIsModalOpen(true);
+    }
     completeStep('recording');
   };
 
@@ -60,12 +66,14 @@ export function RecordingPlayButton({
         </Tooltip>
       )}
 
-      <AudioPlayerModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        audioUrl={recordingUrl}
-        title={tPlayer('callTitle', { from: callFrom, to: callTo })}
-      />
+      {!onPlay ? (
+        <AudioPlayerModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          audioUrl={recordingUrl}
+          title={tPlayer('callTitle', { from: callFrom, to: callTo })}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/frontend/src/features/transcription/components/call-transcription-actions.tsx
+++ b/apps/frontend/src/features/transcription/components/call-transcription-actions.tsx
@@ -7,9 +7,14 @@ import { TranscriptDialog } from './transcript-dialog';
 interface Props {
   callId: string | null | undefined;
   className?: string;
+  asMenuItem?: boolean;
 }
 
-export function CallTranscriptionActions({ callId, className }: Props) {
+export function CallTranscriptionActions({
+  callId,
+  className,
+  asMenuItem = false
+}: Props) {
   const [open, setOpen] = useState(false);
 
   if (!callId) return null;
@@ -20,6 +25,7 @@ export function CallTranscriptionActions({ callId, className }: Props) {
         callId={callId}
         mode='history'
         className={className}
+        asMenuItem={asMenuItem}
         onView={() => setOpen(true)}
       />
       <TranscriptDialog open={open} onOpenChange={setOpen} callId={callId} />

--- a/apps/frontend/src/features/transcription/components/call-transcription-actions.tsx
+++ b/apps/frontend/src/features/transcription/components/call-transcription-actions.tsx
@@ -8,14 +8,17 @@ interface Props {
   callId: string | null | undefined;
   className?: string;
   asMenuItem?: boolean;
+  onView?: () => void;
 }
 
 export function CallTranscriptionActions({
   callId,
   className,
-  asMenuItem = false
+  asMenuItem = false,
+  onView
 }: Props) {
   const [open, setOpen] = useState(false);
+  const ownsDialog = !onView;
 
   if (!callId) return null;
 
@@ -26,9 +29,12 @@ export function CallTranscriptionActions({
         mode='history'
         className={className}
         asMenuItem={asMenuItem}
-        onView={() => setOpen(true)}
+        keepMenuOpenOnView={asMenuItem && ownsDialog}
+        onView={onView ?? (() => setOpen(true))}
       />
-      <TranscriptDialog open={open} onOpenChange={setOpen} callId={callId} />
+      {ownsDialog ? (
+        <TranscriptDialog open={open} onOpenChange={setOpen} callId={callId} />
+      ) : null}
     </>
   );
 }

--- a/apps/frontend/src/features/transcription/components/transcribe-call-button.tsx
+++ b/apps/frontend/src/features/transcription/components/transcribe-call-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { DropdownMenuItem } from '@ringee/frontend-shared/components/ui/dropdown-menu';
 import { FileText, Loader2, Mic } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
@@ -29,6 +30,7 @@ interface Props {
   autoTranscribeEnabled?: boolean;
   size?: 'sm' | 'default';
   className?: string;
+  asMenuItem?: boolean;
 }
 
 export function TranscribeCallButton({
@@ -37,7 +39,8 @@ export function TranscribeCallButton({
   onView,
   autoTranscribeEnabled = false,
   size = 'sm',
-  className
+  className,
+  asMenuItem = false
 }: Props) {
   const t = useTranslations('transcription');
   const { data, actionPending, startRealtime, transcribeRecording, retry } =
@@ -62,6 +65,31 @@ export function TranscribeCallButton({
 
   if (!callId) return null;
 
+  const content = (
+    <>
+      {state.busy || actionPending ? (
+        <Loader2 className='h-4 w-4 animate-spin' />
+      ) : state.icon === 'mic' ? (
+        <Mic className='h-4 w-4' />
+      ) : state.icon === 'file' ? (
+        <FileText className='h-4 w-4' />
+      ) : null}
+      {state.label}
+    </>
+  );
+
+  if (asMenuItem) {
+    return (
+      <DropdownMenuItem
+        className={className}
+        disabled={state.disabled || actionPending}
+        onClick={state.onClick}
+      >
+        {content}
+      </DropdownMenuItem>
+    );
+  }
+
   return (
     <Button
       type='button'
@@ -71,14 +99,7 @@ export function TranscribeCallButton({
       disabled={state.disabled || actionPending}
       onClick={state.onClick}
     >
-      {state.busy || actionPending ? (
-        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-      ) : state.icon === 'mic' ? (
-        <Mic className='mr-2 h-4 w-4' />
-      ) : state.icon === 'file' ? (
-        <FileText className='mr-2 h-4 w-4' />
-      ) : null}
-      {state.label}
+      {content}
     </Button>
   );
 }

--- a/apps/frontend/src/features/transcription/components/transcribe-call-button.tsx
+++ b/apps/frontend/src/features/transcription/components/transcribe-call-button.tsx
@@ -31,6 +31,8 @@ interface Props {
   size?: 'sm' | 'default';
   className?: string;
   asMenuItem?: boolean;
+  /** Keep a menu-mounted transcript dialog alive while it opens. */
+  keepMenuOpenOnView?: boolean;
 }
 
 export function TranscribeCallButton({
@@ -40,7 +42,8 @@ export function TranscribeCallButton({
   autoTranscribeEnabled = false,
   size = 'sm',
   className,
-  asMenuItem = false
+  asMenuItem = false,
+  keepMenuOpenOnView = false
 }: Props) {
   const t = useTranslations('transcription');
   const { data, actionPending, startRealtime, transcribeRecording, retry } =
@@ -83,7 +86,12 @@ export function TranscribeCallButton({
       <DropdownMenuItem
         className={className}
         disabled={state.disabled || actionPending}
-        onClick={state.onClick}
+        onSelect={(event) => {
+          if (keepMenuOpenOnView && onView && state.onClick === onView) {
+            event.preventDefault();
+          }
+          state.onClick?.();
+        }}
       >
         {content}
       </DropdownMenuItem>

--- a/apps/frontend/src/i18n/locales/en/common.json
+++ b/apps/frontend/src/i18n/locales/en/common.json
@@ -40,6 +40,7 @@
   "comingSoon": "Coming soon",
   "beta": "Beta",
   "actions": "Actions",
+  "openActions": "Open actions menu",
   "status": "Status",
   "name": "Name",
   "description": "Description",

--- a/apps/frontend/src/i18n/locales/es/common.json
+++ b/apps/frontend/src/i18n/locales/es/common.json
@@ -40,6 +40,7 @@
   "comingSoon": "Próximamente",
   "beta": "Beta",
   "actions": "Acciones",
+  "openActions": "Abrir menú de acciones",
   "status": "Estado",
   "name": "Nombre",
   "description": "Descripción",

--- a/packages/frontend-shared/src/components/ui/table.tsx
+++ b/packages/frontend-shared/src/components/ui/table.tsx
@@ -5,8 +5,53 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scrollAreaViewport = container.closest<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    );
+    const scrollContainer = scrollAreaViewport ?? container;
+
+    let animationFrame = 0;
+    const updateActionPinOffset = () => {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(() => {
+        const maxScrollLeft = Math.max(
+          scrollContainer.scrollWidth - scrollContainer.clientWidth,
+          0,
+        );
+        const offset =
+          Math.min(scrollContainer.scrollLeft, maxScrollLeft) - maxScrollLeft;
+
+        container.style.setProperty("--table-action-pin-offset", `${offset}px`);
+      });
+    };
+
+    updateActionPinOffset();
+    scrollContainer.addEventListener("scroll", updateActionPinOffset, {
+      passive: true,
+    });
+
+    const resizeObserver = new ResizeObserver(updateActionPinOffset);
+    resizeObserver.observe(container);
+    if (scrollContainer !== container) resizeObserver.observe(scrollContainer);
+    const table = container.querySelector("table");
+    if (table) resizeObserver.observe(table);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      scrollContainer.removeEventListener("scroll", updateActionPinOffset);
+      resizeObserver.disconnect();
+    };
+  }, []);
+
   return (
     <div
+      ref={containerRef}
       data-slot="table-container"
       className="relative w-full overflow-x-auto"
     >

--- a/packages/frontend-shared/src/components/ui/table/data-table-skeleton.tsx
+++ b/packages/frontend-shared/src/components/ui/table/data-table-skeleton.tsx
@@ -6,7 +6,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from ".";
+} from "../table";
 import { cn } from "../../../lib/utils";
 
 interface DataTableSkeletonProps extends React.ComponentProps<"div"> {

--- a/packages/frontend-shared/src/components/ui/table/data-table.tsx
+++ b/packages/frontend-shared/src/components/ui/table/data-table.tsx
@@ -9,7 +9,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from ".";
+} from "../table";
 import { getCommonPinningStyles } from "../../../lib/data-table";
 import { ScrollArea, ScrollBar } from "../scroll-area";
 
@@ -42,6 +42,8 @@ export function DataTable<TData>({
                         }
                         style={{
                           ...getCommonPinningStyles({ column: header.column }),
+                          minWidth:
+                            header.column.id === "actions" ? 160 : undefined,
                         }}
                       >
                         {header.isPlaceholder
@@ -70,6 +72,8 @@ export function DataTable<TData>({
                           }
                           style={{
                             ...getCommonPinningStyles({ column: cell.column }),
+                            minWidth:
+                              cell.column.id === "actions" ? 160 : undefined,
                           }}
                         >
                           {flexRender(

--- a/packages/frontend-shared/src/components/ui/table/table-action-column.tsx
+++ b/packages/frontend-shared/src/components/ui/table/table-action-column.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type * as React from "react";
+
+import { cn } from "../../../lib/utils";
+import { TableCell, TableHead } from "../table";
+
+export const TABLE_ACTION_COLUMN_SIZE = 160;
+
+const pinnedActionStyles: React.CSSProperties = {
+  position: "sticky",
+  right: 0,
+  width: TABLE_ACTION_COLUMN_SIZE,
+  minWidth: TABLE_ACTION_COLUMN_SIZE,
+  background: "var(--background)",
+  boxShadow: "5px 0 5px -5px var(--border) inset",
+  transform: "translateX(var(--table-action-pin-offset, 0px))",
+};
+
+export function TableActionHead({
+  className,
+  style,
+  ...props
+}: React.ComponentProps<"th">) {
+  return (
+    <TableHead
+      className={cn("text-left", className)}
+      style={{ ...style, ...pinnedActionStyles, zIndex: 2 }}
+      {...props}
+    />
+  );
+}
+
+export function TableActionCell({
+  className,
+  style,
+  ...props
+}: React.ComponentProps<"td">) {
+  return (
+    <TableCell
+      className={cn("text-left", className)}
+      style={{ ...style, ...pinnedActionStyles, zIndex: 1 }}
+      {...props}
+    />
+  );
+}

--- a/packages/frontend-shared/src/components/ui/table/table-row-actions.tsx
+++ b/packages/frontend-shared/src/components/ui/table/table-row-actions.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { EllipsisVertical, Loader2 } from "lucide-react";
+import type * as React from "react";
+
+import { Button } from "../button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "../dropdown-menu";
+import { cn } from "../../../lib/utils";
+
+interface TableRowActionsProps {
+  children: React.ReactNode;
+  label: string;
+  menuLabel?: string;
+  loading?: boolean;
+  disabled?: boolean;
+  className?: string;
+  contentClassName?: string;
+}
+
+/**
+ * Canonical row-actions trigger for Ringee tables.
+ *
+ * Keep row-level operations behind this compact, right-aligned menu instead of
+ * spreading several icon buttons across the final cell.
+ */
+export function TableRowActions({
+  children,
+  label,
+  menuLabel,
+  loading = false,
+  disabled = false,
+  className,
+  contentClassName,
+}: TableRowActionsProps) {
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          className={cn(
+            "relative h-8 w-8 p-0 after:absolute after:-inset-1.5",
+            className,
+          )}
+          aria-label={label}
+          disabled={disabled || loading}
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <EllipsisVertical className="h-4 w-4" aria-hidden="true" />
+          )}
+          <span className="sr-only">{label}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className={cn("min-w-40", contentClassName)}
+      >
+        {menuLabel ? (
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>{menuLabel}</DropdownMenuLabel>
+          </DropdownMenuGroup>
+        ) : null}
+        <DropdownMenuGroup>{children}</DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/frontend-shared/src/lib/data-table.ts
+++ b/packages/frontend-shared/src/lib/data-table.ts
@@ -9,10 +9,8 @@ import { dataTableConfig } from "../config/data-table";
 
 export function getCommonPinningStyles<TData>({
   column,
-  withBorder = false,
 }: {
   column: Column<TData>;
-  withBorder?: boolean;
 }): React.CSSProperties {
   const isPinned = column.getIsPinned();
   const isLastLeftPinnedColumn =
@@ -21,18 +19,19 @@ export function getCommonPinningStyles<TData>({
     isPinned === "right" && column.getIsFirstColumn("right");
 
   return {
-    boxShadow: withBorder
-      ? isLastLeftPinnedColumn
-        ? "-4px 0 4px -4px hsl(var(--border)) inset"
-        : isFirstRightPinnedColumn
-          ? "4px 0 4px -4px hsl(var(--border)) inset"
-          : undefined
-      : undefined,
+    boxShadow: isLastLeftPinnedColumn
+      ? "-5px 0 5px -5px var(--border) inset"
+      : isFirstRightPinnedColumn
+        ? "5px 0 5px -5px var(--border) inset"
+        : undefined,
     left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
-    opacity: isPinned ? 0.97 : 1,
     position: isPinned ? "sticky" : "relative",
-    background: isPinned ? "hsl(var(--background))" : "hsl(var(--background))",
+    background: isPinned ? "var(--background)" : undefined,
+    transform:
+      isPinned === "right"
+        ? "translateX(var(--table-action-pin-offset, 0px))"
+        : undefined,
     width: column.getSize(),
     zIndex: isPinned ? 1 : 0,
   };


### PR DESCRIPTION
- Added dropdown menus for action buttons in various tables, improving user experience by consolidating actions.
- Implemented column pinning for action columns in tables to maintain visibility during horizontal scrolling.
- Updated translations for action labels to support new dropdown functionality.
- Refactored action components to utilize shared UI components for consistency across the application.
- Introduced new `TableActionCell` and `TableActionHead` components to standardize action column styling.
- Enhanced performance by optimizing scroll handling for pinned columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changed behavior

- Table actions now use dropdown menus across calls, recordings, contacts, campaigns, callbacks, numbers, backoffice tables, and pending actions.
- Call and recording actions now run through `CallListRowActions`.
- Call history and recording tables no longer provide inline dialing, navigation, playback, download, or transcript controls.
- Destructive actions now use shared confirmation dialogs where applicable.
- Action columns are pinned right and remain visible during horizontal scrolling.
- Contact names and several call-history fields now render as non-interactive text.

## Architectural impact

- Added shared `TableRowActions`, `TableActionHead`, and `TableActionCell` components.
- Added a fixed 160px action-column contract through `TABLE_ACTION_COLUMN_SIZE`.
- `Table` now owns sticky-column offset updates during scroll and resize.
- `getCommonPinningStyles` now applies pinned-column offsets and no longer accepts `withBorder`.
- `RecordingPlayButton`, `CallTranscriptionActions`, and `TranscribeCallButton` now support externally owned dialogs from menu items.
- Added `openActions` translations in English and Spanish.

## Risk areas

- Call lifecycle actions now depend on shared menu state and external transcript/audio dialog ownership.
- Inline dial and navigation removal changes contact and call-history workflows.
- Delete, reject, approve, dismiss, and complete actions depend on centralized confirmation-dialog state.
- Nested scroll areas can misplace pinned action columns if offset measurement fails.
- `getCommonPinningStyles` has a public contract change because `withBorder` was removed.
- Shared action props add public component contracts used across frontend features.

## Files carrying the risk

- `packages/frontend-shared/src/components/ui/table.tsx`
- `packages/frontend-shared/src/components/ui/table/table-row-actions.tsx`
- `packages/frontend-shared/src/components/ui/table/table-action-column.tsx`
- `packages/frontend-shared/src/lib/data-table.ts`
- `apps/frontend/src/features/calls/components/call-list-row-actions.tsx`
- `apps/frontend/src/features/transcription/components/call-transcription-actions.tsx`
- `apps/frontend/src/features/transcription/components/transcribe-call-button.tsx`
- `apps/frontend/src/features/recordings/components/recordings.tables/recording-play-button.tsx`
- `apps/frontend/src/features/history/components/call.history.tables/columns.tsx`
- `apps/frontend/src/features/recordings/components/recordings.tables/columns.tsx`
- `apps/frontend/src/features/campaigns/components/campaign-dispositions-tab.tsx`
- `apps/frontend/src/features/campaigns/components/campaign-leads-tab.tsx`
- `apps/frontend/src/features/contact/components/contact.tables/cell-action.tsx`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->