### PR TITLE
Fix/update custom integrations from ai cals

### DIFF
--- a/apps/orchestrator/src/temporal/activities.ts
+++ b/apps/orchestrator/src/temporal/activities.ts
@@ -26,7 +26,7 @@ import type {
 
 const CRM_DRAIN_BATCH_SIZE = 25;
 const ENRICHMENT_DRAIN_BATCH_SIZE = 25;
-const CUSTOM_INTEGRATIONS_DRAIN_BATCH_SIZE = 25;
+const CUSTOM_INTEGRATIONS_DRAIN_BATCH_SIZE = 100;
 
 /**
  * Builds the Temporal activities object, closing over services resolved from

--- a/apps/orchestrator/src/temporal/schedules.ts
+++ b/apps/orchestrator/src/temporal/schedules.ts
@@ -21,13 +21,12 @@ interface ScheduleDef {
 }
 
 /**
- * Replaces the old worker's setInterval pollers. Cadence notes: the three
- * outbox drains ran every 5s as setIntervals; as Schedules they run every 60s
- * to keep workflow-history volume (and therefore Temporal/Postgres CPU on a
- * self-hosted cluster) low. They drain 25 items per tick, so worst-case added
- * latency is ~60s — acceptable for outbox-style background pushes. The
- * minute-granular schedulers (retry/callback/reminder) likewise run every 60s.
- * Tightening any of these back down directly raises self-hosted billing.
+ * Replaces the old worker's setInterval pollers. Cadence notes: CRM and
+ * enrichment drains run every 60s to keep workflow-history volume (and
+ * therefore Temporal/Postgres CPU on a self-hosted cluster) low. Custom
+ * Integrations is latency-sensitive and runs every 5s; its larger batches
+ * absorb bursts while the SKIP overlap policy prevents concurrent drains.
+ * Tightening a schedule directly raises self-hosted billing.
  */
 const SCHEDULES: ScheduleDef[] = [
   {
@@ -81,7 +80,7 @@ const SCHEDULES: ScheduleDef[] = [
   {
     id: "ringee.custom-integrations-drain",
     workflow: WORKFLOW_NAMES.customIntegrationsDrain,
-    every: "60s",
+    every: "5s",
     catchupWindow: "2m",
   },
   {

--- a/apps/orchestrator/src/temporal/workflows.ts
+++ b/apps/orchestrator/src/temporal/workflows.ts
@@ -38,8 +38,8 @@ const transcriptionJobs = proxyActivities<Activities>({
  * replaces the old in-flight guards).
  *
  * The timeout must cover the drains' real worst case: outbox drains deliver
- * HTTP webhooks/API calls with a 15s per-request timeout over batches of 25,
- * so a batch full of dead endpoints can legitimately take several minutes.
+ * HTTP webhooks/API calls with a 15s per-request timeout over batches of up to
+ * 100, so a batch full of dead endpoints can legitimately take several minutes.
  */
 const periodicJobs = proxyActivities<Activities>({
   startToCloseTimeout: "8 minutes",

--- a/docs/engineering/BUSINESS_RULES.md
+++ b/docs/engineering/BUSINESS_RULES.md
@@ -614,7 +614,7 @@ Re-serializing the parsed body changes the bytes and breaks verification.
 ### HOOK-003 — Outbound events are signed and delivered through an outbox
 
 `Ringee-Signature: t=<unixSec>,v1=<hex>` over `<timestamp>.<body>`, drained by a
-Temporal schedule in batches of 25. Every event shares the envelope
+Temporal schedule every 5s in batches of 100. Every event shares the envelope
 `{ event, eventId, occurredAt, data }`, plus `workspaceId` and `integrationId`
 outbound.
 

--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -148,8 +148,8 @@ The generic, customer-facing integration surface.
 
 - **Inbound**: `contact.upserted`, `company.upserted`, `contact.deleted`,
   `company.deleted` — HMAC-verified, validated against the event spec.
-- **Outbound**: signed, queued and drained in batches of 25 with a 15s per-request
-  timeout, with a delivery log and a failure notifier.
+- **Outbound**: signed, queued and drained every 5s in batches of 100 with a 15s
+  per-request timeout, with a delivery log and a failure notifier.
 - **Single source of truth for both**:
   `packages/platform/src/custom-integrations/event-spec.ts`. It drives inbound
   validation, outbound payload shape **and** the customer-facing documentation

--- a/packages/database/src/database/repositories/call.repository.spec.ts
+++ b/packages/database/src/database/repositories/call.repository.spec.ts
@@ -1,0 +1,80 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CallStatus } from "@prisma/client";
+import { CallRepository } from "./call.repository";
+
+function build(initialStatus: CallStatus) {
+  const updates: Array<{
+    where: Record<string, unknown>;
+    data: Record<string, unknown>;
+  }> = [];
+  const call = {
+    id: "call-1",
+    callControlId: "cc-1",
+    status: initialStatus,
+    direction: "outbound",
+    startedAt: new Date("2026-09-07T13:58:00.000Z"),
+    createdAt: new Date("2026-09-07T13:58:00.000Z"),
+    answeredAt: null,
+    outcome: null,
+  };
+  const repository = new CallRepository({
+    call: {
+      findUnique: async () => call,
+      update: async (input: {
+        where: Record<string, unknown>;
+        data: Record<string, unknown>;
+      }) => {
+        updates.push(input);
+        return { ...call, ...input.data };
+      },
+    },
+  } as never);
+
+  return { repository, updates };
+}
+
+describe("CallRepository.completeCall terminal status", () => {
+  it("persists an explicit provider failure", async () => {
+    const { repository, updates } = build(CallStatus.ringing);
+
+    const result = await repository.completeCall(
+      "cc-1",
+      null,
+      "2026-09-07T14:00:00.000Z",
+      "normal_temporary_failure",
+      CallStatus.failed,
+    );
+
+    assert.equal(updates[0]!.data.status, CallStatus.failed);
+    assert.equal(result!.status, CallStatus.failed);
+  });
+
+  it("keeps successful terminal behavior completed by default", async () => {
+    const { repository, updates } = build(CallStatus.answered);
+
+    const result = await repository.completeCall(
+      "cc-1",
+      null,
+      "2026-09-07T14:00:00.000Z",
+    );
+
+    assert.equal(updates[0]!.data.status, CallStatus.completed);
+    assert.equal(result!.status, CallStatus.completed);
+  });
+
+  it("does not reopen an existing failure on a duplicate hangup", async () => {
+    const { repository, updates } = build(CallStatus.failed);
+
+    const result = await repository.completeCall(
+      "cc-1",
+      null,
+      "2026-09-07T14:00:00.000Z",
+    );
+
+    assert.equal(updates[0]!.data.status, CallStatus.failed);
+    assert.equal(result!.status, CallStatus.failed);
+  });
+});

--- a/packages/database/src/database/repositories/call.repository.ts
+++ b/packages/database/src/database/repositories/call.repository.ts
@@ -342,6 +342,13 @@ export class CallRepository {
     startedAt: string | Date | null | undefined,
     endedAt: string | Date | null | undefined,
     hangupCause?: string,
+    /**
+     * The terminal state already decided by the lifecycle owner. Ordinary
+     * hangups complete; an explicit provider failure remains failed.
+     */
+    terminalStatus:
+      | typeof CallStatus.completed
+      | typeof CallStatus.failed = CallStatus.completed,
   ): Promise<Call | null> {
     const call = await this.findByControlId(callControlId);
 
@@ -373,11 +380,15 @@ export class CallRepository {
       !call.outcome &&
       call.direction !== "inbound" &&
       call.direction !== "incoming";
+    // A later duplicate hangup must not turn an already persisted provider
+    // failure back into a successful completion.
+    const persistedTerminalStatus =
+      call.status === CallStatus.failed ? CallStatus.failed : terminalStatus;
 
     return this.prisma.call.update({
       where: { callControlId },
       data: {
-        status: CallStatus.completed,
+        status: persistedTerminalStatus,
         endedAt: endedAtDate,
         startedAt: startedAtDate,
         durationSeconds,

--- a/packages/services/src/services/call.service.ts
+++ b/packages/services/src/services/call.service.ts
@@ -47,11 +47,6 @@ import { VoiceAgentResultService } from "./voice-agents/voice-agent-result.servi
 import { CrmCallLogService } from "./crm/crm-call-log.service";
 import { InboxTimelineService } from "./inbox/inbox.timeline.service";
 import { CustomIntegrationOutboundService } from "./custom-integrations/custom-integration-outbound.service";
-import {
-  buildCallEventData,
-  callOwnershipFromCall,
-  pickCallTerminalEvent,
-} from "./custom-integrations/custom-integration-event-builders";
 import { PipelineFanoutService } from "./ai-pipeline";
 import { ConcurrentCallGuardService } from "./security";
 import { calculateCallCharge } from "./call-cost.util";
@@ -1220,16 +1215,7 @@ export class CallService implements OnModuleDestroy {
               ),
             );
           // Custom Integrations outbound — choose the most specific event.
-          const ciCtx = callOwnershipFromCall(hangupCall);
-          if (ciCtx) {
-            const eventEnum = pickCallTerminalEvent(hangupCall);
-            void this.customIntegrationOutbound.enqueue({
-              ctx: ciCtx,
-              eventEnum,
-              subjectId: hangupCall.id,
-              data: buildCallEventData(hangupCall),
-            });
-          }
+          void this.customIntegrationOutbound.enqueueCallTerminal(hangupCall);
           // Inbox timeline hook (best-effort, never block hangup processing)
           const ctx = InboxTimelineService.buildOwnershipFromCall(hangupCall);
           if (ctx) {

--- a/packages/services/src/services/custom-integrations/custom-integration-delivery.service.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-delivery.service.ts
@@ -13,8 +13,8 @@ const BASE_BACKOFF_MS = 2_000;
 const MAX_BACKOFF_MS = 5 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 15_000;
 // Deliveries are independent rows, so send them in small parallel waves: a
-// batch of 25 against dead endpoints (15s timeout each) drops from ~6min
-// sequential to ~1.5min, keeping the drain well inside its activity timeout.
+// batch of 100 against dead endpoints (15s timeout each) takes at most ~5min
+// in parallel waves, keeping the drain inside its activity timeout.
 const DRAIN_CONCURRENCY = 5;
 
 export interface DeliveryAttemptResult {

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
@@ -97,4 +97,42 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
       ],
     );
   });
+
+  it("classifies a persisted provider failure as call.failed", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+    );
+
+    await service.enqueueCallTerminal({
+      id: "call-failed",
+      userId: "user-1",
+      organizationId: "org-1",
+      fromNumber: "+13055550100",
+      toNumber: "+13055550123",
+      direction: "outbound",
+      status: CallStatus.failed,
+      endedAt: new Date("2026-09-07T14:00:00.000Z"),
+    } as never);
+
+    assert.equal(deliveries.length, 1);
+    assert.equal(deliveries[0]!.eventType, "call_failed");
+    assert.equal(deliveries[0]!.payload.event, "call.failed");
+    assert.equal(deliveries[0]!.payload.data.status, CallStatus.failed);
+  });
 });

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
@@ -1,0 +1,100 @@
+/// <reference types="node" />
+
+import "reflect-metadata";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CallStatus } from "@ringee/database";
+import { CustomIntegrationOutboundService } from "./custom-integration-outbound.service";
+
+describe("CustomIntegrationOutboundService call fan-out", () => {
+  it("queues a terminal call for every active subscribed integration", async () => {
+    const lookups: Array<Record<string, unknown>> = [];
+    const deliveries: Array<Record<string, any>> = [];
+    const integrations = [
+      {
+        id: "integration-1",
+        userId: "user-1",
+        organizationId: "org-1",
+        outboundUrl: "https://one.example/webhooks",
+      },
+      {
+        id: "integration-2",
+        userId: "user-2",
+        organizationId: "org-1",
+        outboundUrl: "https://two.example/webhooks",
+      },
+    ];
+
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async (
+          ctx: Record<string, unknown>,
+          eventType: string,
+        ) => {
+          lookups.push({ ctx, eventType });
+          return integrations;
+        },
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+    );
+
+    await service.enqueueCallTerminal({
+      id: "call-1",
+      userId: "user-1",
+      organizationId: "org-1",
+      fromNumber: "+13055550100",
+      toNumber: "+13055550123",
+      direction: "outbound",
+      status: CallStatus.completed,
+      startedAt: new Date("2026-09-07T13:58:00.000Z"),
+      answeredAt: new Date("2026-09-07T13:58:05.000Z"),
+      endedAt: new Date("2026-09-07T14:00:00.000Z"),
+      durationSeconds: 120,
+    } as never);
+
+    assert.deepEqual(lookups, [
+      {
+        ctx: { userId: "user-1", organizationId: "org-1" },
+        eventType: "call_completed",
+      },
+    ]);
+    assert.equal(deliveries.length, 2);
+    assert.deepEqual(
+      deliveries.map((delivery) => ({
+        integrationId: delivery.integrationId,
+        eventType: delivery.eventType,
+        subjectId: delivery.subjectId,
+        destinationUrl: delivery.destinationUrl,
+        event: delivery.payload.event,
+        occurredAt: delivery.payload.occurredAt,
+        workspaceId: delivery.payload.workspaceId,
+      })),
+      [
+        {
+          integrationId: "integration-1",
+          eventType: "call_completed",
+          subjectId: "call-1",
+          destinationUrl: "https://one.example/webhooks",
+          event: "call.completed",
+          occurredAt: "2026-09-07T14:00:00.000Z",
+          workspaceId: "org-1",
+        },
+        {
+          integrationId: "integration-2",
+          eventType: "call_completed",
+          subjectId: "call-1",
+          destinationUrl: "https://two.example/webhooks",
+          event: "call.completed",
+          occurredAt: "2026-09-07T14:00:00.000Z",
+          workspaceId: "org-1",
+        },
+      ],
+    );
+  });
+});

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { randomUUID } from "crypto";
 import {
+  Call,
   CustomIntegrationDeliveryRepository,
   CustomIntegrationEventType,
   CustomIntegrationRepository,
@@ -11,6 +12,11 @@ import {
   OutboundEventName,
   OwnershipContext,
 } from "@ringee/platform";
+import {
+  buildCallEventData,
+  callOwnershipFromCall,
+  pickCallTerminalEvent,
+} from "./custom-integration-event-builders";
 
 export interface OutboundEventEnvelope {
   event: OutboundEventName;
@@ -29,6 +35,24 @@ export class CustomIntegrationOutboundService {
     private readonly integrations: CustomIntegrationRepository,
     private readonly deliveries: CustomIntegrationDeliveryRepository,
   ) {}
+
+  /**
+   * Publish the terminal event for a persisted call through the canonical
+   * workspace fan-out. More than one provider callback may report the same
+   * ending; `enqueue`'s per-integration dedupe key makes those replays safe.
+   */
+  async enqueueCallTerminal(call: Call): Promise<void> {
+    const ctx = callOwnershipFromCall(call);
+    if (!ctx) return;
+
+    await this.enqueue({
+      ctx,
+      eventEnum: pickCallTerminalEvent(call),
+      subjectId: call.id,
+      data: buildCallEventData(call),
+      occurredAt: call.endedAt ?? undefined,
+    });
+  }
 
   /**
    * Fan out an event to every active custom integration in the workspace that

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
@@ -48,11 +48,13 @@ function build(
     turns?: Array<{ role: string; text: string; at: Date | null }>;
     transcriptError?: Error;
     alreadyTranscribed?: boolean;
+    completedCall?: Record<string, unknown> | null;
   } = {},
 ) {
   const updates: Array<Record<string, unknown>> = [];
   const transcripts: Array<Record<string, unknown>> = [];
   const attached: Array<Record<string, unknown>> = [];
+  const terminalEvents: Array<Record<string, unknown>> = [];
 
   const service = new VoiceAgentResultService(
     {
@@ -77,6 +79,16 @@ function build(
         attached.push({ id, ...data });
         return { id };
       },
+      completeCall: async () =>
+        over.completedCall === undefined
+          ? {
+              id: "telephony-1",
+              userId: "user-1",
+              organizationId: "org-1",
+              status: CallStatus.completed,
+              endedAt: new Date("2026-09-07T14:00:00.000Z"),
+            }
+          : over.completedCall,
     } as never,
     {
       // The real adapter's parser, in miniature: the domain never sees the
@@ -120,9 +132,14 @@ function build(
         return null;
       },
     } as never,
+    {
+      enqueueCallTerminal: async (call: Record<string, unknown>) => {
+        terminalEvents.push(call);
+      },
+    } as never,
   );
 
-  return { service, updates, transcripts, attached };
+  return { service, updates, transcripts, attached, terminalEvents };
 }
 
 describe("VoiceAgentResultService analysis callback", () => {
@@ -283,6 +300,30 @@ describe("VoiceAgentResultService call status", () => {
       assert.equal(attached[0]!.status, undefined);
       assert.equal(attached[0]!.answeredAt, undefined);
     }
+  });
+
+  it("publishes a terminal agent call to Custom Integrations", async () => {
+    const { service, terminalEvents } = build();
+
+    await service.applyStatus(AGENT_CALL as never, {
+      providerStatus: "completed",
+      callControlId: "cc-1",
+      endedAt: "2026-09-07T14:00:00.000Z",
+    });
+
+    assert.equal(terminalEvents.length, 1);
+    assert.equal(terminalEvents[0]!.id, "telephony-1");
+  });
+
+  it("does not publish when the terminal callback cannot resolve its Call row", async () => {
+    const { service, terminalEvents } = build({ completedCall: null });
+
+    await service.applyStatus(AGENT_CALL as never, {
+      providerStatus: "completed",
+      callControlId: "cc-missing",
+    });
+
+    assert.deepEqual(terminalEvents, []);
   });
 });
 

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
@@ -55,6 +55,7 @@ function build(
   const transcripts: Array<Record<string, unknown>> = [];
   const attached: Array<Record<string, unknown>> = [];
   const terminalEvents: Array<Record<string, unknown>> = [];
+  const completions: Array<Record<string, unknown>> = [];
 
   const service = new VoiceAgentResultService(
     {
@@ -79,16 +80,30 @@ function build(
         attached.push({ id, ...data });
         return { id };
       },
-      completeCall: async () =>
-        over.completedCall === undefined
+      completeCall: async (
+        callControlId: string,
+        startedAt: string | undefined,
+        endedAt: string,
+        hangupCause: string | undefined,
+        terminalStatus: CallStatus,
+      ) => {
+        completions.push({
+          callControlId,
+          startedAt,
+          endedAt,
+          hangupCause,
+          terminalStatus,
+        });
+        return over.completedCall === undefined
           ? {
               id: "telephony-1",
               userId: "user-1",
               organizationId: "org-1",
-              status: CallStatus.completed,
+              status: terminalStatus,
               endedAt: new Date("2026-09-07T14:00:00.000Z"),
             }
-          : over.completedCall,
+          : over.completedCall;
+      },
     } as never,
     {
       // The real adapter's parser, in miniature: the domain never sees the
@@ -139,7 +154,14 @@ function build(
     } as never,
   );
 
-  return { service, updates, transcripts, attached, terminalEvents };
+  return {
+    service,
+    updates,
+    transcripts,
+    attached,
+    terminalEvents,
+    completions,
+  };
 }
 
 describe("VoiceAgentResultService analysis callback", () => {
@@ -303,7 +325,7 @@ describe("VoiceAgentResultService call status", () => {
   });
 
   it("publishes a terminal agent call to Custom Integrations", async () => {
-    const { service, terminalEvents } = build();
+    const { service, terminalEvents, completions } = build();
 
     await service.applyStatus(AGENT_CALL as never, {
       providerStatus: "completed",
@@ -313,6 +335,22 @@ describe("VoiceAgentResultService call status", () => {
 
     assert.equal(terminalEvents.length, 1);
     assert.equal(terminalEvents[0]!.id, "telephony-1");
+    assert.equal(terminalEvents[0]!.status, CallStatus.completed);
+    assert.equal(completions[0]!.terminalStatus, CallStatus.completed);
+  });
+
+  it("retains a provider failure before publishing to Custom Integrations", async () => {
+    const { service, terminalEvents, completions } = build();
+
+    await service.applyStatus(AGENT_CALL as never, {
+      providerStatus: "failed",
+      callControlId: "cc-1",
+      hangupCause: "normal_temporary_failure",
+    });
+
+    assert.equal(completions[0]!.terminalStatus, CallStatus.failed);
+    assert.equal(terminalEvents.length, 1);
+    assert.equal(terminalEvents[0]!.status, CallStatus.failed);
   });
 
   it("does not publish when the terminal callback cannot resolve its Call row", async () => {

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.ts
@@ -18,6 +18,7 @@ import {
   type VoiceAgentInsightResult,
 } from "@ringee/platform";
 import { TranscriptionService } from "../transcription/transcription.service";
+import { CustomIntegrationOutboundService } from "../custom-integrations/custom-integration-outbound.service";
 import { VoiceAgentService } from "./voice-agent.service";
 import type { VoiceAgentAnalysisSettings } from "./voice-agent.types";
 
@@ -71,6 +72,7 @@ export class VoiceAgentResultService {
     private readonly callRepository: CallRepository,
     private readonly provider: VoiceAgentProviderService,
     private readonly transcriptions: TranscriptionService,
+    private readonly customIntegrationOutbound: CustomIntegrationOutboundService,
   ) {}
 
   /**
@@ -389,7 +391,7 @@ export class VoiceAgentResultService {
     if (this.isTerminal(status) && callControlId) {
       // The shared settlement path: it computes the duration, records the
       // hangup cause and auto-dispositions a call that never connected.
-      await this.callRepository.completeCall(
+      const completedCall = await this.callRepository.completeCall(
         callControlId,
         // Not "now". The row already knows when the call was placed, and
         // substituting the moment this callback arrived — which is what the
@@ -399,6 +401,16 @@ export class VoiceAgentResultService {
         input.endedAt ?? new Date().toISOString(),
         input.hangupCause ?? undefined,
       );
+
+      // Voice-agent status callbacks do not traverse CallService's ordinary
+      // call.hangup branch. Publish from this terminal path too, otherwise a
+      // call started through the public API is completed in Ringee but never
+      // reaches any subscribed Custom Integration. A later signed hangup is
+      // harmless because outbound delivery is deduplicated per integration,
+      // event and call.
+      if (completedCall) {
+        await this.customIntegrationOutbound.enqueueCallTerminal(completedCall);
+      }
     }
 
     return updated;

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.ts
@@ -400,6 +400,9 @@ export class VoiceAgentResultService {
         input.startedAt,
         input.endedAt ?? new Date().toISOString(),
         input.hangupCause ?? undefined,
+        status === AiVoiceAgentCallStatus.failed
+          ? CallStatus.failed
+          : CallStatus.completed,
       );
 
       // Voice-agent status callbacks do not traverse CallService's ordinary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Behaviour

- Terminal voice-agent outcomes now enqueue `call_completed` or `call_failed` custom integration events.
- Provider failures persist as `failed` and remain failed after duplicate hangups.
- Custom integration drains run every 5 seconds and process up to 100 events.

## Architectural impact

- `CustomIntegrationOutboundService` owns terminal event selection, payload construction, and workspace fan-out.
- `VoiceAgentResultService` invokes this service after call completion.
- `CallRepository.completeCall` now accepts and preserves terminal status.
- `CallService` no longer builds terminal integration events locally.

## Risk areas

- Review `call_completed` and `call_failed` webhook payloads, including terminal status and call end time.
- Verify workspace ownership is present before fan-out and cannot cross workspace boundaries.
- Verify repeated hangups cannot overwrite provider failures or create duplicate deliveries.
- The 5-second cadence and batch size of 100 increase concurrent outbound webhook load.
- The `completeCall` signature change affects callers and the `@ringee/database` contract.

## Files that carry the risk

- `packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts`
- `packages/services/src/services/voice-agents/voice-agent-result.service.ts`
- `packages/database/src/database/repositories/call.repository.ts`
- `packages/services/src/services/call.service.ts`
- `packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts`
- `packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts`
- `packages/database/src/database/repositories/call.repository.spec.ts`
- `apps/orchestrator/src/temporal/activities.ts`
- `apps/orchestrator/src/temporal/schedules.ts`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->