### PR TITLE
feat: enhance telephony and call detail features with mobile number support and new dialog component

### DIFF
--- a/apps/backend/src/api/routes/telephony.controller.ts
+++ b/apps/backend/src/api/routes/telephony.controller.ts
@@ -92,7 +92,7 @@ export class TelephonyController {
   async getNumbersByCountry(
     @Param("country") country: string,
     @Query("areaCode") areaCode?: string,
-    @Query("numberType") numberType?: "local" | "toll_free",
+    @Query("numberType") numberType?: "local" | "toll_free" | "mobile",
     @Query("features") features?: string | string[],
     @Query("limit", ParseIntPipe) limit?: number,
   ): Promise<AvailableNumber[] | null> {

--- a/apps/frontend/src/components/date-range-filter.tsx
+++ b/apps/frontend/src/components/date-range-filter.tsx
@@ -8,9 +8,9 @@ import {
   PopoverTrigger
 } from '@ringee/frontend-shared/components/ui/popover';
 import { CalendarIcon, XCircle } from 'lucide-react';
-import { useQueryState, parseAsString } from 'nuqs';
+import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
 import { DateRange } from 'react-day-picker';
-import { format } from 'date-fns';
+import { endOfDay, format, startOfDay } from 'date-fns';
 import { cn } from '@ringee/frontend-shared/lib/utils';
 import { useTranslations } from 'next-intl';
 
@@ -21,13 +21,17 @@ import { useTranslations } from 'next-intl';
  */
 export function DateRangeFilter() {
   const t = useTranslations('common.dateFilter');
-  const [dateFrom, setDateFrom] = useQueryState(
-    'dateFrom',
-    parseAsString.withDefault('')
-  );
-  const [dateTo, setDateTo] = useQueryState(
-    'dateTo',
-    parseAsString.withDefault('')
+  const [{ dateFrom, dateTo }, setRange] = useQueryStates(
+    {
+      dateFrom: parseAsString.withDefault(''),
+      dateTo: parseAsString.withDefault(''),
+      page: parseAsInteger.withDefault(1)
+    },
+    {
+      // History and recordings are server-rendered listings. A shallow URL
+      // update changes the label but never asks those listings for new data.
+      shallow: false
+    }
   );
 
   const selectedRange: DateRange = {
@@ -36,22 +40,19 @@ export function DateRangeFilter() {
   };
 
   const handleSelect = (range: DateRange | undefined) => {
-    if (range?.from) {
-      setDateFrom(range.from.toISOString());
-    } else {
-      setDateFrom('');
-    }
-    if (range?.to) {
-      setDateTo(range.to.toISOString());
-    } else {
-      setDateTo('');
-    }
+    void setRange({
+      // Calendar selections are whole local days. Convert their inclusive
+      // boundaries to UTC only after applying local start/end-of-day, so the
+      // final day does not stop at 00:00 and lose the rest of its calls.
+      dateFrom: range?.from ? startOfDay(range.from).toISOString() : null,
+      dateTo: range?.to ? endOfDay(range.to).toISOString() : null,
+      page: 1
+    });
   };
 
   const handleClear = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setDateFrom('');
-    setDateTo('');
+    void setRange({ dateFrom: null, dateTo: null, page: 1 });
   };
 
   const hasValue = dateFrom || dateTo;

--- a/apps/frontend/src/features/ai-voice-agents/components/calls-table.tsx
+++ b/apps/frontend/src/features/ai-voice-agents/components/calls-table.tsx
@@ -18,6 +18,8 @@ import {
 import { useVoiceAgentApi } from '../api';
 import { describeApiError } from '../lib/api-error';
 import type { VoiceAgentCall } from '../types';
+import { CallDetailDialog } from '@/features/call-detail';
+import { CallListRowActions } from '@/features/calls/components/call-list-row-actions';
 
 /** Call history for one agent (§17). */
 export function CallsTable({
@@ -29,10 +31,12 @@ export function CallsTable({
 }) {
   const t = useTranslations('aiVoiceAgents.calls');
   const tCommon = useTranslations('aiVoiceAgents.common');
+  const tGlobal = useTranslations('common');
   const api = useVoiceAgentApi();
   const [calls, setCalls] = useState<VoiceAgentCall[]>([]);
   const [loading, setLoading] = useState(true);
   const [failure, setFailure] = useState<string | null>(null);
+  const [selectedCallId, setSelectedCallId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -80,53 +84,80 @@ export function CallsTable({
   }
 
   return (
-    <Card className='overflow-x-auto rounded-lg p-0'>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>{t('phone')}</TableHead>
-            <TableHead>{t('started')}</TableHead>
-            <TableHead>{t('status')}</TableHead>
-            <TableHead>{t('outcome')}</TableHead>
-            <TableHead>{t('summary')}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {calls.map((call) => (
-            <TableRow key={call.id}>
-              <TableCell className='font-medium'>{call.toNumber}</TableCell>
-              <TableCell>{new Date(call.createdAt).toLocaleString()}</TableCell>
-              <TableCell>
-                <Badge variant='secondary' className='rounded-lg'>
-                  {call.status}
-                </Badge>
-              </TableCell>
-              <TableCell>
-                {call.outcome ? (
-                  <Badge
-                    className='rounded-lg'
-                    variant={
-                      call.outcome === 'appointment_booked' ||
-                      call.outcome === 'confirmed'
-                        ? 'default'
-                        : 'outline'
-                    }
-                  >
-                    {t.has(`outcomes.${call.outcome}`)
-                      ? t(`outcomes.${call.outcome}`)
-                      : call.outcome}
-                  </Badge>
-                ) : (
-                  <span className='text-muted-foreground'>—</span>
-                )}
-              </TableCell>
-              <TableCell className='text-muted-foreground max-w-md truncate text-sm'>
-                {call.summary ?? '—'}
-              </TableCell>
+    <>
+      <CallDetailDialog
+        callId={selectedCallId}
+        onClose={() => setSelectedCallId(null)}
+        closeLabel={tCommon('back')}
+        description={t('detailDescription')}
+      />
+
+      <Card className='overflow-x-auto rounded-lg p-0'>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t('phone')}</TableHead>
+              <TableHead>{t('started')}</TableHead>
+              <TableHead>{t('status')}</TableHead>
+              <TableHead>{t('outcome')}</TableHead>
+              <TableHead>{t('summary')}</TableHead>
+              <TableHead className='w-12'>
+                <span className='sr-only'>{tGlobal('actions')}</span>
+              </TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Card>
+          </TableHeader>
+          <TableBody>
+            {calls.map((call) => (
+              <TableRow key={call.id}>
+                <TableCell className='font-medium'>{call.toNumber}</TableCell>
+                <TableCell>
+                  {new Date(call.createdAt).toLocaleString()}
+                </TableCell>
+                <TableCell>
+                  <Badge variant='secondary' className='rounded-lg'>
+                    {call.status}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  {call.outcome ? (
+                    <Badge
+                      className='rounded-lg'
+                      variant={
+                        call.outcome === 'appointment_booked' ||
+                        call.outcome === 'confirmed'
+                          ? 'default'
+                          : 'outline'
+                      }
+                    >
+                      {t.has(`outcomes.${call.outcome}`)
+                        ? t(`outcomes.${call.outcome}`)
+                        : call.outcome}
+                    </Badge>
+                  ) : (
+                    <span className='text-muted-foreground'>—</span>
+                  )}
+                </TableCell>
+                <TableCell className='text-muted-foreground max-w-md truncate text-sm'>
+                  {call.summary ?? '—'}
+                </TableCell>
+                <TableCell className='text-right'>
+                  {call.callId ? (
+                    <CallListRowActions
+                      callId={call.callId}
+                      callFrom={call.fromNumber}
+                      callTo={call.toNumber}
+                      phoneNumber={call.toNumber}
+                      onView={() => setSelectedCallId(call.callId)}
+                    />
+                  ) : (
+                    <span className='text-muted-foreground'>—</span>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Card>
+    </>
   );
 }

--- a/apps/frontend/src/features/ai-voice-agents/types.ts
+++ b/apps/frontend/src/features/ai-voice-agents/types.ts
@@ -164,6 +164,8 @@ export interface VoiceAgent {
 
 export interface VoiceAgentCall {
   id: string;
+  /** Linked telephony call; null while the provider has not accepted the leg. */
+  callId: string | null;
   toNumber: string;
   fromNumber: string;
   status: string;

--- a/apps/frontend/src/features/call-detail/components/call-detail-dialog.tsx
+++ b/apps/frontend/src/features/call-detail/components/call-detail-dialog.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@ringee/frontend-shared/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle
+} from '@ringee/frontend-shared/components/ui/dialog';
+import { CallDetail } from './call-detail';
+
+/**
+ * Full-screen shell for the canonical call detail.
+ *
+ * History supplies its previous/next controls through `headerActions`; other
+ * call listings can reuse the same review experience without inventing a
+ * second detail layout or navigating away from their current context.
+ */
+export function CallDetailDialog({
+  callId,
+  onClose,
+  closeLabel,
+  description,
+  headerActions
+}: {
+  callId: string | null;
+  onClose: () => void;
+  closeLabel?: string;
+  description?: string;
+  headerActions?: ReactNode;
+}) {
+  const t = useTranslations('calls.detail');
+
+  return (
+    <Dialog
+      open={Boolean(callId)}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        className='data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 top-0 left-0 flex h-dvh max-h-dvh w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 p-0 shadow-none sm:max-w-none'
+      >
+        <DialogTitle className='sr-only'>{t('dialogTitle')}</DialogTitle>
+        <DialogDescription className='sr-only'>
+          {description ?? t('dialogDescription')}
+        </DialogDescription>
+
+        <header className='bg-background/95 z-10 shrink-0 border-b backdrop-blur'>
+          <div className='mx-auto flex min-h-16 w-full max-w-7xl items-center justify-between gap-3 px-3 sm:px-6'>
+            <Button
+              type='button'
+              variant='ghost'
+              className='h-11 rounded-lg px-3'
+              onClick={onClose}
+            >
+              <ArrowLeft className='size-4' />
+              <span className='hidden sm:inline'>
+                {closeLabel ?? t('back')}
+              </span>
+              <span className='sr-only sm:hidden'>
+                {closeLabel ?? t('back')}
+              </span>
+            </Button>
+
+            {headerActions}
+          </div>
+        </header>
+
+        <main className='min-h-0 flex-1 overflow-y-auto'>
+          <div className='mx-auto w-full max-w-7xl px-4 py-6 sm:px-6'>
+            {callId ? (
+              <CallDetail callId={callId} showBackLink={false} />
+            ) : null}
+          </div>
+        </main>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/features/call-detail/index.ts
+++ b/apps/frontend/src/features/call-detail/index.ts
@@ -1,4 +1,5 @@
 export { CallDetail } from './components/call-detail';
+export { CallDetailDialog } from './components/call-detail-dialog';
 export { CallSourceBadge } from './components/call-source-badge';
 export * from './types';
 export * from './lib/format';

--- a/apps/frontend/src/features/contact/components/contact.listing.tsx
+++ b/apps/frontend/src/features/contact/components/contact.listing.tsx
@@ -1,7 +1,6 @@
 import { searchParamsCache } from '@ringee/frontend-shared/lib/searchparams';
 import { ContactTableClient } from './contact-table-client';
 import { apiServer } from '@ringee/frontend-shared/lib/api.server';
-import { serialize } from '@ringee/frontend-shared/lib/searchparams';
 import { unstable_noStore as noStore } from 'next/cache';
 
 export default async function ContactListingPage() {
@@ -13,11 +12,6 @@ export default async function ContactListingPage() {
   const sort = searchParamsCache.get('sort');
   const tags = searchParamsCache.get('tags');
 
-  const filters = {
-    page,
-    limit: pageLimit,
-    ...(search && { search })
-  };
   const sorting = sort?.length
     ? sort.reduce(
         (acc, item) => ({
@@ -28,17 +22,19 @@ export default async function ContactListingPage() {
       )
     : undefined;
 
-  let apiUrl = `/contacts${serialize(filters)}`;
+  // The dashboard URL calls this value `perPage`, while the contacts API calls
+  // it `limit`. Passing `limit` through the shared dashboard serializer silently
+  // dropped it because that serializer only owns dashboard query keys, leaving
+  // the API on its default of 10 regardless of the selected page size.
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(pageLimit)
+  });
+  if (search) params.set('search', search);
+  if (sorting) params.set('sort', JSON.stringify(sorting));
+  if (tags.length > 0) params.set('tags', tags.join(','));
 
-  if (sorting) {
-    apiUrl += `${apiUrl.includes('?') ? '&' : '?'}sort=${JSON.stringify(sorting)}`;
-  }
-
-  if (tags && tags.length > 0) {
-    apiUrl += `${apiUrl.includes('?') ? '&' : '?'}tags=${tags.join(',')}`;
-  }
-
-  const data = await apiServer.get(apiUrl);
+  const data = await apiServer.get(`/contacts?${params.toString()}`);
 
   const totalContacts = data.meta.total;
   const contacts = data.data;

--- a/apps/frontend/src/features/history/components/call-history-detail-dialog.tsx
+++ b/apps/frontend/src/features/history/components/call-history-detail-dialog.tsx
@@ -4,22 +4,15 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { parseAsString, useQueryState } from 'nuqs';
-import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle
-} from '@ringee/frontend-shared/components/ui/dialog';
-import { Separator } from '@ringee/frontend-shared/components/ui/separator';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
 import { CallListRowActions } from '@/features/calls/components/call-list-row-actions';
 import {
   useCallDetailApi,
   type CallDetailNavigation
 } from '@/features/call-detail/api';
-import { CallDetail } from '@/features/call-detail';
+import { CallDetailDialog } from '@/features/call-detail';
 
 const callIdQuery = parseAsString.withOptions({
   history: 'push',
@@ -148,93 +141,59 @@ export function CallHistoryDetailDialog() {
   }, [callId, goTo, navigation?.nextId, navigation?.previousId]);
 
   return (
-    <Dialog
-      open={Boolean(callId)}
-      onOpenChange={(open) => {
-        if (!open) close();
-      }}
-    >
-      <DialogContent
-        showCloseButton={false}
-        className='data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 top-0 left-0 flex h-dvh max-h-dvh w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 p-0 shadow-none sm:max-w-none'
-      >
-        <DialogTitle className='sr-only'>{t('dialogTitle')}</DialogTitle>
-        <DialogDescription className='sr-only'>
-          {t('dialogDescription')}
-        </DialogDescription>
+    <CallDetailDialog
+      callId={callId}
+      onClose={close}
+      headerActions={
+        <nav
+          className='flex items-center gap-2'
+          aria-label={t('navigationLabel')}
+        >
+          <Button
+            type='button'
+            variant='outline'
+            className='h-11 rounded-lg px-3'
+            aria-label={t('previous')}
+            aria-keyshortcuts='ArrowLeft'
+            disabled={!navigation?.previousId}
+            onClick={() => goTo(navigation?.previousId)}
+          >
+            <ChevronLeft className='size-4' />
+            <span className='hidden md:inline'>{t('previous')}</span>
+          </Button>
 
-        <header className='bg-background/95 z-10 shrink-0 border-b backdrop-blur'>
-          <div className='mx-auto flex min-h-16 w-full max-w-7xl items-center justify-between gap-3 px-3 sm:px-6'>
-            <Button
-              type='button'
-              variant='ghost'
-              className='h-11 rounded-lg px-3'
-              onClick={close}
-            >
-              <ArrowLeft className='size-4' />
-              <span className='hidden sm:inline'>{t('back')}</span>
-              <span className='sr-only sm:hidden'>{t('back')}</span>
-            </Button>
-
-            <nav
-              className='flex items-center gap-2'
-              aria-label={t('navigationLabel')}
-            >
-              <Button
-                type='button'
-                variant='outline'
-                className='h-11 rounded-lg px-3'
-                aria-label={t('previous')}
-                aria-keyshortcuts='ArrowLeft'
-                disabled={!navigation?.previousId}
-                onClick={() => goTo(navigation?.previousId)}
-              >
-                <ChevronLeft className='size-4' />
-                <span className='hidden md:inline'>{t('previous')}</span>
-              </Button>
-
-              <div
-                className='text-muted-foreground flex min-w-24 justify-center text-xs tabular-nums sm:min-w-32 sm:text-sm'
-                aria-live='polite'
-              >
-                {navigationFailed ? (
-                  <span>{t('navigationUnavailable')}</span>
-                ) : navigation ? (
-                  <span>
-                    {t('position', {
-                      position: navigation.position,
-                      total: navigation.total
-                    })}
-                  </span>
-                ) : (
-                  <Skeleton className='h-4 w-20 rounded' />
-                )}
-              </div>
-
-              <Button
-                type='button'
-                variant='outline'
-                className='h-11 rounded-lg px-3'
-                aria-label={t('next')}
-                aria-keyshortcuts='ArrowRight'
-                disabled={!navigation?.nextId}
-                onClick={() => goTo(navigation?.nextId)}
-              >
-                <span className='hidden md:inline'>{t('next')}</span>
-                <ChevronRight className='size-4' />
-              </Button>
-            </nav>
+          <div
+            className='text-muted-foreground flex min-w-24 justify-center text-xs tabular-nums sm:min-w-32 sm:text-sm'
+            aria-live='polite'
+          >
+            {navigationFailed ? (
+              <span>{t('navigationUnavailable')}</span>
+            ) : navigation ? (
+              <span>
+                {t('position', {
+                  position: navigation.position,
+                  total: navigation.total
+                })}
+              </span>
+            ) : (
+              <Skeleton className='h-4 w-20 rounded' />
+            )}
           </div>
-        </header>
 
-        <main className='min-h-0 flex-1 overflow-y-auto'>
-          <div className='mx-auto w-full max-w-7xl px-4 py-6 sm:px-6'>
-            {callId ? (
-              <CallDetail callId={callId} showBackLink={false} />
-            ) : null}
-          </div>
-        </main>
-      </DialogContent>
-    </Dialog>
+          <Button
+            type='button'
+            variant='outline'
+            className='h-11 rounded-lg px-3'
+            aria-label={t('next')}
+            aria-keyshortcuts='ArrowRight'
+            disabled={!navigation?.nextId}
+            onClick={() => goTo(navigation?.nextId)}
+          >
+            <span className='hidden md:inline'>{t('next')}</span>
+            <ChevronRight className='size-4' />
+          </Button>
+        </nav>
+      }
+    />
   );
 }

--- a/apps/frontend/src/features/number/components/tables/buy.number.columns.tsx
+++ b/apps/frontend/src/features/number/components/tables/buy.number.columns.tsx
@@ -244,7 +244,8 @@ export const columns: ColumnDef<AvailableNumber>[] = [
       variant: 'select',
       options: [
         { label: 'Local', value: 'local' },
-        { label: 'Toll Free', value: 'toll_free' }
+        { label: 'Toll Free', value: 'toll_free' },
+        { label: 'Mobile', value: 'mobile' }
       ]
     },
     enableColumnFilter: true

--- a/apps/frontend/src/i18n/locales/de/aiVoiceAgents.json
+++ b/apps/frontend/src/i18n/locales/de/aiVoiceAgents.json
@@ -262,6 +262,7 @@
   "calls": {
     "loadError": "Die Anrufe dieses Agenten konnten nicht geladen werden.",
     "empty": "Dieser Agent hat noch niemanden angerufen.",
+    "detailDescription": "Prüfen Sie diesen Anruf, ohne den Agenten zu verlassen.",
     "phone": "Telefon",
     "started": "Gestartet",
     "status": "Status",

--- a/apps/frontend/src/i18n/locales/en/aiVoiceAgents.json
+++ b/apps/frontend/src/i18n/locales/en/aiVoiceAgents.json
@@ -322,6 +322,7 @@
   "calls": {
     "loadError": "Could not load this agent’s calls.",
     "empty": "This agent has not called anyone yet.",
+    "detailDescription": "Review this call without leaving the agent.",
     "phone": "Phone",
     "started": "Started",
     "status": "Status",

--- a/apps/frontend/src/i18n/locales/es/aiVoiceAgents.json
+++ b/apps/frontend/src/i18n/locales/es/aiVoiceAgents.json
@@ -262,6 +262,7 @@
   "calls": {
     "loadError": "No se pudieron cargar las llamadas de este agente.",
     "empty": "Este agente todavía no ha llamado a nadie.",
+    "detailDescription": "Revisa esta llamada sin salir del agente.",
     "phone": "Teléfono",
     "started": "Iniciada",
     "status": "Estado",

--- a/apps/frontend/src/i18n/locales/fr/aiVoiceAgents.json
+++ b/apps/frontend/src/i18n/locales/fr/aiVoiceAgents.json
@@ -262,6 +262,7 @@
   "calls": {
     "loadError": "Impossible de charger les appels de cet agent.",
     "empty": "Cet agent n'a encore appelé personne.",
+    "detailDescription": "Consultez cet appel sans quitter l’agent.",
     "phone": "Téléphone",
     "started": "Démarré",
     "status": "Statut",

--- a/apps/frontend/src/i18n/locales/it/aiVoiceAgents.json
+++ b/apps/frontend/src/i18n/locales/it/aiVoiceAgents.json
@@ -262,6 +262,7 @@
   "calls": {
     "loadError": "Impossibile caricare le chiamate di questo agente.",
     "empty": "Questo agente non ha ancora chiamato nessuno.",
+    "detailDescription": "Esamina questa chiamata senza uscire dall’agente.",
     "phone": "Telefono",
     "started": "Iniziata",
     "status": "Stato",

--- a/apps/frontend/src/i18n/locales/nl/aiVoiceAgents.json
+++ b/apps/frontend/src/i18n/locales/nl/aiVoiceAgents.json
@@ -262,6 +262,7 @@
   "calls": {
     "loadError": "Kon de gesprekken van deze agent niet laden.",
     "empty": "Deze agent heeft nog niemand gebeld.",
+    "detailDescription": "Bekijk dit gesprek zonder de agent te verlaten.",
     "phone": "Telefoon",
     "started": "Gestart",
     "status": "Status",

--- a/apps/frontend/src/i18n/locales/pt/aiVoiceAgents.json
+++ b/apps/frontend/src/i18n/locales/pt/aiVoiceAgents.json
@@ -262,6 +262,7 @@
   "calls": {
     "loadError": "Não foi possível carregar as chamadas deste agente.",
     "empty": "Este agente ainda não ligou a ninguém.",
+    "detailDescription": "Consulte esta chamada sem sair do agente.",
     "phone": "Telefone",
     "started": "Iniciada",
     "status": "Estado",

--- a/packages/database/src/database/repositories/meeting.repository.spec.ts
+++ b/packages/database/src/database/repositories/meeting.repository.spec.ts
@@ -1,72 +1,157 @@
 /// <reference types="node" />
 
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { randomUUID } from "node:crypto";
+import { after, before, describe, it, type TestContext } from "node:test";
+import { PrismaClient } from "@prisma/client";
 import { MeetingRepository } from "./meeting.repository";
 
-const MEETING = {
-  id: "meeting-1",
-  scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
+const prisma = new PrismaClient();
+const repository = new MeetingRepository(prisma as never);
+
+const fixture = {
+  userId: randomUUID(),
+  organizationId: randomUUID(),
+  organizationContactId: randomUUID(),
+  personalContactId: randomUUID(),
 };
 
-function build(conflict = false) {
-  const events: string[] = [];
-  const transaction = {
-    $queryRaw: async (strings: TemplateStringsArray) => {
-      const sql = strings.join("?");
-      if (sql.includes("FOR UPDATE")) {
-        events.push("lock");
-        return [];
-      }
-      events.push("check");
-      return conflict ? [{ id: "meeting-existing" }] : [];
-    },
-    meeting: {
-      create: async () => {
-        events.push("create");
-        return MEETING;
-      },
-    },
-  };
-  const repository = new MeetingRepository({
-    $transaction: async (
-      work: (client: typeof transaction) => Promise<unknown>,
-    ) => work(transaction),
-  } as never);
+let databaseConnected = false;
+let databaseReady = false;
 
-  return { repository, events };
+async function cleanupFixtures() {
+  await prisma.meeting.deleteMany({ where: { userId: fixture.userId } });
+  await prisma.contact.deleteMany({ where: { userId: fixture.userId } });
+  await prisma.organization.deleteMany({
+    where: { id: fixture.organizationId },
+  });
+  await prisma.user.deleteMany({ where: { id: fixture.userId } });
 }
 
-describe("MeetingRepository.createIfAvailable", () => {
-  it("locks, re-checks and creates in one transaction", async () => {
-    const { repository, events } = build();
+function requireDatabase(t: TestContext): boolean {
+  if (databaseReady) return true;
+  t.skip("PostgreSQL is unavailable or the test schema is not initialized");
+  return false;
+}
 
-    const meeting = await repository.createIfAvailable(
-      { userId: "user-1", organizationId: "org-1" },
+function assertExactlyOneBooking(
+  results: Awaited<ReturnType<MeetingRepository["createIfAvailable"]>>[],
+) {
+  assert.equal(
+    results.filter((meeting) => meeting !== null).length,
+    1,
+    "exactly one concurrent request should create a meeting",
+  );
+  assert.equal(
+    results.filter((meeting) => meeting === null).length,
+    1,
+    "the competing request should observe the booked slot",
+  );
+}
+
+before(async () => {
+  try {
+    await prisma.$connect();
+    await prisma.$queryRaw`SELECT 1`;
+    databaseConnected = true;
+  } catch {
+    await prisma.$disconnect().catch(() => undefined);
+    return;
+  }
+
+  await cleanupFixtures();
+  await prisma.user.create({ data: { id: fixture.userId } });
+  await prisma.organization.create({
+    data: {
+      id: fixture.organizationId,
+      clerkId: `meeting-test-${fixture.organizationId}`,
+      name: "Meeting concurrency test",
+    },
+  });
+  await prisma.contact.createMany({
+    data: [
       {
-        contactId: "contact-1",
-        scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
-        duration: 30,
+        id: fixture.organizationContactId,
+        userId: fixture.userId,
+        organizationId: fixture.organizationId,
+        name: "Organization booking",
+        phoneNumber: "+12025550101",
       },
-    );
+      {
+        id: fixture.personalContactId,
+        userId: fixture.userId,
+        organizationId: null,
+        name: "Personal booking",
+        phoneNumber: "+12025550102",
+      },
+    ],
+  });
+  databaseReady = true;
+});
 
-    assert.equal(meeting?.id, "meeting-1");
-    assert.deepEqual(events, ["lock", "check", "create"]);
+after(async () => {
+  if (databaseConnected) {
+    await cleanupFixtures().catch(() => undefined);
+    await prisma.$disconnect();
+  }
+});
+
+describe("MeetingRepository.createIfAvailable", () => {
+  it("allows exactly one concurrent organization booking", async (t) => {
+    if (!requireDatabase(t)) return;
+
+    const ctx = {
+      userId: fixture.userId,
+      organizationId: fixture.organizationId,
+    };
+    const data = {
+      contactId: fixture.organizationContactId,
+      scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
+      duration: 30,
+    };
+
+    const results = await Promise.all([
+      repository.createIfAvailable(ctx, data),
+      repository.createIfAvailable(ctx, data),
+    ]);
+
+    assertExactlyOneBooking(results);
+    assert.equal(
+      await prisma.meeting.count({
+        where: {
+          organizationId: fixture.organizationId,
+          scheduledAt: data.scheduledAt,
+        },
+      }),
+      1,
+    );
   });
 
-  it("does not insert when a meeting now overlaps the slot", async () => {
-    const { repository, events } = build(true);
+  it("allows exactly one concurrent personal booking", async (t) => {
+    if (!requireDatabase(t)) return;
 
-    const meeting = await repository.createIfAvailable(
-      { userId: "user-1" },
-      {
-        contactId: "contact-1",
-        scheduledAt: new Date("2099-01-05T15:00:00.000Z"),
-        duration: 30,
-      },
+    const ctx = { userId: fixture.userId };
+    const data = {
+      contactId: fixture.personalContactId,
+      scheduledAt: new Date("2099-01-06T15:00:00.000Z"),
+      duration: 30,
+    };
+
+    const results = await Promise.all([
+      repository.createIfAvailable(ctx, data),
+      repository.createIfAvailable(ctx, data),
+    ]);
+
+    assertExactlyOneBooking(results);
+    assert.equal(
+      await prisma.meeting.count({
+        where: {
+          userId: fixture.userId,
+          organizationId: null,
+          scheduledAt: data.scheduledAt,
+        },
+      }),
+      1,
     );
-
-    assert.equal(meeting, null);
-    assert.deepEqual(events, ["lock", "check"]);
   });
 });

--- a/packages/frontend-shared/src/lib/searchparams.ts
+++ b/packages/frontend-shared/src/lib/searchparams.ts
@@ -26,7 +26,9 @@ export const searchParams = {
   country: parseAsString.withDefault("US"),
   areaCode: parseAsString,
   countryCode: parseAsString.withDefault("US"),
-  numberType: parseAsStringEnum(["local", "toll_free"]).withDefault("local"),
+  numberType: parseAsStringEnum(["local", "toll_free", "mobile"]).withDefault(
+    "local",
+  ),
   features: parseAsArrayOf(parseAsString).withDefault([]),
   // Date filters for recordings
   dateFrom: parseAsString,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour changes

- Available-number search and number purchase UI now support `numberType=mobile`.
- AI voice-agent calls with a linked `callId` can open the shared call-detail dialog.
- History call navigation now uses the shared dialog.
- Date-range changes update server-rendered listings and reset `page` to `1`.
- Contact queries now map `perPage` to `limit` through explicit `URLSearchParams`.

## Architectural impact

- `CallDetailDialog` owns the shared full-screen layout, close behavior, accessibility metadata, and optional navigation actions.
- `VoiceAgentCall.callId` exposes the telephony-call link as nullable because the provider can accept the call later.
- The mobile number type crosses the backend controller and `@ringee/frontend-shared` query-state contract.
- No `@ringee/services`, `@ringee/platform`, Prisma schema, or production database contract changes are shown.
- Meeting concurrency tests now require a live PostgreSQL schema.

## Risk areas

- The TypeScript union for `numberType` does not validate runtime query strings. The public endpoint can still receive unsupported values such as `national`. Add a runtime enum pipe if the endpoint must reject invalid values.
- Call-detail access depends on `callId`. A missing provider link correctly removes the action, but stale or cross-workspace IDs must still be rejected by the call-detail API.
- The PostgreSQL tests call `t.skip()` when the database or schema is unavailable. CI can report a passing suite without exercising the concurrency guarantee. Require PostgreSQL in the relevant CI job or fail setup when the test is mandatory.
- The contact query rewrite can change serialized tag, sort, or empty-value semantics. Compare the generated URL with the previous `serialize` output.
- Date boundaries are converted from local start/end of day to ISO timestamps. Verify that the history and recordings APIs apply the same timezone interpretation.

## Files that carry the risk

- `apps/backend/src/api/routes/telephony.controller.ts`
- `apps/frontend/src/features/call-detail/components/call-detail-dialog.tsx`
- `apps/frontend/src/features/ai-voice-agents/components/calls-table.tsx`
- `apps/frontend/src/features/history/components/call-history-detail-dialog.tsx`
- `apps/frontend/src/components/date-range-filter.tsx`
- `apps/frontend/src/features/contact/components/contact.listing.tsx`
- `packages/frontend-shared/src/lib/searchparams.ts`
- `packages/database/src/database/repositories/meeting.repository.spec.ts`

Localization files only add call-detail description strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->