### PR TITLE
feat: enhance voice agent functionality with runtime context and outcome event handling

### DIFF
--- a/docs/engineering/BUSINESS_RULES.md
+++ b/docs/engineering/BUSINESS_RULES.md
@@ -931,6 +931,19 @@ making repeated uncached AI calls.
 
 - **Source of truth:** `VoiceCloneReadingSampleService`
 
+### AGENT-013 — The agent's clock is refreshed in its selected time zone
+
+An assistant is long-lived, so a date or time embedded when it is saved becomes
+wrong. Every conversation prompt references Ringee-owned runtime variables for
+the call-start date/time and IANA time zone. Phone calls override those values
+on every dial; browser test sessions refresh them when the session opens. A
+missing time zone is explicitly UTC, and an invalid legacy value falls back to
+UTC rather than preventing the call.
+
+- **Source of truth:** `voiceAgentRuntimeVariables`,
+  `VoiceAgentCallService.startCall`, and
+  `VoiceAgentTestSessionService.start`
+
 ---
 
 ## Onboarding & lifecycle (`LIFE`)

--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -156,6 +156,12 @@ The generic, customer-facing integration surface.
   tab in the dashboard. Changing it changes public docs and live contracts.
 - Envelope: `{ event, eventId, occurredAt, data }`, plus `workspaceId` and
   `integrationId` on outbound.
+- AI voice-agent calls use the same fan-out: terminal status publishes
+  `call.completed`/`call.failed`, post-call analysis publishes
+  `call.outcome.updated`, confirmed bookings publish `meeting.created`, and the
+  recovered recording publishes `recording.ready`. Only events actually
+  produced by the call are sent, and each is filtered by the integration's
+  configured subscriptions.
 
 ### Enrichment (`packages/platform/src/enrichment`)
 

--- a/docs/engineering/TELEPHONY.md
+++ b/docs/engineering/TELEPHONY.md
@@ -294,6 +294,15 @@ Consequences worth keeping:
   results name the conversation and nothing else: no call handle, which is why
   they cannot ride `/api/call/webhook`, whose normalizer drops any event with no
   `call_control_id`.
+- **The agent's clock is call-time context, not saved configuration**
+  (AGENT-013). Its prompt references `current_datetime` and `agent_timezone`;
+  every dial refreshes both from the agent's selected IANA time zone, so public
+  API and dashboard calls interpret “today” and “tomorrow” identically.
+- Agent calls publish the same applicable Custom Integration events as other
+  calls. The status callback emits the terminal event, post-call analysis emits
+  `call.outcome.updated`, a successful booking emits `meeting.created`, and the
+  artifact sweep emits `recording.ready` after the recovered recording is
+  durably stored. Each path uses the outbound outbox's replay-safe dedupe key.
 
 ### Voice delivery and turn-taking
 

--- a/packages/database/src/database/repositories/ai-voice-agent-call.repository.ts
+++ b/packages/database/src/database/repositories/ai-voice-agent-call.repository.ts
@@ -101,6 +101,25 @@ export class AiVoiceAgentCallRepository {
   }
 
   /**
+   * Atomically changes the outcome only when it is a real transition.
+   * Concurrent replays of the same analysis therefore have a single winner,
+   * whose persisted `updatedAt` is the revision for downstream idempotency.
+   */
+  async updateOutcomeIfChanged(
+    id: string,
+    outcome: AiVoiceAgentOutcome,
+  ): Promise<AiVoiceAgentCall | null> {
+    const [updated] = await this.prisma.aiVoiceAgentCall.updateManyAndReturn({
+      where: {
+        id,
+        OR: [{ outcome: null }, { outcome: { not: outcome } }],
+      },
+      data: { outcome },
+    });
+    return updated ?? null;
+  }
+
+  /**
    * Settle the AI-usage charge exactly once. `costSettledAt` is the idempotency
    * guard (BILL-003/BILL-004): a replay updates zero rows and returns false.
    */

