### PR TITLE
feat: implement Ringee-first calendar availability and booking logic

### DIFF
--- a/docs/engineering/BUSINESS_RULES.md
+++ b/docs/engineering/BUSINESS_RULES.md
@@ -736,9 +736,11 @@ able to set it.
 
 The booking agent may only offer a time returned by `get_available_slots`, and
 may only say a meeting is booked after `book_appointment` returns success. This
-is why the tool path uses `CalendarService.getBookableSlots` — which **fails**
-when the calendar is missing or unreachable — rather than `getAvailability`,
-which deliberately falls back to "everything is free" for the human picker.
+is why the tool path uses `CalendarService.getBookableSlots`, which reads active
+Ringee meetings directly, rather than `getAvailability`, which deliberately
+falls back to "everything is free" for the human picker. Ringee owns the booking
+first; Google or Microsoft is only a best-effort outbound sync target afterward,
+so an external availability failure cannot stop or fabricate a Ringee booking.
 
 - **Risk if violated:** the agent books over real meetings and tells the person
   a time that was never free

--- a/docs/engineering/BUSINESS_RULES.md
+++ b/docs/engineering/BUSINESS_RULES.md
@@ -741,6 +741,9 @@ Ringee meetings directly, rather than `getAvailability`, which deliberately
 falls back to "everything is free" for the human picker. Ringee owns the booking
 first; Google or Microsoft is only a best-effort outbound sync target afterward,
 so an external availability failure cannot stop or fabricate a Ringee booking.
+`book_appointment` accepts only an exact slot returned by that same lookup and
+re-checks the overlap under a transaction-scoped workspace row lock before inserting,
+so two concurrent confirmations cannot both reserve the same Ringee time.
 
 - **Risk if violated:** the agent books over real meetings and tells the person
   a time that was never free

--- a/packages/database/src/database/repositories/meeting.repository.spec.ts
+++ b/packages/database/src/database/repositories/meeting.repository.spec.ts
@@ -1,0 +1,72 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MeetingRepository } from "./meeting.repository";
+
+const MEETING = {
+  id: "meeting-1",
+  scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
+};
+
+function build(conflict = false) {
+  const events: string[] = [];
+  const transaction = {
+    $queryRaw: async (strings: TemplateStringsArray) => {
+      const sql = strings.join("?");
+      if (sql.includes("FOR UPDATE")) {
+        events.push("lock");
+        return [];
+      }
+      events.push("check");
+      return conflict ? [{ id: "meeting-existing" }] : [];
+    },
+    meeting: {
+      create: async () => {
+        events.push("create");
+        return MEETING;
+      },
+    },
+  };
+  const repository = new MeetingRepository({
+    $transaction: async (
+      work: (client: typeof transaction) => Promise<unknown>,
+    ) => work(transaction),
+  } as never);
+
+  return { repository, events };
+}
+
+describe("MeetingRepository.createIfAvailable", () => {
+  it("locks, re-checks and creates in one transaction", async () => {
+    const { repository, events } = build();
+
+    const meeting = await repository.createIfAvailable(
+      { userId: "user-1", organizationId: "org-1" },
+      {
+        contactId: "contact-1",
+        scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
+        duration: 30,
+      },
+    );
+
+    assert.equal(meeting?.id, "meeting-1");
+    assert.deepEqual(events, ["lock", "check", "create"]);
+  });
+
+  it("does not insert when a meeting now overlaps the slot", async () => {
+    const { repository, events } = build(true);
+
+    const meeting = await repository.createIfAvailable(
+      { userId: "user-1" },
+      {
+        contactId: "contact-1",
+        scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
+        duration: 30,
+      },
+    );
+
+    assert.equal(meeting, null);
+    assert.deepEqual(events, ["lock", "check"]);
+  });
+});

