### PR TITLE
feat: enhance voice settings and transcription configuration for Telnyx voice agents

### DIFF
--- a/docs/engineering/TELEPHONY.md
+++ b/docs/engineering/TELEPHONY.md
@@ -273,6 +273,45 @@ Consequences worth keeping:
   they cannot ride `/api/call/webhook`, whose normalizer drops any event with no
   `call_control_id`.
 
+### Voice delivery and turn-taking
+
+`telnyx.voice-agent.mapper.ts` owns these provider settings for both assistant
+creation and updates. Ultra voices (`Telnyx.Ultra.*`) enable `expressive_mode`;
+other tiers and an unset voice keep their existing behavior. Telnyx documents
+Ultra's expressive delivery in its [voice assistant guide](https://developers.telnyx.com/docs/inference/ai-assistants/no-code-voice-assistant).
+
+Flux receives an explicit starting profile: `eager_eot_threshold: 0.3`,
+`eot_threshold: 0.7`, `eot_timeout_ms: 3000`. Eager processing prepares a reply
+before the final turn decision and can increase inference usage. The timeout
+limits silence when turn confidence is insufficient; it is not a mandatory
+three-second response delay. Language selection is preserved, and the Nova-3
+fallback receives none of Flux's turn-taking parameters.
+
+The [current transcription guide](https://developers.telnyx.com/docs/inference/ai-assistants/transcription-settings)
+lists Portal defaults of `0.4 / 0.8 / 5000`; Ringee's more responsive profile is
+a tuning choice, not a claim about provider defaults. That guide describes
+`smart_format` and `numerals` for non-Flux Deepgram models, while an older
+`/transcription-settings/index` page groups them with all Deepgram models.
+Ringee omits those formatting flags on Flux pending verified adapter support.
+According to the [interruption guide](https://developers.telnyx.com/docs/inference/ai-assistants/interruption-settings),
+interruptions are enabled by default and Flux owns turn detection; do not apply
+Nova-style speaking-plan thresholds to tune Flux.
+
+Deploying the mapper does not update stored provider assistants. Existing agents
+receive the profile on save or through `VoiceAgentService.resync`; starting a
+browser test alone only changes test access and variables. Reverting code also
+requires a resync: explicitly restore the prior `voice_settings` and
+`transcription.settings` values, since omitting an optional field on a provider
+update is not proof that it was reset.
+
+Before expanding a rollout, compare the same voice, model, prompt and test script
+on browser and telephone calls. Measure end-of-speech to first audible response
+(median and p95), unwanted cutoffs, interruption recovery, booking accuracy and
+inference cost per completed call. Include Spanish accents, pauses while
+dictating a new email or number, mid-sentence corrections, background noise and
+tool delays. Mapper tests verify the API contract; they do not establish voice
+quality or account-level support for eager processing.
+
 ## Recordings and transcription
 
 A finished recording is downloaded, stored as a public mp3 **and** an encrypted

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.test.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.test.ts
@@ -48,6 +48,37 @@ describe("toAssistantPayload", () => {
     expect(payload.llm_api_key_ref).toBe("agent-7-key");
   });
 
+  it("enables expressive delivery for an Ultra voice", () => {
+    const payload = toAssistantPayload(
+      config({ voiceId: "Telnyx.Ultra.Clara" }),
+      { unauthenticatedWebCalls: false },
+    );
+    expect(payload.voice_settings).toEqual({
+      voice: "Telnyx.Ultra.Clara",
+      expressive_mode: true,
+    });
+  });
+
+  it.each(["Telnyx.NaturalHD.astra", "Azure.en-US-JennyNeural"])(
+    "preserves %s without sending Ultra-specific settings",
+    (voiceId) => {
+      const payload = toAssistantPayload(config({ voiceId }), {
+        unauthenticatedWebCalls: false,
+      });
+      expect(payload.voice_settings).toEqual({ voice: voiceId });
+    },
+  );
+
+  it.each([undefined, null, ""])(
+    "leaves the provider voice default intact for %s",
+    (voiceId) => {
+      const payload = toAssistantPayload(config({ voiceId }), {
+        unauthenticatedWebCalls: false,
+      });
+      expect(payload).not.toHaveProperty("voice_settings");
+    },
+  );
+
   it("passes a tool secret by reference so it is never sent in plaintext", () => {
     const payload = toAssistantPayload(
       config({
@@ -105,15 +136,23 @@ describe("toAssistantPayload", () => {
     ]);
   });
 
-  it("transcribes in the language the agent speaks, not the provider default", () => {
-    const payload = toAssistantPayload(config({ language: "es" }), {
-      unauthenticatedWebCalls: false,
-    });
-    expect(payload.transcription).toEqual({
-      model: "deepgram/flux",
-      language: "es",
-    });
-  });
+  it.each(["en", "es", "pt", "fr", "de", "it", "hi", "ru", "ja", "nl"])(
+    "tunes Flux turn-taking while transcribing the agent's language: %s",
+    (language) => {
+      const payload = toAssistantPayload(config({ language }), {
+        unauthenticatedWebCalls: false,
+      });
+      expect(payload.transcription).toEqual({
+        model: "deepgram/flux",
+        language,
+        settings: {
+          eager_eot_threshold: 0.3,
+          eot_threshold: 0.7,
+          eot_timeout_ms: 3000,
+        },
+      });
+    },
+  );
 
   it("reads a locale as its base language", () => {
     const payload = toAssistantPayload(config({ language: "pt-BR" }), {
@@ -129,6 +168,11 @@ describe("toAssistantPayload", () => {
     expect(payload.transcription).toEqual({
       model: "deepgram/flux",
       language: "multi",
+      settings: {
+        eager_eot_threshold: 0.3,
+        eot_threshold: 0.7,
+        eot_timeout_ms: 3000,
+      },
     });
   });
 

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.ts
@@ -49,8 +49,16 @@ export interface TelnyxAssistantPayload {
   enabled_features: string[];
   tools: Record<string, unknown>[];
   dynamic_variables?: Record<string, string>;
-  voice_settings?: { voice: string };
-  transcription?: { model: string; language: string };
+  voice_settings?: { voice: string; expressive_mode?: boolean };
+  transcription?: {
+    model: string;
+    language: string;
+    settings?: {
+      eager_eot_threshold: number;
+      eot_threshold: number;
+      eot_timeout_ms: number;
+    };
+  };
   insight_settings?: { insight_group_id: string };
   post_conversation_settings?: { enabled: boolean };
   telephony_settings: {
@@ -96,10 +104,9 @@ const TRANSCRIBED_LANGUAGES = new Set([
  * languages. A known language outside that set uses Telnyx's recommended
  * multilingual model instead of pretending Flux can transcribe it.
  */
-function toTranscription(language: string | undefined): {
-  model: string;
-  language: string;
-} {
+function toTranscription(
+  language: string | undefined,
+): NonNullable<TelnyxAssistantPayload["transcription"]> {
   const base = (language ?? "").split("-")[0]!.toLowerCase();
   if (base && !TRANSCRIBED_LANGUAGES.has(base)) {
     return { model: BROAD_LANGUAGE_TRANSCRIPTION_MODEL, language: base };
@@ -107,6 +114,16 @@ function toTranscription(language: string | undefined): {
   return {
     model: TRANSCRIPTION_MODEL,
     language: base || "multi",
+    // Flux can prepare a reply early without taking the caller's turn. Eager
+    // processing trades more speculative LLM work for lower perceived latency.
+    // The timeout caps uncertain silence; it is not a delay on every response.
+    // These turn-taking fields must not reach the Nova fallback above.
+    // https://developers.telnyx.com/docs/inference/ai-assistants/transcription-settings
+    settings: {
+      eager_eot_threshold: 0.3,
+      eot_threshold: 0.7,
+      eot_timeout_ms: 3000,
+    },
   };
 }
 
@@ -181,7 +198,18 @@ export function toAssistantPayload(
     ...(config.dynamicVariables
       ? { dynamic_variables: config.dynamicVariables }
       : {}),
-    ...(config.voiceId ? { voice_settings: { voice: config.voiceId } } : {}),
+    ...(config.voiceId
+      ? {
+          voice_settings: {
+            voice: config.voiceId,
+            // The curated catalogue uses Ultra. Keep older or other voice
+            // tiers valid without assuming they support expressive mode.
+            ...(config.voiceId.startsWith("Telnyx.Ultra.")
+              ? { expressive_mode: true }
+              : {}),
+          },
+        }
+      : {}),
     transcription: toTranscription(config.language),
     ...(config.insightGroupId
       ? { insight_settings: { insight_group_id: config.insightGroupId } }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour
- Ultra voices can use expressive mode.
- Flux transcription receives turn-taking thresholds and timeout settings.
- Unsupported languages continue to use Nova without Flux-only settings.
- Existing assistants need save or resync before changes apply.

## Architectural impact
- The Telnyx mapper owns provider-specific voice and transcription settings.
- `TelnyxAssistantPayload` now exposes optional expressive voice settings and transcription settings.

## Risk areas
- Incorrect thresholds can increase latency or cause premature turn detection.
- Unsupported-language routing can change transcription behaviour.
- The expanded payload contract must remain compatible with existing assistants.

## Files to review
- `packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.ts`
- `packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.test.ts`
- `docs/engineering/TELEPHONY.md`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->