### PR TITLE
feat: implement public API for AI Voice Agents with custom integration key guard

### DIFF
--- a/apps/backend/src/api/guards/custom-integration-api-key.guard.ts
+++ b/apps/backend/src/api/guards/custom-integration-api-key.guard.ts
@@ -1,0 +1,64 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
+import {
+  CustomIntegrationAuthService,
+  type ResolvedApiKey,
+} from "@ringee/services";
+import type { Request } from "express";
+
+const API_KEY_HEADER = "x-ringee-api-key";
+
+export interface CustomIntegrationApiRequest extends Request {
+  customIntegrationAuth: ResolvedApiKey;
+}
+
+/**
+ * Authenticates the server-to-server public API with the secret issued for a
+ * Custom Integration. The resolved ownership context comes only from the
+ * stored integration; no workspace identity supplied by the client is used.
+ */
+@Injectable()
+export class CustomIntegrationApiKeyGuard implements CanActivate {
+  constructor(private readonly auth: CustomIntegrationAuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context
+      .switchToHttp()
+      .getRequest<CustomIntegrationApiRequest>();
+    const apiKey = this.readApiKey(request);
+
+    request.customIntegrationAuth = await this.auth.resolveApiKey(apiKey);
+    return true;
+  }
+
+  private readApiKey(request: Request): string | undefined {
+    const customHeader = this.singleHeader(request.headers[API_KEY_HEADER]);
+    const authorization = this.singleHeader(request.headers.authorization);
+
+    if (customHeader && authorization) {
+      throw new UnauthorizedException(
+        "Send the API key in either X-Ringee-Api-Key or Authorization, not both",
+      );
+    }
+    if (customHeader) return customHeader;
+    if (!authorization) return undefined;
+
+    const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+    return match?.[1]?.trim();
+  }
+
+  private singleHeader(
+    value: string | string[] | undefined,
+  ): string | undefined {
+    if (Array.isArray(value)) {
+      throw new UnauthorizedException(
+        "Multiple API key headers are not allowed",
+      );
+    }
+    return value?.trim() || undefined;
+  }
+}