--- a/packages/database/src/database/repositories/meeting.repository.ts
+++ b/packages/database/src/database/repositories/meeting.repository.ts
@@ -7,6 +7,44 @@ import { OwnershipContext, buildOwnershipFilter } from "@ringee/platform";
 export class MeetingRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  /**
+   * Ringee meetings that occupy any part of the requested window.
+   *
+   * The end of a meeting is derived from its stored duration, so this uses a
+   * parameterized SQL query rather than approximating the overlap with only
+   * `scheduledAt`. The ownership predicate still comes from the canonical
+   * workspace filter: organization calendars see organization meetings, while
+   * personal calendars see only personal rows.
+   */
+  async findBusySlots(
+    ctx: OwnershipContext,
+    start: Date,
+    end: Date,
+  ): Promise<Array<{ start: Date; end: Date }>> {
+    const owner = buildOwnershipFilter(ctx);
+    const userFilter = owner.userId
+      ? Prisma.sql`AND "userId" = ${owner.userId}::uuid`
+      : Prisma.empty;
+    const organizationFilter =
+      owner.organizationId === null
+        ? Prisma.sql`AND "organizationId" IS NULL`
+        : owner.organizationId
+          ? Prisma.sql`AND "organizationId" = ${owner.organizationId}::uuid`
+          : Prisma.empty;
+
+    return this.prisma.$queryRaw<Array<{ start: Date; end: Date }>>`
+      SELECT
+        "scheduledAt" AS "start",
+        "scheduledAt" + ("duration" * INTERVAL '1 minute') AS "end"
+      FROM "Meeting"
+      WHERE "status" IN ('scheduled', 'rescheduled')
+        AND "scheduledAt" < ${end}
+        AND "scheduledAt" + ("duration" * INTERVAL '1 minute') > ${start}
+        ${userFilter}
+        ${organizationFilter}
+    `;
+  }
+
   async create(
     ctx: OwnershipContext,
     data: {

--- a/packages/database/src/database/repositories/meeting.repository.ts
+++ b/packages/database/src/database/repositories/meeting.repository.ts
@@ -3,6 +3,34 @@ import { PrismaService } from "../prisma.service";
 import { Prisma, Meeting, MeetingStatus } from "@prisma/client";
 import { OwnershipContext, buildOwnershipFilter } from "@ringee/platform";
 
+interface MeetingCreateData {
+  contactId: string;
+  callId?: string;
+  title?: string;
+  scheduledAt: Date;
+  duration?: number;
+  location?: string;
+  notes?: string;
+}
+
+function ownershipSql(ctx: OwnershipContext): {
+  userFilter: Prisma.Sql;
+  organizationFilter: Prisma.Sql;
+} {
+  const owner = buildOwnershipFilter(ctx);
+  return {
+    userFilter: owner.userId
+      ? Prisma.sql`AND "userId" = ${owner.userId}::uuid`
+      : Prisma.empty,
+    organizationFilter:
+      owner.organizationId === null
+        ? Prisma.sql`AND "organizationId" IS NULL`
+        : owner.organizationId
+          ? Prisma.sql`AND "organizationId" = ${owner.organizationId}::uuid`
+          : Prisma.empty,
+  };
+}
+
 @Injectable()
 export class MeetingRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -21,16 +49,7 @@ export class MeetingRepository {
     start: Date,
     end: Date,
   ): Promise<Array<{ start: Date; end: Date }>> {
-    const owner = buildOwnershipFilter(ctx);
-    const userFilter = owner.userId
-      ? Prisma.sql`AND "userId" = ${owner.userId}::uuid`
-      : Prisma.empty;
-    const organizationFilter =
-      owner.organizationId === null
-        ? Prisma.sql`AND "organizationId" IS NULL`
-        : owner.organizationId
-          ? Prisma.sql`AND "organizationId" = ${owner.organizationId}::uuid`
-          : Prisma.empty;
+    const { userFilter, organizationFilter } = ownershipSql(ctx);
 
     return this.prisma.$queryRaw<Array<{ start: Date; end: Date }>>`
       SELECT
@@ -47,34 +66,84 @@ export class MeetingRepository {
 
   async create(
     ctx: OwnershipContext,
-    data: {
-      contactId: string;
-      callId?: string;
-      title?: string;
-      scheduledAt: Date;
-      duration?: number;
-      location?: string;
-      notes?: string;
-    },
+    data: MeetingCreateData,
   ): Promise<Meeting> {
     return this.prisma.meeting.create({
-      data: {
-        scheduledAt: data.scheduledAt,
-        duration: data.duration ?? 30,
-        title: data.title,
-        location: data.location,
-        notes: data.notes,
-        user: { connect: { id: ctx.userId } },
-        organization: ctx.organizationId
-          ? { connect: { id: ctx.organizationId } }
-          : undefined,
-        contact: { connect: { id: data.contactId } },
-        call: data.callId ? { connect: { id: data.callId } } : undefined,
-      },
+      data: this.createData(ctx, data),
       include: {
         contact: true,
       },
     });
+  }
+
+  /**
+   * Re-checks the requested Ringee slot and creates the meeting as one guarded
+   * database operation. A transaction-scoped workspace row lock serializes agent
+   * bookings in the same workspace across API instances; the overlap query is
+   * deliberately repeated after taking it because the earlier tool lookup may
+   * already be stale by the time the caller confirms a time.
+   */
+  async createIfAvailable(
+    ctx: OwnershipContext,
+    data: MeetingCreateData,
+  ): Promise<Meeting | null> {
+    const duration = data.duration ?? 30;
+    const end = new Date(data.scheduledAt.getTime() + duration * 60_000);
+    const { userFilter, organizationFilter } = ownershipSql(ctx);
+
+    return this.prisma.$transaction(async (tx) => {
+      if (ctx.organizationId) {
+        await tx.$queryRaw`
+          SELECT "id"
+          FROM "Organization"
+          WHERE "id" = ${ctx.organizationId}::uuid
+          FOR UPDATE
+        `;
+      } else {
+        await tx.$queryRaw`
+          SELECT "id"
+          FROM "User"
+          WHERE "id" = ${ctx.userId}::uuid
+          FOR UPDATE
+        `;
+      }
+
+      const conflict = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "id"
+        FROM "Meeting"
+        WHERE "status" IN ('scheduled', 'rescheduled')
+          AND "scheduledAt" < ${end}
+          AND "scheduledAt" + ("duration" * INTERVAL '1 minute') > ${data.scheduledAt}
+          ${userFilter}
+          ${organizationFilter}
+        LIMIT 1
+      `;
+      if (conflict.length > 0) return null;
+
+      return tx.meeting.create({
+        data: this.createData(ctx, { ...data, duration }),
+        include: { contact: true },
+      });
+    });
+  }
+
+  private createData(
+    ctx: OwnershipContext,
+    data: MeetingCreateData,
+  ): Prisma.MeetingCreateInput {
+    return {
+      scheduledAt: data.scheduledAt,
+      duration: data.duration ?? 30,
+      title: data.title,
+      location: data.location,
+      notes: data.notes,
+      user: { connect: { id: ctx.userId } },
+      organization: ctx.organizationId
+        ? { connect: { id: ctx.organizationId } }
+        : undefined,
+      contact: { connect: { id: data.contactId } },
+      call: data.callId ? { connect: { id: data.callId } } : undefined,
+    };
   }
 
   async findById(id: string): Promise<Meeting | null> {

--- a/packages/services/src/services/calendar.service.spec.ts
+++ b/packages/services/src/services/calendar.service.spec.ts
@@ -1,0 +1,94 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CalendarService } from "./calendar.service";
+
+function build(busy: Array<{ start: Date; end: Date }> = []): {
+  service: CalendarService;
+  windows: Array<{ start: Date; end: Date }>;
+} {
+  const windows: Array<{ start: Date; end: Date }> = [];
+  const service = new CalendarService(
+    {
+      findByUserOrOrg: async () => {
+        throw new Error("External calendars must not be read for availability");
+      },
+    } as never,
+    {
+      findBusySlots: async (_ctx: unknown, start: Date, end: Date) => {
+        windows.push({ start, end });
+        return busy;
+      },
+    } as never,
+  );
+
+  return { service, windows };
+}
+
+describe("CalendarService Ringee availability", () => {
+  it("uses Ringee meetings without calling an external calendar", async () => {
+    const { service, windows } = build([
+      {
+        start: new Date("2099-01-05T09:30:00.000Z"),
+        end: new Date("2099-01-05T10:00:00.000Z"),
+      },
+    ]);
+
+    const slots = await service.getBookableSlots(
+      { userId: "user-1", organizationId: "org-1" },
+      {
+        date: "2099-01-05",
+        timeZone: "UTC",
+        durationMinutes: 30,
+      },
+    );
+
+    assert.deepEqual(windows, [
+      {
+        start: new Date("2099-01-05T09:00:00.000Z"),
+        end: new Date("2099-01-05T18:00:00.000Z"),
+      },
+    ]);
+    assert.equal(
+      slots.some((slot) => slot.start === "2099-01-05T09:30:00.000Z"),
+      false,
+    );
+    assert.equal(slots[0]?.start, "2099-01-05T09:00:00.000Z");
+  });
+
+  it("blocks every slot that overlaps a Ringee meeting", async () => {
+    const { service } = build([
+      {
+        start: new Date("2099-01-05T09:15:00.000Z"),
+        end: new Date("2099-01-05T10:15:00.000Z"),
+      },
+    ]);
+
+    const slots = await service.getBookableSlots(
+      { userId: "user-1" },
+      {
+        date: "2099-01-05",
+        timeZone: "UTC",
+        durationMinutes: 30,
+      },
+    );
+
+    assert.equal(
+      slots.some((slot) => slot.start === "2099-01-05T09:00:00.000Z"),
+      false,
+    );
+    assert.equal(
+      slots.some((slot) => slot.start === "2099-01-05T09:30:00.000Z"),
+      false,
+    );
+    assert.equal(
+      slots.some((slot) => slot.start === "2099-01-05T10:00:00.000Z"),
+      false,
+    );
+    assert.equal(
+      slots.some((slot) => slot.start === "2099-01-05T10:30:00.000Z"),
+      true,
+    );
+  });
+});

