### PR TITLE
feat: enhance webhook tool management in VoiceAgentService and add unit tests

### DIFF
--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -169,11 +169,12 @@ says it is having a technical problem and books nothing, a call with no summary
 and no outcome, and no error anywhere. Deployment configuration is responsible
 for supplying the bare origin; `apiConfiguration` uses the value unchanged.
 
-The URLs a provider **stores** — an assistant's tool webhooks, an insight
-group's callback — are written at save time and outlive the address they were
-built from. They are re-pointed before every dial (`ensureInsightGroup`,
-`ensureToolEndpoints`), which is the only thing that recovers an agent whose
-URLs predate the current address.
+The configuration a provider **stores** — an assistant's tool webhooks, an
+insight group's callback — is written at save time and outlives the code and
+address it was built from. Before every dial, `ensureToolEndpoints` restores
+missing tools and stale URLs while `ensureInsightGroup` re-points the callback.
+That is what recovers both an agent created before a new required tool existed
+and one whose URLs predate the current address.
 
 ## Contract change checklist
 

--- a/packages/services/src/services/voice-agents/voice-agent.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent.service.spec.ts
@@ -1,0 +1,103 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { apiConfiguration } from "@ringee/configuration";
+import { VoiceAgentService } from "./voice-agent.service";
+
+const CTX = { userId: "user-1", organizationId: "org-1" };
+const AGENT = {
+  id: "agent-1",
+  type: "reminders_notifications",
+  providerAssistantId: "assistant-1",
+};
+
+function supportToolUrl(): string {
+  const base = apiConfiguration.PUBLIC_BACKEND_URL!.replace(/\/+$/, "");
+  return `${base}/api/ai-voice-agents/tools/agent-1/request-human-support`;
+}
+
+function build(currentWebhookUrls: string[]) {
+  const syncs: string[] = [];
+  const service = new VoiceAgentService(
+    {} as never,
+    {
+      require: () => ({
+        buildTools: (ctx: {
+          agentId: string;
+          toolBaseUrl: string;
+          toolSecretRef: string;
+        }) => [
+          {
+            kind: "webhook",
+            name: "request_human_support",
+            description: "Notify an administrator.",
+            url: `${ctx.toolBaseUrl}/${ctx.agentId}/request-human-support`,
+            method: "POST",
+            headers: [
+              {
+                name: "X-Ringee-Tool-Secret",
+                secretRef: ctx.toolSecretRef,
+              },
+            ],
+          },
+          { kind: "hangup", description: "End the call." },
+        ],
+      }),
+    } as never,
+    {} as never,
+    {
+      getAssistant: async () => ({
+        assistantId: "assistant-1",
+        callingAppId: "calling-app-1",
+        unauthenticatedWebCallsEnabled: false,
+        toolWebhookUrls: currentWebhookUrls,
+      }),
+    } as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+
+  (
+    service as unknown as {
+      syncToProvider: (
+        ctx: typeof CTX,
+        agentId: string,
+      ) => Promise<typeof AGENT>;
+    }
+  ).syncToProvider = async (_ctx, agentId) => {
+    syncs.push(agentId);
+    return AGENT;
+  };
+
+  return { service, syncs };
+}
+
+describe("VoiceAgentService tool delivery", () => {
+  it("re-syncs an older assistant when a required webhook tool is missing", async () => {
+    const { service, syncs } = build([]);
+
+    await service.ensureToolEndpoints(CTX, AGENT as never);
+
+    assert.deepEqual(syncs, ["agent-1"]);
+  });
+
+  it("does not rewrite an assistant whose webhook set is current", async () => {
+    const { service, syncs } = build([supportToolUrl()]);
+
+    await service.ensureToolEndpoints(CTX, AGENT as never);
+
+    assert.deepEqual(syncs, []);
+  });
+
+  it("re-syncs webhook tools that still point to an old backend", async () => {
+    const { service, syncs } = build([
+      "https://old-api.example/api/ai-voice-agents/tools/agent-1/request-human-support",
+    ]);
+
+    await service.ensureToolEndpoints(CTX, AGENT as never);
+
+    assert.deepEqual(syncs, ["agent-1"]);
+  });
+});

--- a/packages/services/src/services/voice-agents/voice-agent.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent.service.ts
@@ -745,14 +745,14 @@ export class VoiceAgentService {
   }
 
   /**
-   * Makes sure the agent's tools still call this backend, before it dials.
+   * Makes sure the agent has the current set of webhook tools and that all of
+   * them still call this backend, before it dials.
    *
-   * Tool URLs are written onto the assistant when the agent is saved and never
-   * looked at again, so they outlive the address they were built from: change
-   * `PUBLIC_BACKEND_URL` and every agent in the workspace keeps pointing at the
-   * old one until somebody happens to open and re-save it. That is not a
-   * degraded agent — it is one that answers "I am having a technical problem
-   * with the calendar" and books nothing, on a call the workspace paid for.
+   * Tool definitions are written when the agent is saved and otherwise outlive
+   * the code that created them. A new required tool (such as human support) is
+   * absent from every older assistant, while a changed `PUBLIC_BACKEND_URL`
+   * leaves all existing tools pointing at the old backend. In either case the
+   * assistant has to be re-derived from its blueprint before the paid call.
    *
    * Best-effort, like `ensureCallingApp` and `ensureInsightGroup` beside it: a
    * re-sync that fails is worth a call with stale tools, never worth refusing
@@ -770,13 +770,25 @@ export class VoiceAgentService {
     if (!assistant) return;
 
     const base = this.toolBaseUrl();
-    const stale = assistant.toolWebhookUrls.filter(
-      (url) => !url.startsWith(base),
-    );
-    if (stale.length === 0) return;
+    const expected = this.blueprints
+      .require(agent.type)
+      .buildTools({
+        agentId: agent.id,
+        toolBaseUrl: base,
+        toolSecretRef: this.toolSecretIdentifier(agent.id),
+        // Retrieval stores do not affect the webhook set compared here.
+        knowledgeBucketIds: [],
+      })
+      .flatMap((tool) => (tool.kind === "webhook" ? [tool.url] : []))
+      .sort();
+    const actual = [...assistant.toolWebhookUrls].sort();
+    const matches =
+      actual.length === expected.length &&
+      actual.every((url, index) => url === expected[index]);
+    if (matches) return;
 
     this.logger.warn(
-      `Agent ${agent.id} has ${stale.length} tool(s) pointing somewhere else (${stale[0]}); re-syncing against ${base}`,
+      `Agent ${agent.id} has stale or missing webhook tools; re-syncing against its current blueprint`,
     );
     await this.syncToProvider(ctx, agent.id);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour changes

- Before each dial, webhook tools and insight callbacks are refreshed when provider-stored URLs differ from the current blueprint.
- The check now detects missing, extra, and outdated URLs.

## Architectural impact

- The responsibility remains in `@ringee/services`.
- No public entity or cross-package contract changed.

## Risk areas

- A failed re-sync can prevent webhook delivery during the call lifecycle.
- Incorrect URL-set comparison can remove valid tools or retain stale endpoints.
- The comparison must remain scoped to the active assistant and insight group.

## Files carrying the risk

- `packages/services/src/services/voice-agents/voice-agent.service.ts`
- `packages/services/src/services/voice-agents/voice-agent.service.spec.ts`
- `docs/engineering/INTEGRATIONS.md` — documents the endpoint refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->