--- a/apps/backend/src/api/guards/custom-integration-api-key.guard.ts
+++ b/apps/backend/src/api/guards/custom-integration-api-key.guard.ts
@@ -11,6 +11,7 @@ import {
 import type { Request } from "express";
 
 const API_KEY_HEADER = "x-ringee-api-key";
+const BEARER_PREFIX = "bearer ";
 
 export interface CustomIntegrationApiRequest extends Request {
   customIntegrationAuth: ResolvedApiKey;
@@ -47,8 +48,15 @@ export class CustomIntegrationApiKeyGuard implements CanActivate {
     if (customHeader) return customHeader;
     if (!authorization) return undefined;
 
-    const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
-    return match?.[1]?.trim();
+    const value = authorization.trim();
+    if (
+      value.length <= BEARER_PREFIX.length ||
+      value.slice(0, BEARER_PREFIX.length).toLowerCase() !== BEARER_PREFIX
+    ) {
+      return undefined;
+    }
+
+    return value.slice(BEARER_PREFIX.length).trim() || undefined;
   }
 
   private singleHeader(

--- a/apps/backend/src/api/routes/public-api.controller.ts
+++ b/apps/backend/src/api/routes/public-api.controller.ts
@@ -1,0 +1,168 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { AiVoiceAgentType } from "@ringee/database";
+import { Public, StartVoiceAgentCallDto } from "@ringee/platform";
+import {
+  VoiceAgentCallService,
+  VoiceAgentResultService,
+  VoiceAgentService,
+} from "@ringee/services";
+import {
+  CustomIntegrationApiKeyGuard,
+  type CustomIntegrationApiRequest,
+} from "../guards/custom-integration-api-key.guard";
+
+/**
+ * Resource-oriented public API for the execution side of AI Voice Agents.
+ * Creation and configuration remain dashboard-only.
+ */
+@Public()
+@UseGuards(CustomIntegrationApiKeyGuard)
+@Controller("v1/ai-voice-agents")
+export class PublicAiVoiceAgentController {
+  constructor(
+    private readonly agents: VoiceAgentService,
+    private readonly calls: VoiceAgentCallService,
+    private readonly results: VoiceAgentResultService,
+  ) {}
+
+  @Get()
+  async list(
+    @Req() request: CustomIntegrationApiRequest,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+    @Query("type") type?: string,
+  ) {
+    const ctx = request.customIntegrationAuth.ctx;
+    const [result, callerNumbers] = await Promise.all([
+      this.agents.list(ctx, {
+        page: parsePositiveInteger(page, "page"),
+        limit: parsePositiveInteger(limit, "limit", 100),
+        type: parseAgentType(type),
+      }),
+      this.agents.listCallerNumbers(ctx),
+    ]);
+    const callerNumbersById = new Map(
+      callerNumbers.map((number) => [number.id, number]),
+    );
+
+    return {
+      ...result,
+      // Public responses deliberately omit provider ids, credential references
+      // and callback hashes from the underlying database row.
+      data: result.data.map((agent) => ({
+        id: agent.id,
+        name: agent.name,
+        type: agent.type,
+        status: agent.status,
+        voice: agent.voiceLabel,
+        callCount: agent.callCount,
+        callerNumberId: agent.callerNumberId,
+        callsFrom: agent.callerNumberId
+          ? (callerNumbersById.get(agent.callerNumberId)?.phoneNumber ?? null)
+          : null,
+        createdAt: agent.createdAt,
+        updatedAt: agent.updatedAt,
+      })),
+      callerNumbers,
+      variablesByType: Object.fromEntries(
+        this.agents
+          .listTypes()
+          .map((agentType) => [agentType.type, agentType.variables]),
+      ),
+    };
+  }
+
+  @Get("phone-numbers")
+  listCallerNumbers(@Req() request: CustomIntegrationApiRequest) {
+    return this.agents.listCallerNumbers(request.customIntegrationAuth.ctx);
+  }
+
+  @Get("calls/:callId")
+  async getCall(
+    @Req() request: CustomIntegrationApiRequest,
+    @Param("callId", ParseUUIDPipe) callId: string,
+  ) {
+    const call = await this.calls.requireCall(
+      request.customIntegrationAuth.ctx,
+      callId,
+    );
+    return this.results.toResult(call);
+  }
+
+  @Post(":agentId/calls")
+  startCall(
+    @Req() request: CustomIntegrationApiRequest,
+    @Param("agentId", ParseUUIDPipe) agentId: string,
+    @Body() dto: StartVoiceAgentCallDto,
+  ) {
+    return this.calls.startCall(request.customIntegrationAuth.ctx, agentId, {
+      to: dto.to,
+      fromNumberId: dto.from_number_id,
+      variables: dto.variables,
+      metadata: dto.metadata,
+    });
+  }
+
+  @Get(":agentId/calls")
+  async listCalls(
+    @Req() request: CustomIntegrationApiRequest,
+    @Param("agentId", ParseUUIDPipe) agentId: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const result = await this.calls.listCalls(
+      request.customIntegrationAuth.ctx,
+      agentId,
+      {
+        page: parsePositiveInteger(page, "page"),
+        limit: parsePositiveInteger(limit, "limit", 100),
+      },
+    );
+    return {
+      ...result,
+      data: result.data.map((call) => this.results.toResult(call)),
+    };
+  }
+}
+
+function parsePositiveInteger(
+  raw: string | undefined,
+  field: string,
+  max?: number,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  if (
+    !Number.isInteger(value) ||
+    value < 1 ||
+    (max !== undefined && value > max)
+  ) {
+    throw new BadRequestException(
+      max
+        ? `${field} must be a whole number between 1 and ${max}`
+        : `${field} must be a positive whole number`,
+    );
+  }
+  return value;
+}
+
+function parseAgentType(raw: string | undefined): AiVoiceAgentType | undefined {
+  if (raw === undefined) return undefined;
+  if (!Object.values(AiVoiceAgentType).includes(raw as AiVoiceAgentType)) {
+    throw new BadRequestException(
+      "type is not a supported AI voice agent type",
+    );
+  }
+  return raw as AiVoiceAgentType;
+}

--- a/apps/backend/src/api/routes/routes.module.ts
+++ b/apps/backend/src/api/routes/routes.module.ts
@@ -77,6 +77,8 @@ import { DemoRequestController } from "./demo-request.controller";
 import { InfrastructureController } from "./infrastructure.controller";
 import { StripeAbuseProtectionService } from "./stripe-abuse-protection.service";
 import { UserAccessEnforcementService } from "./user-access-enforcement.service";
+import { PublicAiVoiceAgentController } from "./public-api.controller";
+import { CustomIntegrationApiKeyGuard } from "../guards/custom-integration-api-key.guard";
 
 @Module({
   controllers: [
@@ -145,6 +147,7 @@ import { UserAccessEnforcementService } from "./user-access-enforcement.service"
     InfrastructureController,
     FreeTrialController,
     DemoRequestController,
+    PublicAiVoiceAgentController,
   ],
   // TranscriptionMediaGateway lives here (not in the shared ServicesModule) so
   // the Telnyx media-stream WS server binds its port only in the API process.
@@ -153,6 +156,7 @@ import { UserAccessEnforcementService } from "./user-access-enforcement.service"
     TranscriptionMediaGateway,
     StripeAbuseProtectionService,
     UserAccessEnforcementService,
+    CustomIntegrationApiKeyGuard,
   ],
   imports: [
     McpModule,

--- a/docs/engineering/CANONICAL_IMPLEMENTATIONS.md
+++ b/docs/engineering/CANONICAL_IMPLEMENTATIONS.md
@@ -137,15 +137,16 @@ pick the one matching your runtime.
 
 ## Security primitives
 
-| Responsibility             | Owner                                                        |
-| -------------------------- | ------------------------------------------------------------ |
-| Integration API keys       | `platform/src/custom-integrations/api-key.util.ts`           |
-| Outbound webhook signing   | `platform/src/custom-integrations/webhook-signing.util.ts`   |
-| Event catalogue (in & out) | `platform/src/custom-integrations/event-spec.ts`             |
-| Publishable keys           | `platform/src/sdk/publishable-key.ts`                        |
-| SDK session / OTP / origin | `platform/src/sdk/*`, `services/sdk/*`                       |
-| Magic-link tokens          | `services/call-session/call-session-access-token.service.ts` |
-| Encryption at rest         | `CryptoService` — `platform/src/crypto/`                     |
+| Responsibility             | Owner                                                             |
+| -------------------------- | ----------------------------------------------------------------- |
+| Integration API keys       | `platform/src/custom-integrations/api-key.util.ts`                |
+| Public API key guard       | `apps/backend/src/api/guards/custom-integration-api-key.guard.ts` |
+| Outbound webhook signing   | `platform/src/custom-integrations/webhook-signing.util.ts`        |
+| Event catalogue (in & out) | `platform/src/custom-integrations/event-spec.ts`                  |
+| Publishable keys           | `platform/src/sdk/publishable-key.ts`                             |
+| SDK session / OTP / origin | `platform/src/sdk/*`, `services/sdk/*`                            |
+| Magic-link tokens          | `services/call-session/call-session-access-token.service.ts`      |
+| Encryption at rest         | `CryptoService` — `platform/src/crypto/`                          |
 
 ## Provider registries
 

--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -58,12 +58,25 @@ agent-client method or CLI command creates, updates or deletes a voice agent.
 Every surface requires an active organization workspace (AGENT-011); personal
 workspace requests are rejected before any provider command or billed call.
 
-| Surface            | List                                       | Trigger                                                                                     |
-| ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| REST API           | `GET /api/ai-voice-agents?page=1&limit=20` | `POST /api/ai-voice-agents/:agentId/calls`                                                  |
-| MCP                | `list_ai_voice_agents`                     | `start_ai_voice_agent_call`                                                                 |
-| `@ringee-io/agent` | `listAiVoiceAgents({ limit })`             | `startAiVoiceAgentCall({ agentId, to, fromNumberId, variables, metadata })`                 |
-| CLI                | `ringee voice-agents list`                 | `ringee voice-agents call <agentId> --to +E164 [--from <numberId>] [--var key=value] --yes` |
+| Surface            | List                                          | Trigger                                                                                     |
+| ------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Dashboard REST     | `GET /api/ai-voice-agents?page=1&limit=20`    | `POST /api/ai-voice-agents/:agentId/calls`                                                  |
+| Public REST        | `GET /api/v1/ai-voice-agents?page=1&limit=20` | `POST /api/v1/ai-voice-agents/:agentId/calls`                                               |
+| MCP                | `list_ai_voice_agents`                        | `start_ai_voice_agent_call`                                                                 |
+| `@ringee-io/agent` | `listAiVoiceAgents({ limit })`                | `startAiVoiceAgentCall({ agentId, to, fromNumberId, variables, metadata })`                 |
+| CLI                | `ringee voice-agents list`                    | `ringee voice-agents call <agentId> --to +E164 [--from <numberId>] [--var key=value] --yes` |
+
+The public REST routes use the API key issued for a Custom Integration. Send it
+as either `X-Ringee-Api-Key: cik_live_…` or
+`Authorization: Bearer cik_live_…`; never both. The key resolves the user and
+organization from the stored integration, so the request accepts no workspace
+identity from the client. Disabled integrations fail with `401`.
+
+Execution-only companion routes are:
+
+- `GET /api/v1/ai-voice-agents/phone-numbers`
+- `GET /api/v1/ai-voice-agents/:agentId/calls`
+- `GET /api/v1/ai-voice-agents/calls/:callId`
 
 The REST trigger body uses the API's existing snake-case field for caller ID:
 
@@ -76,7 +89,7 @@ The REST trigger body uses the API's existing snake-case field for caller ID:
 }
 ```
 
-All four trigger paths converge on `VoiceAgentCallService.startCall`; none may
+All trigger paths converge on `VoiceAgentCallService.startCall`; none may
 reimplement DNC, balance, caller-ID or variable validation. The MCP catalog marks
 the trigger as credit-consuming and confirmation-required, and the CLI enforces
 that contract with `--yes`. Results are read with

--- a/docs/engineering/SECURITY.md
+++ b/docs/engineering/SECURITY.md
@@ -17,20 +17,23 @@ Rules: `AUTH-*`, `HOOK-*`, `WRK-*`, `SESS-*` in
 | Embedded SDK       | publishable key + `Origin` + OTP + live membership re-check |
 | Magic link         | hashed opaque token, uniform failures                       |
 | Custom Integration | hashed API key, constant-time compare                       |
+| Public API         | Custom Integration API key → stored ownership context       |
 | MCP connector      | the workspace UUID in the URL — a capability URL            |
 
 ## `@Public()` is the highest-risk decorator in the codebase
 
 It removes the only authentication on a route. Roughly 50 handlers use it, each
-legitimately, in five groups:
+legitimately, in six groups:
 
 1. **Provider webhooks** — Telnyx call/messaging/desk-phone, Stripe, Clerk,
    Custom Integration inbound. Authorization = signature.
 2. **SDK endpoints** (`/api/v1/sdk/*`) — authorization = `SdkSessionGuard` +
    origin, applied on top of `@Public()`.
-3. **Magic-link session endpoints** — authorization = hashed token.
-4. **MCP / ChatGPT app transports** — authorization = the URL itself.
-5. **Genuinely public reads** — rates, available numbers, country requirements,
+3. **Public API endpoints** (`/api/v1/ai-voice-agents/*`) — authorization =
+   `CustomIntegrationApiKeyGuard` over a hashed, active integration key.
+4. **Magic-link session endpoints** — authorization = hashed token.
+5. **MCP / ChatGPT app transports** — authorization = the URL itself.
+6. **Genuinely public reads** — rates, available numbers, country requirements,
    `.well-known` challenges, the demo-request form.
 
 Before adding `@Public()`, answer in one sentence what proves the caller is

--- a/packages/platform/src/crm/phone.test.ts
+++ b/packages/platform/src/crm/phone.test.ts
@@ -34,8 +34,16 @@ describe("normalizePhoneE164", () => {
     // The lenient fallback used to fold the extension into the digits and
     // return "+555267122" — a number that is then dialled and stored.
     expect(normalizePhoneE164("555-2671 ext 22")).toBe("+5552671");
+    expect(normalizePhoneE164("555-2671 ext.22")).toBe("+5552671");
+    expect(normalizePhoneE164("555-2671 extension 22")).toBe("+5552671");
     expect(normalizePhoneE164("555-2671x22")).toBe("+5552671");
+    expect(normalizePhoneE164("555-2671#22")).toBe("+5552671");
     expect(normalizePhoneE164("555-2671;ext=22")).toBe("+5552671");
+  });
+
+  it("handles long untrusted input in linear time", () => {
+    const padding = " ".repeat(100_000);
+    expect(normalizePhoneE164(`555-2671${padding}ext 22`)).toBe("+5552671");
   });
 
   it("rejects empty and out-of-range input", () => {

--- a/packages/platform/src/crm/phone.ts
+++ b/packages/platform/src/crm/phone.ts
@@ -25,7 +25,50 @@ const MIN_DIGITS = 6;
 const MAX_DIGITS = 15;
 
 /** `x22`, `ext 22`, `ext. 22`, `#22`, and the RFC 3966 `;ext=22`. */
-const EXTENSION_SUFFIX = /(?:\s*(?:ext\.?|extension|x|#)\s*|;ext=)\d+\s*$/i;
+const EXTENSION_MARKERS = [";ext=", "extension", "ext.", "ext", "x", "#"];
+
+function isAsciiDigit(charCode: number): boolean {
+  return charCode >= 48 && charCode <= 57;
+}
+
+function isWhitespace(character: string): boolean {
+  return character.trim() === "";
+}
+
+/**
+ * Strip a trailing extension in one pass. This intentionally avoids a regular
+ * expression: CRM phone values are untrusted and can be arbitrarily long.
+ */
+function stripExtensionSuffix(value: string): string {
+  let cursor = value.length;
+
+  while (cursor > 0 && isWhitespace(value[cursor - 1])) cursor -= 1;
+
+  const digitsEnd = cursor;
+  while (cursor > 0 && isAsciiDigit(value.charCodeAt(cursor - 1))) cursor -= 1;
+  if (cursor === digitsEnd) return value;
+
+  const digitsStart = cursor;
+  while (cursor > 0 && isWhitespace(value[cursor - 1])) cursor -= 1;
+
+  const markerEnd = cursor;
+  for (const marker of EXTENSION_MARKERS) {
+    // RFC 3966 does not allow whitespace between `;ext=` and its digits.
+    if (marker === ";ext=" && markerEnd !== digitsStart) continue;
+
+    const markerStart = markerEnd - marker.length;
+    if (markerStart < 0) continue;
+    if (value.slice(markerStart, markerEnd).toLowerCase() !== marker) continue;
+
+    let suffixStart = markerStart;
+    while (suffixStart > 0 && isWhitespace(value[suffixStart - 1])) {
+      suffixStart -= 1;
+    }
+    return value.slice(0, suffixStart);
+  }
+
+  return value;
+}
 
 function lenientE164(cleaned: string): string | null {
   if (cleaned.startsWith("+")) {
@@ -54,7 +97,7 @@ export function normalizePhoneE164(
   // itself when the number is valid, but the lenient fallback only strips
   // punctuation — so "555-2671 ext 22" used to come back as "+555267122", a
   // number that is then dialled and persisted as if it were real.
-  const phonePart = trimmed.replace(EXTENSION_SUFFIX, "");
+  const phonePart = stripExtensionSuffix(trimmed);
 
   const parsed = parsePhoneNumberFromString(
     phonePart,

--- a/packages/platform/src/custom-integrations/api-key.util.ts
+++ b/packages/platform/src/custom-integrations/api-key.util.ts
@@ -24,6 +24,10 @@ export function generateCustomIntegrationApiKey(): GeneratedApiKey {
 }
 
 export function hashApiKey(plaintext: string): string {
+  // These values are generated opaque credentials with at least 192 bits of
+  // entropy, not user-chosen passwords. A deterministic digest is required for
+  // indexed lookup and preserves compatibility with already-issued keys.
+  // codeql[js/insufficient-password-hash]
   return createHash("sha256").update(plaintext).digest("hex");
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Behaviour

- Adds public REST operations for AI Voice Agents: list agents and caller numbers, read calls, start calls, and list agent calls.
- Authenticates requests with one Custom Integration API key from `X-Ringee-Api-Key` or `Authorization: Bearer`.
- Rejects conflicting or duplicate API-key headers.
- Uses the resolved integration context for workspace scope.
- Improves phone normalization for extension formats, RFC 3966 input, and very large padded values.

## Architectural impact

- Adds `PublicAiVoiceAgentController` under `/api/v1/ai-voice-agents/*`.
- Assigns public API-key enforcement to `CustomIntegrationApiKeyGuard`.
- Routes public call creation through the shared `VoiceAgentCallService.startCall` lifecycle.
- Registers the controller and guard in `routes.module.ts`.
- Changes `@ringee/platform` phone normalization behavior without changing database contracts.
- No `@ringee/services` or database contract changes are shown.

## Risk areas

- Workspace isolation depends on `ResolvedApiKey.ctx` for every operation.
- Public call creation enters the existing dial, debit, retry, and webhook lifecycle.
- REST response shapes and `StartVoiceAgentCallDto` mapping are public contracts.
- Pagination and `AiVoiceAgentType` validation must match existing API behavior.
- UUID validation applies to route parameters.
- Phone normalization changes can affect dialing, caller matching, and downstream CRM behavior.

## Files carrying the risk

- `apps/backend/src/api/guards/custom-integration-api-key.guard.ts`
- `apps/backend/src/api/routes/public-api.controller.ts`
- `apps/backend/src/api/routes/routes.module.ts`
- `packages/platform/src/crm/phone.ts`
- `packages/platform/src/crm/phone.test.ts`

Documentation updates cover the canonical security owner, integration matrix, and public endpoint authorization guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->