--- a/packages/services/src/services/calendar.service.ts
+++ b/packages/services/src/services/calendar.service.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  ForbiddenException,
-  NotFoundException,
-  BadRequestException,
-} from "@nestjs/common";
+import { Injectable, BadRequestException } from "@nestjs/common";
 import {
   CalendarIntegrationRepository,
   MeetingRepository,
@@ -345,11 +340,12 @@ export class CalendarService {
    * Real, bookable slots for one day, as absolute times.
    *
    * `getAvailability` above is the human picker: it works in server-local time
-   * and, when a calendar is missing or the provider errors, deliberately falls
-   * back to "everything is free" so the UI still renders something. Neither
-   * behaviour is safe for an AI agent, which offers these times out loud and
-   * then books one — a fabricated slot double-books a real meeting. So this
-   * variant works in an explicit time zone and **fails** rather than guessing.
+   * and deliberately falls back to "everything is free" so the UI still
+   * renders something. Neither behaviour is safe for an AI agent, which offers
+   * these times out loud and then books one. This variant therefore reads the
+   * Ringee meeting calendar directly and uses an explicit time zone. External
+   * calendars are an outbound sync target after Ringee owns the booking; they
+   * are not an availability dependency for the agent.
    */
   async getBookableSlots(
     ctx: OwnershipContext,
@@ -359,20 +355,11 @@ export class CalendarService {
       /** IANA zone the day and the returned times are expressed in. */
       timeZone: string;
       durationMinutes: number;
-      /** The specific connected calendar to read, when one was chosen. */
-      integrationId?: string | null;
-      provider?: CalendarProvider;
       /** Business hours in `timeZone`. Defaults to 09:00–18:00. */
       dayStartHour?: number;
       dayEndHour?: number;
     },
   ): Promise<BookableSlot[]> {
-    const integration = await this.requireIntegration(
-      ctx,
-      opts.provider,
-      opts.integrationId,
-    );
-
     const dayStart = zonedTimeToUtc(
       opts.date,
       opts.dayStartHour ?? 9,
@@ -398,9 +385,9 @@ export class CalendarService {
       );
     }
 
-    // No catch: an unreachable calendar means "unknown", and an agent must not
-    // turn unknown into "free".
-    const busy = await this.fetchFreeBusyWindow(integration, dayStart, dayEnd);
+    // No provider call belongs here. Ringee is the source of truth for agent
+    // bookings; Google/Microsoft receive the event only after it exists here.
+    const busy = await this.meetingRepo.findBusySlots(ctx, dayStart, dayEnd);
 
     const slots: BookableSlot[] = [];
     const now = Date.now();
@@ -461,19 +448,14 @@ export class CalendarService {
       duration: number;
       attendeeEmail?: string;
       provider?: CalendarProvider;
+      integrationId?: string | null;
     },
   ): Promise<{ externalEventId: string; meetLink?: string }> {
-    const integrations = await this.calendarRepo.findByUserOrOrg(
-      ctx.userId,
-      ctx.organizationId,
+    const integration = await this.requireIntegration(
+      ctx,
+      dto.provider,
+      dto.integrationId,
     );
-    const integration = dto.provider
-      ? integrations.find((i) => i.provider === dto.provider)
-      : integrations[0];
-
-    if (!integration) {
-      throw new BadRequestException("No calendar connected");
-    }
 
     const event = await this.createEvent(integration, {
       summary: dto.title || "Meeting via Ringee",

--- a/packages/services/src/services/meeting.service.spec.ts
+++ b/packages/services/src/services/meeting.service.spec.ts
@@ -22,7 +22,7 @@ const STORED_MEETING = {
   updatedAt: new Date("2099-01-01T00:00:00.000Z"),
 };
 
-function build(options: { syncError?: Error } = {}) {
+function build(options: { syncError?: Error; slotAvailable?: boolean } = {}) {
   const events: string[] = [];
   const calendarRequests: Array<Record<string, unknown>> = [];
 
@@ -31,6 +31,10 @@ function build(options: { syncError?: Error } = {}) {
       create: async () => {
         events.push("ringee:create");
         return STORED_MEETING;
+      },
+      createIfAvailable: async () => {
+        events.push("ringee:create-protected");
+        return options.slotAvailable === false ? null : STORED_MEETING;
       },
     } as never,
     {} as never,
@@ -100,5 +104,24 @@ describe("MeetingService Ringee-first calendar sync", () => {
     assert.equal(meeting.id, "meeting-1");
     assert.equal(meeting.externalEventId, null);
     assert.equal(meeting.location, null);
+  });
+
+  it("does not sync externally when the protected Ringee slot was taken", async () => {
+    const { service, events } = build({ slotAvailable: false });
+
+    await assert.rejects(
+      () =>
+        service.createMeeting(
+          { userId: "user-1", organizationId: "org-1" },
+          {
+            contactId: "contact-1",
+            scheduledAt: "2099-01-05T15:00:00.000Z",
+            requireAvailableSlot: true,
+          },
+        ),
+      /no longer available/,
+    );
+
+    assert.deepEqual(events, ["ringee:create-protected"]);
   });
 });

--- a/packages/services/src/services/meeting.service.spec.ts
+++ b/packages/services/src/services/meeting.service.spec.ts
@@ -1,0 +1,104 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MeetingService } from "./meeting.service";
+
+const STORED_MEETING = {
+  id: "meeting-1",
+  userId: "user-1",
+  organizationId: "org-1",
+  contactId: "contact-1",
+  callId: null,
+  title: "Product demo",
+  scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
+  duration: 30,
+  location: null,
+  notes: null,
+  status: "scheduled",
+  externalEventId: null,
+  cancelledAt: null,
+  createdAt: new Date("2099-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2099-01-01T00:00:00.000Z"),
+};
+
+function build(options: { syncError?: Error } = {}) {
+  const events: string[] = [];
+  const calendarRequests: Array<Record<string, unknown>> = [];
+
+  const service = new MeetingService(
+    {
+      create: async () => {
+        events.push("ringee:create");
+        return STORED_MEETING;
+      },
+    } as never,
+    {} as never,
+    {
+      createCalendarEvent: async (
+        _ctx: unknown,
+        dto: Record<string, unknown>,
+      ) => {
+        events.push("google:sync");
+        calendarRequests.push(dto);
+        if (options.syncError) throw options.syncError;
+        return {
+          externalEventId: "google-event-1",
+          meetLink: "https://meet.google.com/abc-defg-hij",
+        };
+      },
+    } as never,
+    { enqueueMeetingSync: async () => undefined } as never,
+    { scheduleForSubject: async () => undefined } as never,
+    { findById: async () => null } as never,
+    { enqueue: async () => undefined } as never,
+    {} as never,
+    {} as never,
+  );
+
+  return { service, events, calendarRequests };
+}
+
+describe("MeetingService Ringee-first calendar sync", () => {
+  it("stores in Ringee before syncing the configured external calendar", async () => {
+    const { service, events, calendarRequests } = build();
+
+    const meeting = await service.createMeeting(
+      { userId: "user-1", organizationId: "org-1" },
+      {
+        contactId: "contact-1",
+        title: "Product demo",
+        scheduledAt: "2099-01-05T15:00:00.000Z",
+        duration: 30,
+        attendeeEmail: "prospect@example.com",
+        calendarIntegrationId: "calendar-1",
+      },
+    );
+
+    assert.deepEqual(events, ["ringee:create", "google:sync"]);
+    assert.equal(calendarRequests[0]?.meetingId, "meeting-1");
+    assert.equal(calendarRequests[0]?.integrationId, "calendar-1");
+    assert.equal(meeting.externalEventId, "google-event-1");
+    assert.equal(meeting.location, "https://meet.google.com/abc-defg-hij");
+  });
+
+  it("keeps the Ringee booking when external sync fails", async () => {
+    const { service, events } = build({
+      syncError: new Error("Google Calendar API error: 503"),
+    });
+
+    const meeting = await service.createMeeting(
+      { userId: "user-1", organizationId: "org-1" },
+      {
+        contactId: "contact-1",
+        scheduledAt: "2099-01-05T15:00:00.000Z",
+        calendarIntegrationId: "calendar-1",
+      },
+    );
+
+    assert.deepEqual(events, ["ringee:create", "google:sync"]);
+    assert.equal(meeting.id, "meeting-1");
+    assert.equal(meeting.externalEventId, null);
+    assert.equal(meeting.location, null);
+  });
+});

--- a/packages/services/src/services/meeting.service.ts
+++ b/packages/services/src/services/meeting.service.ts
@@ -2,6 +2,7 @@ import {
   forwardRef,
   Inject,
   Injectable,
+  ConflictException,
   ForbiddenException,
   NotFoundException,
   Logger,
@@ -107,9 +108,10 @@ export class MeetingService {
       attendeeEmail?: string;
       calendarProvider?: "google" | "microsoft";
       calendarIntegrationId?: string | null;
+      requireAvailableSlot?: boolean;
     },
   ): Promise<Meeting> {
-    const meeting = await this.meetingRepo.create(ctx, {
+    const meetingData = {
       contactId: dto.contactId,
       callId: dto.callId,
       title: dto.title,
@@ -117,7 +119,13 @@ export class MeetingService {
       duration: dto.duration,
       location: dto.location,
       notes: dto.notes,
-    });
+    };
+    const meeting = dto.requireAvailableSlot
+      ? await this.meetingRepo.createIfAvailable(ctx, meetingData)
+      : await this.meetingRepo.create(ctx, meetingData);
+    if (!meeting) {
+      throw new ConflictException("That time is no longer available.");
+    }
 
     // Auto-set call outcome to meeting_booked if linked to a call. Fold the
     // fanout in below, AFTER the calendar event, so the Meet link makes it into

--- a/packages/services/src/services/meeting.service.ts
+++ b/packages/services/src/services/meeting.service.ts
@@ -106,6 +106,7 @@ export class MeetingService {
       notes?: string;
       attendeeEmail?: string;
       calendarProvider?: "google" | "microsoft";
+      calendarIntegrationId?: string | null;
     },
   ): Promise<Meeting> {
     const meeting = await this.meetingRepo.create(ctx, {
@@ -146,6 +147,7 @@ export class MeetingService {
         duration: dto.duration || 30,
         attendeeEmail: dto.attendeeEmail,
         provider: dto.calendarProvider as any,
+        integrationId: dto.calendarIntegrationId,
       });
       this.logger.log(
         `Synced meeting ${meeting.id} to external calendar: ${calendarResult.externalEventId}`,
@@ -195,7 +197,16 @@ export class MeetingService {
       );
     }
 
-    return meeting;
+    // `createCalendarEvent` persists these fields after Ringee creates the
+    // meeting. Reflect them in this response as well so tool callers receive
+    // the Meet/Teams link without needing a second read.
+    return calendarResult
+      ? {
+          ...meeting,
+          externalEventId: calendarResult.externalEventId,
+          location: calendarResult.meetLink ?? meeting.location,
+        }
+      : meeting;
   }
 
   async getMeetingById(ctx: OwnershipContext, id: string): Promise<Meeting> {

--- a/packages/services/src/services/voice-agents/voice-agent-tool.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-tool.service.spec.ts
@@ -7,6 +7,7 @@ import { VoiceAgentToolService } from "./voice-agent-tool.service";
 
 const SECRET = "rva_test_secret";
 const SECRET_HASH = createHash("sha256").update(SECRET).digest("hex");
+const FUTURE = "2099-01-05T15:00:00.000Z";
 
 const AGENT = {
   id: "agent-1",
@@ -34,6 +35,7 @@ function build(
   const updates: Array<Record<string, unknown>> = [];
   const created: Array<Record<string, unknown>> = [];
   const lookups: string[] = [];
+  const availabilityChecks: Array<Record<string, unknown>> = [];
 
   const service = new VoiceAgentToolService(
     {
@@ -57,9 +59,21 @@ function build(
       },
     } as never,
     {
-      getBookableSlots: async () => {
+      getBookableSlots: async (
+        _ctx: unknown,
+        opts: Record<string, unknown>,
+      ) => {
+        availabilityChecks.push(opts);
         if (over.slotsError) throw over.slotsError;
-        return over.slots ?? [];
+        return (
+          over.slots ?? [
+            {
+              start: FUTURE,
+              end: "2099-01-05T15:30:00.000Z",
+              label: "Monday, January 5, 10:00 AM",
+            },
+          ]
+        );
       },
     } as never,
     {
@@ -85,10 +99,8 @@ function build(
     { findOrCreateByPhone: async () => ({ id: "contact-2" }) } as never,
   );
 
-  return { service, updates, created, lookups };
+  return { service, updates, created, lookups, availabilityChecks };
 }
-
-const FUTURE = new Date(Date.now() + 3 * 24 * 3600_000).toISOString();
 
 describe("VoiceAgentToolService authorization", () => {
   it("refuses a tool call with the wrong secret", async () => {
@@ -169,7 +181,7 @@ describe("VoiceAgentToolService availability", () => {
 
 describe("VoiceAgentToolService booking", () => {
   it("books the meeting and records the outcome on the call", async () => {
-    const { service, updates, created } = build();
+    const { service, updates, created, availabilityChecks } = build();
 
     const result = await service.bookAppointment("agent-1", SECRET, "cc-1", {
       start: FUTURE,
@@ -186,6 +198,14 @@ describe("VoiceAgentToolService booking", () => {
     assert.equal(created[0]?.title, "Product Demo");
     assert.equal(created[0]?.duration, 30);
     assert.equal(created[0]?.calendarIntegrationId, "cal-1");
+    assert.equal(created[0]?.requireAvailableSlot, true);
+    assert.deepEqual(availabilityChecks, [
+      {
+        date: "2099-01-05",
+        timeZone: "America/New_York",
+        durationMinutes: 30,
+      },
+    ]);
     // The tool knows a meeting exists; the later transcript analysis must not
     // be the thing that decides this.
     assert.deepEqual(updates, [
@@ -239,6 +259,20 @@ describe("VoiceAgentToolService booking", () => {
       start: "tomorrow afternoon",
     });
     assert.equal(result.ok, false);
+  });
+
+  it("refuses a start that is not an exact Ringee bookable slot", async () => {
+    const { service, created, updates } = build({ slots: [] });
+
+    const result = await service.bookAppointment("agent-1", SECRET, "cc-1", {
+      start: FUTURE,
+    });
+
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /no longer available/);
+    assert.deepEqual(created, []);
+    assert.deepEqual(updates, []);
   });
 
   it("tells the agent to offer another time when the booking fails", async () => {

--- a/packages/services/src/services/voice-agents/voice-agent-tool.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-tool.service.spec.ts
@@ -145,7 +145,7 @@ describe("VoiceAgentToolService availability", () => {
 
   it("reports a calendar failure instead of claiming the day is free", async () => {
     const { service } = build({
-      slotsError: new Error("No calendar connected"),
+      slotsError: new Error("Ringee calendar unavailable"),
     });
 
     const result = await service.getAvailableSlots("agent-1", SECRET, {
@@ -185,6 +185,7 @@ describe("VoiceAgentToolService booking", () => {
     assert.equal(created[0]?.contactId, "contact-1");
     assert.equal(created[0]?.title, "Product Demo");
     assert.equal(created[0]?.duration, 30);
+    assert.equal(created[0]?.calendarIntegrationId, "cal-1");
     // The tool knows a meeting exists; the later transcript analysis must not
     // be the thing that decides this.
     assert.deepEqual(updates, [

--- a/packages/services/src/services/voice-agents/voice-agent-tool.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-tool.service.ts
@@ -85,7 +85,6 @@ export class VoiceAgentToolService {
         date,
         timeZone: timezone,
         durationMinutes: agent.meetingDurationMinutes,
-        integrationId: agent.calendarIntegrationId,
       });
 
       return {
@@ -180,6 +179,7 @@ export class VoiceAgentToolService {
         duration: agent.meetingDurationMinutes,
         notes: input.notes,
         attendeeEmail: input.attendee_email,
+        calendarIntegrationId: agent.calendarIntegrationId,
       });
 
       const end = new Date(

--- a/packages/services/src/services/voice-agents/voice-agent-tool.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-tool.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   Logger,
   UnauthorizedException,
@@ -171,6 +172,24 @@ export class VoiceAgentToolService {
     }
 
     try {
+      const timezone = agent.timezone || "UTC";
+      const date = this.dateInTimeZone(start, timezone);
+      const slots = await this.calendars.getBookableSlots(ctx, {
+        date,
+        timeZone: timezone,
+        durationMinutes: agent.meetingDurationMinutes,
+      });
+      const exactSlot = slots.some(
+        (slot) => new Date(slot.start).getTime() === start.getTime(),
+      );
+      if (!exactSlot) {
+        return {
+          ok: false,
+          error:
+            "That time is no longer available. Offer another available time.",
+        };
+      }
+
       const meeting = await this.meetings.createMeeting(ctx, {
         contactId,
         callId: agentCall?.callId ?? undefined,
@@ -180,6 +199,7 @@ export class VoiceAgentToolService {
         notes: input.notes,
         attendeeEmail: input.attendee_email,
         calendarIntegrationId: agent.calendarIntegrationId,
+        requireAvailableSlot: true,
       });
 
       const end = new Date(
@@ -206,6 +226,13 @@ export class VoiceAgentToolService {
         },
       };
     } catch (error) {
+      if (error instanceof ConflictException) {
+        return {
+          ok: false,
+          error:
+            "That time is no longer available. Offer another available time.",
+        };
+      }
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(
         `Booking failed for agent ${agentId} at ${start.toISOString()}: ${message}`,
@@ -258,6 +285,19 @@ export class VoiceAgentToolService {
     if (!start?.trim()) return null;
     const parsed = new Date(start.trim());
     return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  /** The calendar date on which an instant falls in the agent's time zone. */
+  private dateInTimeZone(instant: Date, timeZone: string): string {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(instant);
+    const part = (type: Intl.DateTimeFormatPartTypes) =>
+      parts.find((value) => value.type === type)?.value ?? "";
+    return `${part("year")}-${part("month")}-${part("day")}`;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Behaviour

- Ringee meetings are now the availability source for voice-agent bookings.
- Booking requires an exact slot from the availability lookup.
- The repository locks the relevant user or organization row before it checks overlaps and creates the meeting.
- A concurrent booking receives an unavailable-time conflict and does not create a second meeting.
- External calendar synchronization runs after the Ringee booking.
- A synchronization failure leaves the Ringee booking in place.

## Architectural impact

- `CalendarService.getBookableSlots` reads Ringee busy periods through `MeetingRepository`.
- `getBookableSlots` no longer accepts `provider` or `integrationId`.
- `MeetingService.createMeeting` supports `calendarIntegrationId` and optional Ringee slot enforcement.
- External integration lookup remains inside `CalendarService.createCalendarEvent`.
- `MeetingRepository.createIfAvailable` adds transactional locking and overlap checks to the `@ringee/database` contract.
- The voice-agent tool now converts the requested start time to the agent timezone, validates the exact available slot, and enables availability enforcement during creation.

## Risk areas

- A booking can persist without an external calendar event when synchronization fails.
- Availability and locking depend on correct organization or user ownership scope.
- The business-day query window and timezone conversion can include or exclude slots at date boundaries.
- The availability lookup and booking enforcement must use equivalent overlap and duration rules.
- Removing `provider` and `integrationId` from `getBookableSlots` changes the `@ringee/services` contract.
- Adding `calendarIntegrationId` and `requireAvailableSlot` changes the meeting creation DTO and callers.
- Retries after a synchronization failure can create duplicate external events unless the flow has idempotency protection.

## Files to review first

- `packages/database/src/database/repositories/meeting.repository.ts`
- `packages/services/src/services/calendar.service.ts`
- `packages/services/src/services/meeting.service.ts`
- `packages/services/src/services/voice-agents/voice-agent-tool.service.ts`
- `docs/engineering/BUSINESS_RULES.md`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->