### PR TITLE
feat: implement isActiveNameConflict method in CompanyRepository and update CRM company sync logic to handle name collisions

### DIFF
--- a/packages/database/src/database/repositories/company.repository.spec.ts
+++ b/packages/database/src/database/repositories/company.repository.spec.ts
@@ -2,6 +2,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { Prisma } from "@prisma/client";
 import { CompanyRepository } from "./company.repository";
 
 interface CapturedQuery {
@@ -123,5 +124,48 @@ describe("CompanyRepository normalized names", () => {
         data: { name: "  ACME   Labs ", normalizedName: "acme labs" },
       },
     ]);
+  });
+});
+
+describe("CompanyRepository.isActiveNameConflict", () => {
+  const repository = new CompanyRepository({} as never);
+
+  it("recognizes personal and organization normalized-name conflicts", () => {
+    const personalConflict = new Prisma.PrismaClientKnownRequestError(
+      "duplicate",
+      {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["userId", "normalizedName"] },
+      },
+    );
+    const organizationConflict = new Prisma.PrismaClientKnownRequestError(
+      "duplicate",
+      {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["organizationId", "normalizedName"] },
+      },
+    );
+
+    assert.equal(repository.isActiveNameConflict(personalConflict), true);
+    assert.equal(repository.isActiveNameConflict(organizationConflict), true);
+  });
+
+  it("does not hide unrelated unique violations", () => {
+    const unrelatedConflict = new Prisma.PrismaClientKnownRequestError(
+      "duplicate",
+      {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["domain"] },
+      },
+    );
+
+    assert.equal(repository.isActiveNameConflict(unrelatedConflict), false);
+    assert.equal(
+      repository.isActiveNameConflict(new Error("duplicate")),
+      false,
+    );
   });
 });

--- a/packages/database/src/database/repositories/company.repository.spec.ts
+++ b/packages/database/src/database/repositories/company.repository.spec.ts
@@ -125,6 +125,35 @@ describe("CompanyRepository normalized names", () => {
       },
     ]);
   });
+
+  it("scopes active updates to the current personal workspace", async () => {
+    const writes: unknown[] = [];
+    const prisma = {
+      company: {
+        update: async (input: unknown) => {
+          writes.push(input);
+          return { id: "company-1" };
+        },
+      },
+    };
+    const repository = new CompanyRepository(prisma as never);
+
+    await repository.updateActive({ userId: "user-1" }, "company-1", {
+      name: "  ACME   Labs ",
+    });
+
+    assert.deepEqual(writes, [
+      {
+        where: {
+          id: "company-1",
+          userId: "user-1",
+          organizationId: null,
+          deletedAt: null,
+        },
+        data: { name: "  ACME   Labs ", normalizedName: "acme labs" },
+      },
+    ]);
+  });
 });
 
 describe("CompanyRepository.isActiveNameConflict", () => {

--- a/packages/database/src/database/repositories/company.repository.ts
+++ b/packages/database/src/database/repositories/company.repository.ts
@@ -177,6 +177,27 @@ export class CompanyRepository {
     });
   }
 