--- a/packages/platform/src/custom-integrations/event-spec.ts
+++ b/packages/platform/src/custom-integrations/event-spec.ts
@@ -387,15 +387,17 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
   {
     name: "call.outcome.updated",
     direction: "outbound",
-    description: "The user recorded or changed the outcome of a call.",
+    description:
+      "A user recorded an outcome, or an AI voice agent produced its post-call outcome.",
     whenItFires:
-      "Fired whenever a Ringee user sets or changes a call outcome — may happen well after call.completed.",
+      "Fired when Ringee records or changes a call outcome — including an AI voice agent's post-call analysis — and may happen well after call.completed.",
     requiredFields: [
       { name: "data.callId", type: "string", description: "Ringee call UUID." },
       {
         name: "data.outcome",
         type: "string",
-        description: "CallOutcome value.",
+        description:
+          "CallOutcome value, or the AI voice agent's normalized outcome for an agent call.",
       },
       {
         name: "data.updatedAt",
@@ -412,6 +414,22 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       ENTITY_CONTACT,
       ENTITY_COMPANY,
       ENTITY_USER,
+      {
+        name: "data.agentCallId",
+        type: "string",
+        description: "AI voice-agent call UUID, when an agent placed the call.",
+      },
+      {
+        name: "data.agentId",
+        type: "string",
+        description: "AI voice-agent UUID, when an agent placed the call.",
+      },
+      {
+        name: "data.metadata",
+        type: "object",
+        description:
+          "Caller-supplied AI voice-agent metadata, when present on the call.",
+      },
     ],
     examplePayload: {
       event: "call.outcome.updated",
@@ -427,7 +445,7 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     },
     notes: [
-      "If the user never records an outcome, this event is not sent.",
+      "If neither a user nor an AI voice agent records an outcome, this event is not sent.",
       "When the outcome is meeting_booked, a separate meeting.created event is also fired.",
     ],
   },

--- a/packages/platform/src/voice-agents/interfaces/voice-agent.provider.ts
+++ b/packages/platform/src/voice-agents/interfaces/voice-agent.provider.ts
@@ -111,6 +111,8 @@ export interface VoiceAgentAssistant {
   callingAppId: string | null;
   /** Whether an unauthenticated browser may currently talk to this agent. */
   unauthenticatedWebCallsEnabled: boolean;
+  /** Whether the stored prompt consumes Ringee's call-time clock variables. */
+  runtimeContextConfigured: boolean;
   /**
    * Where the assistant currently calls Ringee back for its tools.
    *

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.test.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.test.ts
@@ -255,6 +255,7 @@ describe("toVoiceAgentAssistant", () => {
       assistantId: "assistant-1",
       callingAppId: "3035069911979263363",
       unauthenticatedWebCallsEnabled: true,
+      runtimeContextConfigured: false,
       toolWebhookUrls: [],
     });
   });
@@ -263,6 +264,7 @@ describe("toVoiceAgentAssistant", () => {
     const assistant = toVoiceAgentAssistant({ id: "assistant-2" });
     expect(assistant.callingAppId).toBeNull();
     expect(assistant.unauthenticatedWebCallsEnabled).toBe(false);
+    expect(assistant.runtimeContextConfigured).toBe(false);
   });
 
   // Where the assistant currently calls Ringee back. The dial path compares
@@ -285,6 +287,16 @@ describe("toVoiceAgentAssistant", () => {
     expect(assistant.toolWebhookUrls).toEqual([
       "https://api.ringee.io/api/x/available-slots",
     ]);
+  });
+
+  it("recognizes prompts that consume Ringee's call-time clock", () => {
+    const assistant = toVoiceAgentAssistant({
+      id: "assistant-4",
+      instructions:
+        "It is {{current_datetime}} in {{agent_timezone}} at call start.",
+    });
+
+    expect(assistant.runtimeContextConfigured).toBe(true);
   });
 });
 

--- a/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.ts
+++ b/packages/platform/src/voice-agents/telnyx/telnyx.voice-agent.mapper.ts
@@ -22,6 +22,7 @@ import type {
 export interface TelnyxAssistantResponse {
   id: string;
   name?: string;
+  instructions?: string | null;
   tools?: Array<{
     type?: string | null;
     webhook?: { url?: string | null } | null;
@@ -249,6 +250,9 @@ export function toVoiceAgentAssistant(
     callingAppId: raw.telephony_settings?.default_texml_app_id ?? null,
     unauthenticatedWebCallsEnabled:
       raw.telephony_settings?.supports_unauthenticated_web_calls ?? false,
+    runtimeContextConfigured:
+      raw.instructions?.includes("{{current_datetime}}") === true &&
+      raw.instructions?.includes("{{agent_timezone}}") === true,
     toolWebhookUrls: (raw.tools ?? []).flatMap((tool) => {
       const url = str(tool?.webhook?.url);
       return tool?.type === "webhook" && url ? [url] : [];

--- a/packages/services/src/services/custom-integrations/custom-integration-event-builders.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-event-builders.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  AiVoiceAgentCall,
   Call,
   CallbackTask,
   CallStatus,
@@ -93,6 +94,28 @@ export function buildCallOutcomeData(call: Call): Record<string, unknown> {
     outcome: call.outcome,
     outcomeNote: call.outcomeNote ?? undefined,
     updatedAt: (call.updatedAt ?? new Date()).toISOString(),
+  };
+}
+
+/**
+ * AI voice-agent analyses own a wider outcome vocabulary than `CallOutcome`.
+ * Keep the public event on the same call-oriented envelope while preserving
+ * the agent's actual conclusion instead of coercing it into an unrelated
+ * human-dialer disposition.
+ */
+export function buildVoiceAgentCallOutcomeData(
+  agentCall: Pick<
+    AiVoiceAgentCall,
+    "id" | "agentId" | "callId" | "outcome" | "metadata" | "updatedAt"
+  >,
+): Record<string, unknown> {
+  return {
+    callId: agentCall.callId,
+    agentCallId: agentCall.id,
+    agentId: agentCall.agentId,
+    outcome: agentCall.outcome,
+    metadata: agentCall.metadata ?? undefined,
+    updatedAt: agentCall.updatedAt.toISOString(),
   };
 }
 

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
@@ -135,4 +135,40 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
     assert.equal(deliveries[0]!.payload.event, "call.failed");
     assert.equal(deliveries[0]!.payload.data.status, CallStatus.failed);
   });
+
+  it("keeps the subject id while deduplicating a specific event transition", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+    );
+
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "call_outcome_updated",
+      subjectId: "call-1",
+      dedupeKey: "call-1:outcome:not_interested:revision-2",
+      data: { callId: "call-1", outcome: "not_interested" },
+    });
+
+    assert.equal(deliveries[0]!.subjectId, "call-1");
+    assert.equal(
+      deliveries[0]!.dedupeKey,
+      "integration-1:call_outcome_updated:call-1:outcome:not_interested:revision-2:v1",
+    );
+  });
 });

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
@@ -63,6 +63,8 @@ export class CustomIntegrationOutboundService {
     ctx: OwnershipContext;
     eventEnum: CustomIntegrationEventType;
     subjectId: string;
+    /** Stable identity for one event transition; defaults to the subject. */
+    dedupeKey?: string;
     data: Record<string, unknown>;
     occurredAt?: Date;
   }): Promise<void> {
@@ -94,7 +96,7 @@ export class CustomIntegrationOutboundService {
           subjectId: input.subjectId,
           destinationUrl: integration.outboundUrl,
           payload: envelope as unknown as Record<string, unknown>,
-          dedupeKey: `${integration.id}:${input.eventEnum}:${input.subjectId}:v1`,
+          dedupeKey: `${integration.id}:${input.eventEnum}:${input.dedupeKey ?? input.subjectId}:v1`,
         });
       }
     } catch (err) {

--- a/packages/services/src/services/recording-processing.service.spec.ts
+++ b/packages/services/src/services/recording-processing.service.spec.ts
@@ -1,0 +1,98 @@
+/// <reference types="node" />
+
+import "reflect-metadata";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { RecordingProcessingService } from "./recording-processing.service";
+
+describe("RecordingProcessingService custom integration delivery", () => {
+  it("publishes recording.ready with the Recording row created for an agent call", async () => {
+    const published: Array<{
+      callId: string;
+      recordingId: string;
+      publicUrl: string;
+    }> = [];
+    let uploadCount = 0;
+
+    const service = new RecordingProcessingService(
+      { encryptBuffer: (buffer: Buffer) => buffer } as never,
+      {
+        downloadRecording: async () =>
+          Uint8Array.from([1, 2, 3]).buffer as ArrayBuffer,
+      } as never,
+      {
+        findByControlId: async () => ({
+          id: "call-1",
+          userId: "user-1",
+          organizationId: "org-1",
+          callControlId: "cc-1",
+        }),
+      } as never,
+      {
+        findRecordingsByCallId: async () => [],
+        createRecording: async () => ({
+          id: "recording-1",
+          callId: "call-1",
+          status: "completed",
+          format: "mp3",
+          url: "encrypted-url",
+          durationSec: null,
+          createdAt: new Date("2026-09-08T05:30:45.000Z"),
+          updatedAt: new Date("2026-09-08T05:30:45.000Z"),
+        }),
+      } as never,
+      {} as never,
+      {
+        findById: async () => ({ encryptionKey: "workspace-key" }),
+      } as never,
+      {
+        findLatestByCallId: async () => null,
+        create: async () => ({ id: "public-recording-1" }),
+      } as never,
+      { enqueueRecordingNote: async () => undefined } as never,
+      {
+        enqueueRecordingUpload: async (
+          callId: string,
+          recordingId: string,
+          publicUrl: string,
+        ) => {
+          published.push({ callId, recordingId, publicUrl });
+        },
+      } as never,
+      {} as never,
+      { resolve: async () => ({ transcribeRecordings: false }) } as never,
+    );
+
+    (
+      service as unknown as {
+        uploadService: {
+          uploadBuffer: () => Promise<string>;
+        };
+      }
+    ).uploadService = {
+      uploadBuffer: async () => {
+        uploadCount += 1;
+        return uploadCount === 1 ? "public-url" : "encrypted-url";
+      },
+    };
+
+    await service.processCallRecording({
+      callControlId: "cc-1",
+      recording: {
+        publicUrl: "provider-url",
+        privateUrl: "provider-url",
+        recordingStartedAt: "2026-09-08T05:29:45.000Z",
+        recordingEndedAt: "2026-09-08T05:30:45.000Z",
+      },
+    });
+
+    assert.deepEqual(published, [
+      {
+        callId: "call-1",
+        recordingId: "recording-1",
+        publicUrl: "public-url",
+      },
+    ]);
+  });
+});

--- a/packages/services/src/services/recording-processing.service.ts
+++ b/packages/services/src/services/recording-processing.service.ts
@@ -164,27 +164,24 @@ export class RecordingProcessingService {
         (recording) => recording.status !== "completed",
       );
 
-      if (processingRecording) {
-        await this.recordingService.updateRecording(processingRecording.id, {
-          url: newUrl,
-          format: "mp3",
-          status: "completed",
-        });
-      } else {
-        await this.recordingService.createRecording({
-          callId: call.id,
-          url: newUrl,
-          format: "mp3",
-          status: "completed",
-        });
-      }
+      const completedRecording = processingRecording
+        ? await this.recordingService.updateRecording(processingRecording.id, {
+            url: newUrl,
+            format: "mp3",
+            status: "completed",
+          })
+        : await this.recordingService.createRecording({
+            callId: call.id,
+            url: newUrl,
+            format: "mp3",
+            status: "completed",
+          });
 
       // Best-effort: upload recording file to CRM
       try {
-        const recId = processingRecording?.id ?? recordings[0]?.id ?? call.id;
         await this.crmRecordingUpload.enqueueRecordingUpload(
           call.id,
-          recId,
+          completedRecording.id,
           publicUrl,
         );
       } catch (uploadErr) {

--- a/packages/services/src/services/voice-agents/voice-agent-call.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-call.service.spec.ts
@@ -42,8 +42,11 @@ function build(options: {
   variables?: Array<{ key: string; required: boolean }>;
   /** What the tool re-sync throws, for the test that it is best-effort. */
   toolSyncError?: Error;
+  /** Agent-local clock used for runtime context. */
+  timezone?: string | null;
 }) {
   const placed: Array<{ from: string }> = [];
+  const providerVariables: Array<Record<string, string>> = [];
   const contacts: ResolvedContact[] = [];
   const agent = {
     id: "agent-1",
@@ -52,6 +55,7 @@ function build(options: {
     providerAssistantId: "assistant-1",
     providerTexmlAppId: "app-1",
     callerNumberId: options.callerNumberId ?? null,
+    timezone: options.timezone ?? null,
   };
 
   const configured: string[] = [];
@@ -87,9 +91,13 @@ function build(options: {
       markForciblyEnded: async () => ({ id: "call-1" }),
     } as never,
     {
-      startCall: async (input: { from: string }) => {
+      startCall: async (input: {
+        from: string;
+        variables: Record<string, string>;
+      }) => {
         deliveryEvents.push("call:placed");
         placed.push({ from: input.from });
+        providerVariables.push(input.variables);
         return { providerCallId: "prov-1", callControlId: "cc-1" };
       },
     } as never,
@@ -118,6 +126,7 @@ function build(options: {
     configured,
     analysisEnsured,
     deliveryEvents,
+    providerVariables,
   };
 }
 
@@ -264,6 +273,18 @@ describe("VoiceAgentCallService contacts", () => {
  * created before Ringee configured these at all would otherwise never get one.
  */
 describe("VoiceAgentCallService calling application", () => {
+  it("supplies the agent-local date and time on every dial", async () => {
+    const { service, providerVariables } = build({
+      usable: [NUMBERS.miami],
+      timezone: "America/Santo_Domingo",
+    });
+
+    await service.startCall(CTX as never, "agent-1", { to: TO });
+
+    assert.equal(providerVariables[0]!.agent_timezone, "America/Santo_Domingo");
+    assert.match(providerVariables[0]!.current_datetime, /GMT-04:00$/);
+  });
+
   it("configures the calling application before placing the call", async () => {
     const { service, configured } = build({ usable: [NUMBERS.miami] });
 

--- a/packages/services/src/services/voice-agents/voice-agent-call.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-call.service.ts
@@ -31,6 +31,7 @@ import { UserService } from "../user.service";
 import { VoiceAgentBlueprintRegistry } from "./blueprints/voice-agent-blueprint.registry";
 import { assertVoiceAgentAccess } from "./voice-agent-access";
 import { VoiceAgentService } from "./voice-agent.service";
+import { voiceAgentRuntimeVariables } from "./voice-agent-conversation";
 import {
   AI_VOICE_AGENT_CALL_SOURCE,
   AI_VOICE_AGENT_CONTACT_SOURCE,
@@ -160,7 +161,13 @@ export class VoiceAgentCallService {
         callingAppId: await this.requireCallingApp(agent),
         from,
         to,
-        variables,
+        // The assistant is long-lived, but the clock is not. Override the
+        // Ringee-owned runtime values on every dial so web, public API, CLI and
+        // MCP calls all interpret dates in the agent's selected time zone.
+        variables: {
+          ...variables,
+          ...voiceAgentRuntimeVariables(agent.timezone),
+        },
         conversationCallbackUrl: this.conversationCallbackUrl(),
         statusCallbackUrl: this.statusCallbackUrl(agentCall.id, callbackToken),
         ringTimeoutSeconds: RING_TIMEOUT_SECONDS,

--- a/packages/services/src/services/voice-agents/voice-agent-conversation.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-conversation.spec.ts
@@ -4,6 +4,7 @@ import type { VoiceAgentConversationSettings } from "./voice-agent.types";
 import {
   composeVoiceAgentInstructions,
   readVoiceAgentConversationSettings,
+  voiceAgentRuntimeVariables,
 } from "./voice-agent-conversation";
 
 const defaults: VoiceAgentConversationSettings = {
@@ -33,9 +34,40 @@ describe("voice agent conversation settings", () => {
   });
 
   it("does not duplicate safety rules on the unchanged default prompt", () => {
-    assert.equal(
-      composeVoiceAgentInstructions(defaults, defaults, "NEVER INVENT"),
-      defaults.instructions,
+    const instructions = composeVoiceAgentInstructions(
+      defaults,
+      defaults,
+      "NEVER INVENT",
+    );
+    assert.match(instructions, /^## Role\n\nBook a meeting\./);
+    assert.doesNotMatch(instructions, /NEVER INVENT/);
+    assert.match(instructions, /\{\{current_datetime\}\}/);
+    assert.match(instructions, /\{\{agent_timezone\}\}/);
+  });
+
+  it("formats the call-start clock in the agent's selected timezone", () => {
+    assert.deepEqual(
+      voiceAgentRuntimeVariables(
+        "America/Santo_Domingo",
+        new Date("2026-09-08T05:30:45.000Z"),
+      ),
+      {
+        agent_timezone: "America/Santo_Domingo",
+        current_datetime: "Tuesday, September 8, 2026 at 01:30:45 GMT-04:00",
+      },
+    );
+  });
+
+  it("falls back to an explicit UTC clock for an invalid legacy timezone", () => {
+    assert.deepEqual(
+      voiceAgentRuntimeVariables(
+        "Legacy/Invalid",
+        new Date("2026-09-08T05:30:45.000Z"),
+      ),
+      {
+        agent_timezone: "UTC",
+        current_datetime: "Tuesday, September 8, 2026 at 05:30:45 GMT+00:00",
+      },
     );
   });
 

--- a/packages/services/src/services/voice-agents/voice-agent-conversation.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-conversation.ts
@@ -1,5 +1,56 @@
 import type { VoiceAgentConversationSettings } from "./voice-agent.types";
 
+/**
+ * Runtime values Ringee owns and refreshes when a conversation starts.
+ *
+ * Provider assistants are long-lived, so putting a literal timestamp in their
+ * stored instructions would make it stale. The instructions reference these
+ * dynamic variables instead; phone calls override them per dial and browser
+ * test sessions refresh them when the session opens.
+ */
+export function voiceAgentRuntimeVariables(
+  timezone: string | null | undefined,
+  now = new Date(),
+): Record<string, string> {
+  const selectedTimezone = timezone?.trim() || "UTC";
+  const format = (timeZone: string) =>
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+      timeZoneName: "longOffset",
+    }).format(now);
+
+  try {
+    return {
+      agent_timezone: selectedTimezone,
+      current_datetime: format(selectedTimezone),
+    };
+  } catch {
+    // Older rows could predate IANA validation. A bad legacy value must not
+    // prevent a call; UTC is explicit and deterministic rather than guessed.
+    return {
+      agent_timezone: "UTC",
+      current_datetime: format("UTC"),
+    };
+  }
+}
+
+const RUNTIME_CONTEXT_INSTRUCTIONS = [
+  "## Ringee runtime context",
+  "",
+  "At the start of this conversation, the local date and time is",
+  "{{current_datetime}} in {{agent_timezone}}. Treat this value and time zone",
+  "as authoritative when interpreting relative dates such as today, tomorrow",
+  "or next week.",
+].join("\n");
+
 const GREETING_MODES = new Set<VoiceAgentConversationSettings["greetingMode"]>([
   "assistant_speaks_first",
   "assistant_generates_greeting",
@@ -69,6 +120,7 @@ export function composeVoiceAgentInstructions(
       ].join("\n"),
     );
   }
+  sections.push(RUNTIME_CONTEXT_INSTRUCTIONS);
   if (hasCustomInstructions || hasPostInstructions) {
     sections.push(safetyInstructions.trim());
   }

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
@@ -49,6 +49,7 @@ function build(
     transcriptError?: Error;
     alreadyTranscribed?: boolean;
     completedCall?: Record<string, unknown> | null;
+    insightOutcome?: string;
   } = {},
 ) {
   const updates: Array<Record<string, unknown>> = [];
@@ -57,6 +58,11 @@ function build(
   const terminalEvents: Array<Record<string, unknown>> = [];
   const outcomeEvents: Array<Record<string, unknown>> = [];
   const completions: Array<Record<string, unknown>> = [];
+  let currentOutcome =
+    over.agentCall && "outcome" in over.agentCall
+      ? over.agentCall.outcome
+      : AGENT_CALL.outcome;
+  let outcomeRevision = 0;
 
   const service = new VoiceAgentResultService(
     {
@@ -70,6 +76,22 @@ function build(
           ...data,
           metadata: { external_id: "customer-42" },
           updatedAt: new Date("2026-09-07T14:05:00.000Z"),
+        };
+      },
+      updateOutcomeIfChanged: async (_id: string, outcome: string) => {
+        if (currentOutcome === outcome) return null;
+        currentOutcome = outcome;
+        updates.push({ outcome });
+        const updatedAt = new Date(
+          new Date("2026-09-07T14:05:00.000Z").getTime() +
+            outcomeRevision * 1_000,
+        );
+        outcomeRevision += 1;
+        return {
+          ...AGENT_CALL,
+          outcome,
+          metadata: { external_id: "customer-42" },
+          updatedAt,
         };
       },
     } as never,
@@ -123,7 +145,9 @@ function build(
                 { insightId: "insight-summary", result: "Booked a demo." },
                 {
                   insightId: "insight-outcome",
-                  result: '{"outcome":"appointment_booked"}',
+                  result: JSON.stringify({
+                    outcome: over.insightOutcome ?? "appointment_booked",
+                  }),
                 },
               ],
             }
@@ -184,13 +208,16 @@ describe("VoiceAgentResultService analysis callback", () => {
 
     assert.equal(accepted, true);
     assert.deepEqual(updates, [
-      { summary: "Booked a demo.", outcome: "appointment_booked" },
+      { summary: "Booked a demo." },
+      { outcome: "appointment_booked" },
     ]);
     assert.deepEqual(outcomeEvents, [
       {
         ctx: { userId: "user-1", organizationId: "org-1" },
         eventEnum: "call_outcome_updated",
         subjectId: "telephony-1",
+        dedupeKey:
+          "telephony-1:outcome:appointment_booked:2026-09-07T14:05:00.000Z",
         data: {
           callId: "telephony-1",
           agentCallId: "call-1",
@@ -202,6 +229,75 @@ describe("VoiceAgentResultService analysis callback", () => {
         occurredAt: new Date("2026-09-07T14:05:00.000Z"),
       },
     ]);
+  });
+
+  it("does not publish an unchanged outcome when the callback is replayed", async () => {
+    const { service, updates, outcomeEvents } = build({
+      insightOutcome: "callback_requested",
+    });
+
+    await service.applyInsightCallback(AGENT_ID, TOKEN, {
+      conversation_id: "conv-1",
+    });
+    await service.applyInsightCallback(AGENT_ID, TOKEN, {
+      conversation_id: "conv-1",
+    });
+
+    assert.deepEqual(updates, [
+      { summary: "Booked a demo." },
+      { outcome: "callback_requested" },
+      { summary: "Booked a demo." },
+    ]);
+    assert.equal(outcomeEvents.length, 1);
+  });
+
+  it("publishes each genuine outcome transition with a distinct revision key", async () => {
+    const state = { insightOutcome: "callback_requested" };
+    const { service, outcomeEvents } = build(state);
+
+    await service.applyInsightCallback(AGENT_ID, TOKEN, {
+      conversation_id: "conv-1",
+    });
+    state.insightOutcome = "not_interested";
+    await service.applyInsightCallback(AGENT_ID, TOKEN, {
+      conversation_id: "conv-1",
+    });
+
+    assert.deepEqual(
+      outcomeEvents.map((event) => ({
+        outcome: (event.data as Record<string, unknown>).outcome,
+        dedupeKey: event.dedupeKey,
+      })),
+      [
+        {
+          outcome: "callback_requested",
+          dedupeKey:
+            "telephony-1:outcome:callback_requested:2026-09-07T14:05:00.000Z",
+        },
+        {
+          outcome: "not_interested",
+          dedupeKey:
+            "telephony-1:outcome:not_interested:2026-09-07T14:05:01.000Z",
+        },
+      ],
+    );
+  });
+
+  it("still refreshes other analysis fields when the outcome is unchanged", async () => {
+    const { service, updates, outcomeEvents } = build({
+      agentCall: {
+        ...AGENT_CALL,
+        outcome: "callback_requested",
+      },
+      insightOutcome: "callback_requested",
+    });
+
+    await service.applyInsightCallback(AGENT_ID, TOKEN, {
+      conversation_id: "conv-1",
+    });
+
+    assert.deepEqual(updates, [{ summary: "Booked a demo." }]);
+    assert.deepEqual(outcomeEvents, []);
   });
 
   it("writes nothing when the token does not verify", async () => {
@@ -299,10 +395,8 @@ describe("VoiceAgentResultService analysis callback", () => {
     assert.equal(attached.length, 1);
     assert.equal(attached[0]!.callSessionId, "cs-1");
     // And the analysis lands on the call, which is the point of all of it.
-    assert.deepEqual(updates[1], {
-      summary: "Booked a demo.",
-      outcome: "appointment_booked",
-    });
+    assert.deepEqual(updates[1], { summary: "Booked a demo." });
+    assert.deepEqual(updates[2], { outcome: "appointment_booked" });
   });
 });
 

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.spec.ts
@@ -55,6 +55,7 @@ function build(
   const transcripts: Array<Record<string, unknown>> = [];
   const attached: Array<Record<string, unknown>> = [];
   const terminalEvents: Array<Record<string, unknown>> = [];
+  const outcomeEvents: Array<Record<string, unknown>> = [];
   const completions: Array<Record<string, unknown>> = [];
 
   const service = new VoiceAgentResultService(
@@ -64,7 +65,12 @@ function build(
       findByCallControlId: async () => over.byControlId ?? null,
       update: async (_id: string, data: Record<string, unknown>) => {
         updates.push(data);
-        return AGENT_CALL;
+        return {
+          ...AGENT_CALL,
+          ...data,
+          metadata: { external_id: "customer-42" },
+          updatedAt: new Date("2026-09-07T14:05:00.000Z"),
+        };
       },
     } as never,
     {
@@ -151,6 +157,9 @@ function build(
       enqueueCallTerminal: async (call: Record<string, unknown>) => {
         terminalEvents.push(call);
       },
+      enqueue: async (event: Record<string, unknown>) => {
+        outcomeEvents.push(event);
+      },
     } as never,
   );
 
@@ -160,13 +169,14 @@ function build(
     transcripts,
     attached,
     terminalEvents,
+    outcomeEvents,
     completions,
   };
 }
 
 describe("VoiceAgentResultService analysis callback", () => {
   it("writes the analysis onto the call it belongs to", async () => {
-    const { service, updates } = build();
+    const { service, updates, outcomeEvents } = build();
 
     const accepted = await service.applyInsightCallback(AGENT_ID, TOKEN, {
       conversation_id: "conv-1",
@@ -175,6 +185,22 @@ describe("VoiceAgentResultService analysis callback", () => {
     assert.equal(accepted, true);
     assert.deepEqual(updates, [
       { summary: "Booked a demo.", outcome: "appointment_booked" },
+    ]);
+    assert.deepEqual(outcomeEvents, [
+      {
+        ctx: { userId: "user-1", organizationId: "org-1" },
+        eventEnum: "call_outcome_updated",
+        subjectId: "telephony-1",
+        data: {
+          callId: "telephony-1",
+          agentCallId: "call-1",
+          agentId: "agent-1",
+          outcome: "appointment_booked",
+          metadata: { external_id: "customer-42" },
+          updatedAt: "2026-09-07T14:05:00.000Z",
+        },
+        occurredAt: new Date("2026-09-07T14:05:00.000Z"),
+      },
     ]);
   });
 

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.ts
@@ -315,13 +315,27 @@ export class VoiceAgentResultService {
     }
 
     if (Object.keys(update).length === 0) return;
-    const updated = await this.agentCalls.update(agentCall.id, update);
+
+    // The non-outcome fields may legitimately be refreshed by a replay. The
+    // outcome itself is a transition: claim it atomically so concurrent copies
+    // of the same provider callback cannot publish it twice.
+    const { outcome, ...otherUpdates } = update;
+    if (Object.keys(otherUpdates).length > 0) {
+      await this.agentCalls.update(agentCall.id, otherUpdates);
+    }
+    if (!outcome) return;
+
+    const updated = await this.agentCalls.updateOutcomeIfChanged(
+      agentCall.id,
+      outcome,
+    );
+    if (!updated) return;
 
     // Agent analyses do not pass through CallService.setOutcome: their outcome
     // vocabulary is deliberately wider than the human dialer's CallOutcome.
     // Publish the normalized call event here, after the analysis is durable.
-    // Replayed insight callbacks are harmless because the outbound outbox
-    // deduplicates per integration, event and underlying Call.
+    // `updatedAt` is this persisted transition's revision. It keeps an outbox
+    // replay idempotent without collapsing a later, genuine outcome change.
     if (updated.callId && updated.outcome) {
       await this.customIntegrationOutbound.enqueue({
         ctx: {
@@ -330,6 +344,7 @@ export class VoiceAgentResultService {
         },
         eventEnum: "call_outcome_updated",
         subjectId: updated.callId,
+        dedupeKey: `${updated.callId}:outcome:${updated.outcome}:${updated.updatedAt.toISOString()}`,
         data: buildVoiceAgentCallOutcomeData(updated),
         occurredAt: updated.updatedAt,
       });

--- a/packages/services/src/services/voice-agents/voice-agent-result.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent-result.service.ts
@@ -19,6 +19,7 @@ import {
 } from "@ringee/platform";
 import { TranscriptionService } from "../transcription/transcription.service";
 import { CustomIntegrationOutboundService } from "../custom-integrations/custom-integration-outbound.service";
+import { buildVoiceAgentCallOutcomeData } from "../custom-integrations/custom-integration-event-builders";
 import { VoiceAgentService } from "./voice-agent.service";
 import type { VoiceAgentAnalysisSettings } from "./voice-agent.types";
 
@@ -314,7 +315,25 @@ export class VoiceAgentResultService {
     }
 
     if (Object.keys(update).length === 0) return;
-    await this.agentCalls.update(agentCall.id, update);
+    const updated = await this.agentCalls.update(agentCall.id, update);
+
+    // Agent analyses do not pass through CallService.setOutcome: their outcome
+    // vocabulary is deliberately wider than the human dialer's CallOutcome.
+    // Publish the normalized call event here, after the analysis is durable.
+    // Replayed insight callbacks are harmless because the outbound outbox
+    // deduplicates per integration, event and underlying Call.
+    if (updated.callId && updated.outcome) {
+      await this.customIntegrationOutbound.enqueue({
+        ctx: {
+          userId: updated.userId,
+          organizationId: updated.organizationId,
+        },
+        eventEnum: "call_outcome_updated",
+        subjectId: updated.callId,
+        data: buildVoiceAgentCallOutcomeData(updated),
+        occurredAt: updated.updatedAt,
+      });
+    }
   }
 
   /**

--- a/packages/services/src/services/voice-agents/voice-agent.service.spec.ts
+++ b/packages/services/src/services/voice-agents/voice-agent.service.spec.ts
@@ -17,7 +17,7 @@ function supportToolUrl(): string {
   return `${base}/api/ai-voice-agents/tools/agent-1/request-human-support`;
 }
 
-function build(currentWebhookUrls: string[]) {
+function build(currentWebhookUrls: string[], runtimeContextConfigured = true) {
   const syncs: string[] = [];
   const service = new VoiceAgentService(
     {} as never,
@@ -51,6 +51,7 @@ function build(currentWebhookUrls: string[]) {
         assistantId: "assistant-1",
         callingAppId: "calling-app-1",
         unauthenticatedWebCallsEnabled: false,
+        runtimeContextConfigured,
         toolWebhookUrls: currentWebhookUrls,
       }),
     } as never,
@@ -90,6 +91,14 @@ describe("VoiceAgentService tool delivery", () => {
     await service.ensureToolEndpoints(CTX, AGENT as never);
 
     assert.deepEqual(syncs, []);
+  });
+
+  it("re-syncs an older assistant whose prompt has no call-time clock", async () => {
+    const { service, syncs } = build([supportToolUrl()], false);
+
+    await service.ensureToolEndpoints(CTX, AGENT as never);
+
+    assert.deepEqual(syncs, ["agent-1"]);
   });
 
   it("re-syncs webhook tools that still point to an old backend", async () => {

--- a/packages/services/src/services/voice-agents/voice-agent.service.ts
+++ b/packages/services/src/services/voice-agents/voice-agent.service.ts
@@ -44,6 +44,7 @@ import { CompanyProfileService } from "./company-profile.service";
 import {
   composeVoiceAgentInstructions,
   readVoiceAgentConversationSettings,
+  voiceAgentRuntimeVariables,
 } from "./voice-agent-conversation";
 import {
   DEFAULT_ANALYSIS_SETTINGS,
@@ -1014,8 +1015,9 @@ export class VoiceAgentService {
   }
 
   /**
-   * Makes sure the agent has the current set of webhook tools and that all of
-   * them still call this backend, before it dials.
+   * Makes sure the agent has the current set of webhook tools, that all of them
+   * still call this backend, and that its prompt consumes Ringee's call-time
+   * clock before it dials.
    *
    * Tool definitions are written when the agent is saved and otherwise outlive
    * the code that created them. A new required tool (such as human support) is
@@ -1052,12 +1054,13 @@ export class VoiceAgentService {
       .sort();
     const actual = [...assistant.toolWebhookUrls].sort();
     const matches =
+      assistant.runtimeContextConfigured &&
       actual.length === expected.length &&
       actual.every((url, index) => url === expected[index]);
     if (matches) return;
 
     this.logger.warn(
-      `Agent ${agent.id} has stale or missing webhook tools; re-syncing against its current blueprint`,
+      `Agent ${agent.id} has stale tools or runtime context; re-syncing against its current blueprint`,
     );
     await this.syncToProvider(ctx, agent.id);
   }
@@ -1222,6 +1225,7 @@ export class VoiceAgentService {
       company_name: company.name,
       company_description: company.description,
       company_website: company.website,
+      ...voiceAgentRuntimeVariables(agent.timezone),
     };
     for (const variable of blueprint.variables) {
       variables[variable.key] = "";

--- a/packages/services/src/services/voice-agents/voice-agent.types.ts
+++ b/packages/services/src/services/voice-agents/voice-agent.types.ts
@@ -223,4 +223,6 @@ export const RINGEE_DYNAMIC_VARIABLES = [
   "company_name",
   "company_description",
   "company_website",
+  "agent_timezone",
+  "current_datetime",
 ] as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour changes

- Every voice-agent dial now overrides provider variables with `agent_timezone` and `current_datetime`.
- Invalid or missing time zones use UTC.
- Browser test sessions receive the same runtime context.
- Provider assistants without both runtime placeholders are re-synced.
- AI voice-agent analysis now publishes `call.outcome.updated`.
- Recording processing now publishes `recording.ready` with the completed recording ID and public URL.
- Custom Integration delivery remains subscription-filtered and outbox-backed.

## Architectural impact

- `@ringee/services` now owns runtime clock generation and AI voice-agent outcome payload construction.
- `@ringee/platform` exposes `runtimeContextConfigured` across the Telnyx adapter boundary.
- The outcome webhook payload preserves the agent outcome vocabulary and adds `agentCallId`, `agentId`, and `metadata`.
- `RINGEE_DYNAMIC_VARIABLES` now defines `agent_timezone` and `current_datetime` as always-supplied variables.

## Risk areas

- Call lifecycle: outcome and recording events depend on updated call and recording rows. Review enqueue timing, retry behavior, and duplicate suppression.
- Custom Integration public contract: validate the new `call.outcome.updated` fields and agent-specific outcome shape against existing consumers.
- Provider synchronization: assistants with legacy prompts are re-synced on the next tool-endpoint check. Confirm this does not overwrite provider-side changes unexpectedly.
- Time-zone handling: verify DST formatting, invalid IANA zones, and consistency between outbound dials and browser sessions.

## Review first

- `packages/services/src/services/voice-agents/voice-agent-call.service.ts`
- `packages/services/src/services/voice-agents/voice-agent-conversation.ts`
- `packages/services/src/services/voice-agents/voice-agent.service.ts`
- `packages/services/src/services/voice-agents/voice-agent-result.service.ts`
- `packages/services/src/services/custom-integrations/custom-integration-event-builders.ts`
- `packages/services/src/services/recording-processing.service.ts`
- `packages/platform/src/custom-integrations/event-spec.ts`

Documentation changes only record the new runtime-context and webhook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->