+  isActiveNameConflict(error: unknown): boolean {
+    if (
+      !(error instanceof Prisma.PrismaClientKnownRequestError) ||
+      error.code !== "P2002"
+    ) {
+      return false;
+    }
+
+    const target = error.meta?.target;
+    const fields = Array.isArray(target)
+      ? target.map(String)
+      : [String(target ?? "")];
+
+    return (
+      fields.some((field) => field.includes("normalizedName")) &&
+      fields.some(
+        (field) => field.includes("userId") || field.includes("organizationId"),
+      )
+    );
+  }
+
   softDelete(id: string): Promise<Company> {
     return this.prisma.company.update({
       where: { id },

--- a/packages/database/src/database/repositories/company.repository.ts
+++ b/packages/database/src/database/repositories/company.repository.ts
@@ -177,6 +177,24 @@ export class CompanyRepository {
     });
   }
 
+  updateActive(
+    ctx: OwnershipContext,
+    id: string,
+    data: Prisma.CompanyUpdateInput,
+  ): Promise<Company> {
+    const name = typeof data.name === "string" ? data.name : undefined;
+    return this.prisma.company.update({
+      where: {
+        id,
+        ...buildOwnershipFilter(ctx),
+        deletedAt: null,
+      },
+      data: name
+        ? { ...data, normalizedName: normalizeCompanyName(name) }
+        : data,
+    });
+  }
+
   isActiveNameConflict(error: unknown): boolean {
     if (
       !(error instanceof Prisma.PrismaClientKnownRequestError) ||

--- a/packages/services/src/services/crm/crm-company-sync.service.spec.ts
+++ b/packages/services/src/services/crm/crm-company-sync.service.spec.ts
@@ -25,17 +25,58 @@ const syncResult = {
   raw: null,
 } as never;
 
-function buildService(updateError: Error, isActiveNameConflict: boolean) {
-  const updates: AnyRecord[] = [];
+function buildService(forcedUpdateError?: Error) {
   const links: AnyRecord[] = [];
+  const nameConflict = new Error("duplicate name");
+  const company = {
+    id: "company-1",
+    userId: "user-1",
+    organizationId: "org-1",
+    deletedAt: null,
+    name: "Local Acme",
+    domain: "old.example",
+    industry: "Consulting",
+    size: "1-10",
+    phone: "+18005550999",
+    website: "https://old.example",
+  };
+  const normalizedNameOwners = new Map([
+    ["local acme", company.id],
+    ["acme", "company-2"],
+  ]);
 
   const companyRepo = {
-    update: async (id: string, data: AnyRecord) => {
-      updates.push({ id, data });
-      if (updates.length === 1) throw updateError;
-      return { id, ...data };
+    updateActive: async (
+      updateCtx: typeof ctx,
+      id: string,
+      data: AnyRecord,
+    ) => {
+      if (forcedUpdateError) throw forcedUpdateError;
+
+      const isOwned = updateCtx.organizationId
+        ? company.organizationId === updateCtx.organizationId
+        : company.userId === updateCtx.userId &&
+          company.organizationId === null;
+      if (company.id !== id || company.deletedAt !== null || !isOwned) {
+        throw new Error("company not found in workspace");
+      }
+
+      if (typeof data.name === "string") {
+        const normalizedName = data.name
+          .trim()
+          .replace(/\s+/g, " ")
+          .toLowerCase();
+        const owner = normalizedNameOwners.get(normalizedName);
+        if (owner && owner !== company.id) throw nameConflict;
+        normalizedNameOwners.set(normalizedName, company.id);
+      }
+
+      for (const [field, value] of Object.entries(data)) {
+        if (value !== undefined) Object.assign(company, { [field]: value });
+      }
+      return company;
     },
-    isActiveNameConflict: () => isActiveNameConflict,
+    isActiveNameConflict: (error: unknown) => error === nameConflict,
   };
   const linkRepo = {
     findByExternalId: async () => ({ companyId: "company-1" }),
@@ -53,12 +94,12 @@ function buildService(updateError: Error, isActiveNameConflict: boolean) {
     {} as never,
   );
 
-  return { service, updates, links };
+  return { service, company, links };
 }
 
 describe("CrmCompanySyncService.upsertCompany", () => {
   it("preserves the local name and syncs other fields on a name collision", async () => {
-    const harness = buildService(new Error("duplicate name"), true);
+    const harness = buildService();
 
     const result = await harness.service.upsertCompany(
       connection,
@@ -67,28 +108,31 @@ describe("CrmCompanySyncService.upsertCompany", () => {
     );
 
     assert.deepEqual(result, { companyId: "company-1", created: false });
-    assert.equal(harness.updates.length, 2);
-    assert.equal(
-      (harness.updates[0].data as AnyRecord).name,
-      "Acme",
-      "the first update should try to apply the CRM name",
-    );
-    assert.equal("name" in (harness.updates[1].data as AnyRecord), false);
-    assert.equal((harness.updates[1].data as AnyRecord).domain, "acme.example");
+    assert.deepEqual(harness.company, {
+      id: "company-1",
+      userId: "user-1",
+      organizationId: "org-1",
+      deletedAt: null,
+      name: "Local Acme",
+      domain: "acme.example",
+      industry: "Software",
+      size: "11-50",
+      phone: "+18005550100",
+      website: "https://acme.example",
+    });
     assert.equal(harness.links.length, 1);
     assert.equal(harness.links[0].companyId, "company-1");
   });
 
   it("rethrows unique violations that are not normalized-name conflicts", async () => {
     const error = new Error("unrelated unique violation");
-    const harness = buildService(error, false);
+    const harness = buildService(error);
 
     await assert.rejects(
       harness.service.upsertCompany(connection, syncResult, ctx),
       (caught) => caught === error,
     );
 
-    assert.equal(harness.updates.length, 1);
     assert.equal(harness.links.length, 0);
   });
 });

--- a/packages/services/src/services/crm/crm-company-sync.service.spec.ts
+++ b/packages/services/src/services/crm/crm-company-sync.service.spec.ts
@@ -1,0 +1,94 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CrmCompanySyncService } from "./crm-company-sync.service";
+
+type AnyRecord = Record<string, unknown>;
+
+const connection = {
+  id: "connection-1",
+  provider: "attio",
+} as never;
+
+const ctx = { userId: "user-1", organizationId: "org-1" };
+
+const syncResult = {
+  company: { externalId: "external-company-1", externalType: "company" },
+  name: "Acme",
+  domain: "acme.example",
+  industry: "Software",
+  size: "11-50",
+  phone: "+18005550100",
+  website: "https://acme.example",
+  customFields: {},
+  raw: null,
+} as never;
+
+function buildService(updateError: Error, isActiveNameConflict: boolean) {
+  const updates: AnyRecord[] = [];
+  const links: AnyRecord[] = [];
+
+  const companyRepo = {
+    update: async (id: string, data: AnyRecord) => {
+      updates.push({ id, data });
+      if (updates.length === 1) throw updateError;
+      return { id, ...data };
+    },
+    isActiveNameConflict: () => isActiveNameConflict,
+  };
+  const linkRepo = {
+    findByExternalId: async () => ({ companyId: "company-1" }),
+    upsertLink: async (input: AnyRecord) => {
+      links.push(input);
+      return input;
+    },
+  };
+
+  const service = new CrmCompanySyncService(
+    {} as never,
+    {} as never,
+    companyRepo as never,
+    linkRepo as never,
+    {} as never,
+  );
+
+  return { service, updates, links };
+}
+
+describe("CrmCompanySyncService.upsertCompany", () => {
+  it("preserves the local name and syncs other fields on a name collision", async () => {
+    const harness = buildService(new Error("duplicate name"), true);
+
+    const result = await harness.service.upsertCompany(
+      connection,
+      syncResult,
+      ctx,
+    );
+
+    assert.deepEqual(result, { companyId: "company-1", created: false });
+    assert.equal(harness.updates.length, 2);
+    assert.equal(
+      (harness.updates[0].data as AnyRecord).name,
+      "Acme",
+      "the first update should try to apply the CRM name",
+    );
+    assert.equal("name" in (harness.updates[1].data as AnyRecord), false);
+    assert.equal((harness.updates[1].data as AnyRecord).domain, "acme.example");
+    assert.equal(harness.links.length, 1);
+    assert.equal(harness.links[0].companyId, "company-1");
+  });
+
+  it("rethrows unique violations that are not normalized-name conflicts", async () => {
+    const error = new Error("unrelated unique violation");
+    const harness = buildService(error, false);
+
+    await assert.rejects(
+      harness.service.upsertCompany(connection, syncResult, ctx),
+      (caught) => caught === error,
+    );
+
+    assert.equal(harness.updates.length, 1);
+    assert.equal(harness.links.length, 0);
+  });
+});

--- a/packages/services/src/services/crm/crm-company-sync.service.ts
+++ b/packages/services/src/services/crm/crm-company-sync.service.ts
@@ -58,7 +58,7 @@ export class CrmCompanySyncService {
     );
 
     if (existingLink?.companyId) {
-      await this.updateExisting(existingLink.companyId, result);
+      await this.updateExisting(ctx, existingLink.companyId, result);
       await this.touchLink(connection, result, existingLink.companyId);
       return { companyId: existingLink.companyId, created: false };
     }
@@ -72,7 +72,7 @@ export class CrmCompanySyncService {
     }
 
     if (existing) {
-      await this.updateExisting(existing.id, result);
+      await this.updateExisting(ctx, existing.id, result);
       await this.touchLink(connection, result, existing.id);
       return { companyId: existing.id, created: false };
     }
@@ -109,6 +109,7 @@ export class CrmCompanySyncService {
   }
 
   private async updateExisting(
+    ctx: OwnershipContext,
     companyId: string,
     result: CrmCompanySyncResult,
   ): Promise<void> {
@@ -121,7 +122,7 @@ export class CrmCompanySyncService {
     };
 
     try {
-      await this.companyRepo.update(companyId, {
+      await this.companyRepo.updateActive(ctx, companyId, {
         name: result.name,
         ...syncedFields,
       });
@@ -135,7 +136,7 @@ export class CrmCompanySyncService {
         `CRM company ${result.company.externalId} matched company ${companyId}, ` +
           `but the name "${result.name}" is already in use; preserving the local name`,
       );
-      await this.companyRepo.update(companyId, syncedFields);
+      await this.companyRepo.updateActive(ctx, companyId, syncedFields);
     }
   }
 

--- a/packages/services/src/services/crm/crm-company-sync.service.ts
+++ b/packages/services/src/services/crm/crm-company-sync.service.ts
@@ -112,14 +112,31 @@ export class CrmCompanySyncService {
     companyId: string,
     result: CrmCompanySyncResult,
   ): Promise<void> {
-    await this.companyRepo.update(companyId, {
-      name: result.name,
+    const syncedFields = {
       domain: result.domain ?? undefined,
       industry: result.industry ?? undefined,
       size: result.size ?? undefined,
       phone: result.phone ?? undefined,
       website: result.website ?? undefined,
-    });
+    };
+
+    try {
+      await this.companyRepo.update(companyId, {
+        name: result.name,
+        ...syncedFields,
+      });
+    } catch (error) {
+      if (!this.companyRepo.isActiveNameConflict(error)) throw error;
+
+      // A CRM link or exact domain match is stronger identity evidence than a
+      // name shared by another active company. Preserve that identity and the
+      // existing local name while still applying the remaining CRM fields.
+      this.logger.warn(
+        `CRM company ${result.company.externalId} matched company ${companyId}, ` +
+          `but the name "${result.name}" is already in use; preserving the local name`,
+      );
+      await this.companyRepo.update(companyId, syncedFields);
+    }
   }
 
   private async touchLink(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Behaviour changes

- CRM company sync now handles active company-name collisions.
- When the normalized CRM name conflicts with an active personal or organization company, sync preserves the existing local `name`.
- Sync still updates the remaining CRM fields and creates the external link after this fallback.
- Unrelated unique-constraint errors still fail the sync and do not create the external link.

## Architectural impact

- `CompanyRepository` now owns detection of Prisma `P2002` conflicts for `normalizedName` with `userId` or `organizationId`.
- `CompanyRepository.updateActive` now scopes updates by ownership and active status, and normalizes updated names.
- `CrmCompanySyncService` uses `updateActive` for existing-company updates.
- No public API, database schema, or exported contract changed.

## Risk areas

- The fallback performs a second update after the first update fails. Review partial-update behavior and retry safety.
- The conflict check depends on Prisma error metadata and constraint target shape. Changes to Prisma error formatting could bypass the fallback or classify an unrelated conflict incorrectly.
- The fallback preserves the local name, which can leave CRM and local company names out of sync by design.
- Ownership and active-row filters can prevent updates when the stored company no longer matches the sync context.

## Files carrying the risk

- `packages/services/src/services/crm/crm-company-sync.service.ts`
- `packages/database/src/database/repositories/company.repository.ts`
- `packages/services/src/services/crm/crm-company-sync.service.spec.ts`
- `packages/database/src/database/repositories/company.repository.spec.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->