### PR TITLE
Feat/send owners all events

### DIFF
--- a/apps/frontend/src/features/integrations/components/custom-integration-events-docs.tsx
+++ b/apps/frontend/src/features/integrations/components/custom-integration-events-docs.tsx
@@ -9,6 +9,8 @@ import {
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
 import { ArrowDownLeft, ArrowUpRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import type { ReactNode } from 'react';
 import { useCustomIntegrationEventSpecs } from '../hooks/use-custom-integrations';
 import type { CustomIntegrationEventSpec } from '../types/custom-integrations';
 
@@ -39,6 +41,7 @@ export function CustomIntegrationEventsDocs() {
         title='Outbound events'
         subtitle='Ringee sends these to your outbound webhook URL when you subscribe to them.'
         items={outbound}
+        intro={<SharedOutboundFields />}
       />
     </div>
   );
@@ -47,11 +50,14 @@ export function CustomIntegrationEventsDocs() {
 function Section({
   title,
   subtitle,
-  items
+  items,
+  intro
 }: {
   title: string;
   subtitle: string;
   items: CustomIntegrationEventSpec[];
+  /** Rendered above the event list, for what every event in it shares. */
+  intro?: ReactNode;
 }) {
   return (
     <section className='space-y-3'>
@@ -61,6 +67,7 @@ function Section({
         </h3>
         <p className='text-muted-foreground mt-1 text-xs'>{subtitle}</p>
       </div>
+      {intro}
       <Accordion type='multiple' className='space-y-2'>
         {items.map((spec) => (
           <AccordionItem
@@ -84,6 +91,39 @@ function Section({
         ))}
       </Accordion>
     </section>
+  );
+}
+
+/**
+ * `data.user`, `data.agent` and `data.externalId` are resolved centrally for
+ * every outbound event, so they are documented once above the list rather than
+ * repeated inside each one.
+ */
+function SharedOutboundFields() {
+  const t = useTranslations('integrations.custom.detail.docs');
+  return (
+    <div className='text-xs'>
+      <FieldTable
+        title={t('sharedFields.title')}
+        rows={[
+          {
+            name: 'data.user',
+            type: 'object',
+            description: t('sharedFields.user')
+          },
+          {
+            name: 'data.agent',
+            type: 'object',
+            description: t('sharedFields.agent')
+          },
+          {
+            name: 'data.externalId',
+            type: 'string',
+            description: t('sharedFields.externalId')
+          }
+        ]}
+      />
+    </div>
   );
 }
 

--- a/apps/frontend/src/i18n/locales/de/integrations.json
+++ b/apps/frontend/src/i18n/locales/de/integrations.json
@@ -110,6 +110,14 @@
         "attempts": "Versuche={count}",
         "refresh": "Aktualisieren",
         "empty": "Noch keine Events."
+      },
+      "docs": {
+        "sharedFields": {
+          "title": "In jedem ausgehenden Event enthalten",
+          "user": "Der Ringee-Benutzer, zu dem das Event gehört: ID, primäre E-Mail-Adresse und vollständiger Name.",
+          "agent": "Der KI-Sprachagent, der das Event ausgelöst hat: ID und Name. Fehlt, wenn eine Person den Anruf getätigt hat.",
+          "externalId": "Ihre eigene Korrelations-ID, sofern der zugrunde liegende KI-Sprachagenten-Anruf sie in seinen Metadaten mitführte."
+        }
       }
     },
     "card": {

--- a/apps/frontend/src/i18n/locales/de/integrations.json
+++ b/apps/frontend/src/i18n/locales/de/integrations.json
@@ -113,8 +113,8 @@
       },
       "docs": {
         "sharedFields": {
-          "title": "In jedem ausgehenden Event enthalten",
-          "user": "Der Ringee-Benutzer, zu dem das Event gehört: ID, primäre E-Mail-Adresse und vollständiger Name.",
+          "title": "Für jedes ausgehende Event",
+          "user": "Der Ringee-Benutzer, zu dem das Event gehört: ID, primäre E-Mail-Adresse und vollständiger Name. Entfällt nur, wenn dieser Benutzer nicht mehr aufgelöst werden kann.",
           "agent": "Der KI-Sprachagent, der das Event ausgelöst hat: ID und Name. Fehlt, wenn eine Person den Anruf getätigt hat.",
           "externalId": "Ihre eigene Korrelations-ID, sofern der zugrunde liegende KI-Sprachagenten-Anruf sie in seinen Metadaten mitführte."
         }

--- a/apps/frontend/src/i18n/locales/en/integrations.json
+++ b/apps/frontend/src/i18n/locales/en/integrations.json
@@ -110,6 +110,14 @@
         "attempts": "attempts={count}",
         "refresh": "Refresh",
         "empty": "No events yet."
+      },
+      "docs": {
+        "sharedFields": {
+          "title": "Included in every outbound event",
+          "user": "The Ringee user the event belongs to: id, primary email and full name.",
+          "agent": "The AI voice agent that produced the event: id and name. Absent when a person placed the call.",
+          "externalId": "Your own correlation id, when the AI voice-agent call behind the event carried one in its metadata."
+        }
       }
     },
     "card": {

--- a/apps/frontend/src/i18n/locales/en/integrations.json
+++ b/apps/frontend/src/i18n/locales/en/integrations.json
@@ -113,8 +113,8 @@
       },
       "docs": {
         "sharedFields": {
-          "title": "Included in every outbound event",
-          "user": "The Ringee user the event belongs to: id, primary email and full name.",
+          "title": "Shared by every outbound event",
+          "user": "The Ringee user the event belongs to: id, primary email and full name. Omitted only when that user can no longer be resolved.",
           "agent": "The AI voice agent that produced the event: id and name. Absent when a person placed the call.",
           "externalId": "Your own correlation id, when the AI voice-agent call behind the event carried one in its metadata."
         }

--- a/apps/frontend/src/i18n/locales/es/integrations.json
+++ b/apps/frontend/src/i18n/locales/es/integrations.json
@@ -110,6 +110,14 @@
         "attempts": "intentos={count}",
         "refresh": "Actualizar",
         "empty": "Aún no hay eventos."
+      },
+      "docs": {
+        "sharedFields": {
+          "title": "Incluido en todos los eventos salientes",
+          "user": "El usuario de Ringee al que pertenece el evento: id, email principal y nombre completo.",
+          "agent": "El agente de voz con IA que generó el evento: id y nombre. No aparece cuando la llamada la hizo una persona.",
+          "externalId": "Tu propio id de correlación, cuando la llamada del agente de voz con IA lo traía en sus metadatos."
+        }
       }
     },
     "card": {

--- a/apps/frontend/src/i18n/locales/es/integrations.json
+++ b/apps/frontend/src/i18n/locales/es/integrations.json
@@ -113,8 +113,8 @@
       },
       "docs": {
         "sharedFields": {
-          "title": "Incluido en todos los eventos salientes",
-          "user": "El usuario de Ringee al que pertenece el evento: id, email principal y nombre completo.",
+          "title": "Común a todos los eventos salientes",
+          "user": "El usuario de Ringee al que pertenece el evento: id, email principal y nombre completo. Solo se omite si ese usuario ya no se puede resolver.",
           "agent": "El agente de voz con IA que generó el evento: id y nombre. No aparece cuando la llamada la hizo una persona.",
           "externalId": "Tu propio id de correlación, cuando la llamada del agente de voz con IA lo traía en sus metadatos."
         }

--- a/apps/frontend/src/i18n/locales/fr/integrations.json
+++ b/apps/frontend/src/i18n/locales/fr/integrations.json
@@ -113,8 +113,8 @@
       },
       "docs": {
         "sharedFields": {
-          "title": "Inclus dans chaque événement sortant",
-          "user": "L'utilisateur Ringee auquel appartient l'événement : id, e-mail principal et nom complet.",
+          "title": "Commun à tous les événements sortants",
+          "user": "L'utilisateur Ringee auquel appartient l'événement : id, e-mail principal et nom complet. Omis uniquement lorsque cet utilisateur ne peut plus être résolu.",
           "agent": "L'agent vocal IA à l'origine de l'événement : id et nom. Absent lorsque l'appel a été passé par une personne.",
           "externalId": "Votre propre identifiant de corrélation, lorsque l'appel de l'agent vocal IA le portait dans ses métadonnées."
         }

--- a/apps/frontend/src/i18n/locales/fr/integrations.json
+++ b/apps/frontend/src/i18n/locales/fr/integrations.json
@@ -110,6 +110,14 @@
         "attempts": "tentatives={count}",
         "refresh": "Actualiser",
         "empty": "Aucun événement pour le moment."
+      },
+      "docs": {
+        "sharedFields": {
+          "title": "Inclus dans chaque événement sortant",
+          "user": "L'utilisateur Ringee auquel appartient l'événement : id, e-mail principal et nom complet.",
+          "agent": "L'agent vocal IA à l'origine de l'événement : id et nom. Absent lorsque l'appel a été passé par une personne.",
+          "externalId": "Votre propre identifiant de corrélation, lorsque l'appel de l'agent vocal IA le portait dans ses métadonnées."
+        }
       }
     },
     "card": {

--- a/apps/frontend/src/i18n/locales/it/integrations.json
+++ b/apps/frontend/src/i18n/locales/it/integrations.json
@@ -113,8 +113,8 @@
       },
       "docs": {
         "sharedFields": {
-          "title": "Incluso in ogni evento in uscita",
-          "user": "L'utente Ringee a cui appartiene l'evento: id, email principale e nome completo.",
+          "title": "Comune a tutti gli eventi in uscita",
+          "user": "L'utente Ringee a cui appartiene l'evento: id, email principale e nome completo. Omesso solo quando quell'utente non è più risolvibile.",
           "agent": "L'agente vocale IA che ha prodotto l'evento: id e nome. Assente quando la chiamata è stata fatta da una persona.",
           "externalId": "Il tuo id di correlazione, quando la chiamata dell'agente vocale IA lo portava nei suoi metadati."
         }

--- a/apps/frontend/src/i18n/locales/it/integrations.json
+++ b/apps/frontend/src/i18n/locales/it/integrations.json
@@ -110,6 +110,14 @@
         "attempts": "tentativi={count}",
         "refresh": "Aggiorna",
         "empty": "Ancora nessun evento."
+      },
+      "docs": {
+        "sharedFields": {
+          "title": "Incluso in ogni evento in uscita",
+          "user": "L'utente Ringee a cui appartiene l'evento: id, email principale e nome completo.",
+          "agent": "L'agente vocale IA che ha prodotto l'evento: id e nome. Assente quando la chiamata è stata fatta da una persona.",
+          "externalId": "Il tuo id di correlazione, quando la chiamata dell'agente vocale IA lo portava nei suoi metadati."
+        }
       }
     },
     "card": {

--- a/apps/frontend/src/i18n/locales/nl/integrations.json
+++ b/apps/frontend/src/i18n/locales/nl/integrations.json
@@ -113,8 +113,8 @@
       },
       "docs": {
         "sharedFields": {
-          "title": "In elk uitgaand event aanwezig",
-          "user": "De Ringee-gebruiker bij wie het event hoort: id, primair e-mailadres en volledige naam.",
+          "title": "Geldt voor elk uitgaand event",
+          "user": "De Ringee-gebruiker bij wie het event hoort: id, primair e-mailadres en volledige naam. Ontbreekt alleen wanneer die gebruiker niet meer kan worden opgezocht.",
           "agent": "De AI-spraakagent die het event heeft veroorzaakt: id en naam. Ontbreekt wanneer een persoon het gesprek voerde.",
           "externalId": "Je eigen correlatie-id, wanneer het AI-spraakagentgesprek achter het event die in de metadata meedroeg."
         }

--- a/apps/frontend/src/i18n/locales/nl/integrations.json
+++ b/apps/frontend/src/i18n/locales/nl/integrations.json
@@ -110,6 +110,14 @@
         "attempts": "pogingen={count}",
         "refresh": "Vernieuwen",
         "empty": "Nog geen events."
+      },
+      "docs": {
+        "sharedFields": {
+          "title": "In elk uitgaand event aanwezig",
+          "user": "De Ringee-gebruiker bij wie het event hoort: id, primair e-mailadres en volledige naam.",
+          "agent": "De AI-spraakagent die het event heeft veroorzaakt: id en naam. Ontbreekt wanneer een persoon het gesprek voerde.",
+          "externalId": "Je eigen correlatie-id, wanneer het AI-spraakagentgesprek achter het event die in de metadata meedroeg."
+        }
       }
     },
     "card": {

--- a/apps/frontend/src/i18n/locales/pt/integrations.json
+++ b/apps/frontend/src/i18n/locales/pt/integrations.json
@@ -113,8 +113,8 @@
       },
       "docs": {
         "sharedFields": {
-          "title": "Incluído em todos os eventos de saída",
-          "user": "O utilizador Ringee a quem o evento pertence: id, email principal e nome completo.",
+          "title": "Comum a todos os eventos de saída",
+          "user": "O utilizador Ringee a quem o evento pertence: id, email principal e nome completo. Só é omitido quando esse utilizador já não pode ser resolvido.",
           "agent": "O agente de voz com IA que produziu o evento: id e nome. Ausente quando a chamada foi feita por uma pessoa.",
           "externalId": "O seu próprio id de correlação, quando a chamada do agente de voz com IA o trazia nos seus metadados."
         }

--- a/apps/frontend/src/i18n/locales/pt/integrations.json
+++ b/apps/frontend/src/i18n/locales/pt/integrations.json
@@ -110,6 +110,14 @@
         "attempts": "tentativas={count}",
         "refresh": "Atualizar",
         "empty": "Ainda não há eventos."
+      },
+      "docs": {
+        "sharedFields": {
+          "title": "Incluído em todos os eventos de saída",
+          "user": "O utilizador Ringee a quem o evento pertence: id, email principal e nome completo.",
+          "agent": "O agente de voz com IA que produziu o evento: id e nome. Ausente quando a chamada foi feita por uma pessoa.",
+          "externalId": "O seu próprio id de correlação, quando a chamada do agente de voz com IA o trazia nos seus metadados."
+        }
       }
     },
     "card": {

--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -177,12 +177,14 @@ The generic, customer-facing integration surface.
   tab in the dashboard. Changing it changes public docs and live contracts.
 - Envelope: `{ event, eventId, occurredAt, data }`, plus `workspaceId` and
   `integrationId` on outbound.
-- Every outbound event names its actors, resolved centrally in
+- Outbound events name their actors, resolved centrally in
   `CustomIntegrationOutboundService` rather than by each producer: `data.user`
   (`{ id, email, fullName }`, the primary email) is the workspace user the event
   belongs to, and `data.agent` (`{ id, name }`) is the AI voice agent when one
   produced it. Both are ownership-checked, and a producer that already set
-  either keeps its own value.
+  either keeps its own value. Each lookup is best-effort and isolated: one that
+  fails leaves its field off the payload rather than dropping the event, so
+  `data.user` is absent when that user can no longer be resolved.
 - AI voice-agent calls use the same fan-out: terminal status publishes
   `call.completed`/`call.failed`, post-call analysis publishes
   `call.outcome.updated`, confirmed callbacks and bookings publish

--- a/docs/engineering/INTEGRATIONS.md
+++ b/docs/engineering/INTEGRATIONS.md
@@ -177,6 +177,12 @@ The generic, customer-facing integration surface.
   tab in the dashboard. Changing it changes public docs and live contracts.
 - Envelope: `{ event, eventId, occurredAt, data }`, plus `workspaceId` and
   `integrationId` on outbound.
+- Every outbound event names its actors, resolved centrally in
+  `CustomIntegrationOutboundService` rather than by each producer: `data.user`
+  (`{ id, email, fullName }`, the primary email) is the workspace user the event
+  belongs to, and `data.agent` (`{ id, name }`) is the AI voice agent when one
+  produced it. Both are ownership-checked, and a producer that already set
+  either keeps its own value.
 - AI voice-agent calls use the same fan-out: terminal status publishes
   `call.completed`/`call.failed`, post-call analysis publishes
   `call.outcome.updated`, confirmed callbacks and bookings publish

--- a/packages/database/src/database/repositories/ai-voice-agent.repository.ts
+++ b/packages/database/src/database/repositories/ai-voice-agent.repository.ts
@@ -60,6 +60,22 @@ export class AiVoiceAgentRepository {
   }
 
   /**
+   * Workspace-checked name lookup for event payloads and other read-only
+   * references. Same ownership rule as `findByIdForOwner`, without loading the
+   * knowledge sources a reference never needs. A soft-deleted agent still
+   * resolves: an event about a past call must name the agent that placed it.
+   */
+  findRefForOwner(
+    ctx: OwnershipContext,
+    id: string,
+  ): Promise<{ id: string; name: string } | null> {
+    return this.prisma.aiVoiceAgent.findFirst({
+      where: { id, ...buildOwnershipFilter(ctx) },
+      select: { id: true, name: true },
+    });
+  }
+
+  /**
    * Lookup by the provider's assistant id, used when a provider callback names
    * an assistant. The caller still has to prove the workspace matches.
    */

--- a/packages/platform/src/custom-integrations/event-spec.ts
+++ b/packages/platform/src/custom-integrations/event-spec.ts
@@ -32,6 +32,10 @@ const ENVELOPE_NOTE =
   "All events share an envelope: { event, eventId, occurredAt, data }. " +
   "Outbound events also include workspaceId and integrationId.";
 
+const ACTOR_NOTE =
+  "Every outbound event carries data.user — the Ringee user it belongs to, with their primary email — " +
+  "and data.agent { id, name } when an AI voice agent produced it.";
+
 // ─── Inbound events ────────────────────────────────────────────────────────
 
 export const INBOUND_EVENT_NAMES = [
@@ -294,7 +298,14 @@ const ENTITY_COMPANY = {
 const ENTITY_USER = {
   name: "data.user",
   type: "object",
-  description: "Ringee user reference: { id, email?, fullName? }",
+  description:
+    "The Ringee user responsible for the event: { id, email (primary), fullName }. Present on every outbound event.",
+};
+const ENTITY_VOICE_AGENT = {
+  name: "data.agent",
+  type: "object",
+  description:
+    "The AI voice agent behind the event: { id, name }. Present on every event produced by an AI voice-agent call, and absent when a human placed it.",
 };
 const VOICE_AGENT_EXTERNAL_ID = {
   name: "data.externalId",
@@ -339,10 +350,11 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       VOICE_AGENT_EXTERNAL_ID,
       ENTITY_CONTACT,
       ENTITY_COMPANY,
-      ENTITY_USER,
       {
         name: "data.durationSeconds",
         type: "number",
@@ -373,6 +385,11 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       data: {
         callId: "f3b1…",
         externalId: "crm-123",
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
         fromNumber: "+14155550100",
         toNumber: "+14155550123",
         status: "completed",
@@ -388,6 +405,7 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     },
     notes: [
+      ACTOR_NOTE,
       ENVELOPE_NOTE,
       "This event does NOT include the outcome. Outcomes are sent separately via call.outcome.updated.",
     ],
@@ -414,6 +432,8 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       VOICE_AGENT_EXTERNAL_ID,
       {
         name: "data.call",
@@ -428,7 +448,6 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
       ENTITY_CONTACT,
       ENTITY_COMPANY,
-      ENTITY_USER,
       {
         name: "data.agentCallId",
         type: "string",
@@ -466,12 +485,19 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
           durationSeconds: 142,
         },
         externalId: "crm-123",
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
+        agent: { id: "va_…", name: "Sofia" },
         outcome: "meeting_booked",
         outcomeNote: "Demo scheduled for next Tuesday",
         updatedAt: "2026-05-23T14:50:00.000Z",
       },
     },
     notes: [
+      ACTOR_NOTE,
       "If neither a user nor an AI voice agent records an outcome, this event is not sent.",
       "`data.call` carries the telephony detail so consumers do not have to correlate with call.completed; it is omitted only when the call row can no longer be resolved.",
       "When the outcome is meeting_booked, a separate meeting.created event is also fired.",
@@ -494,6 +520,8 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       {
         name: "data.createdBy",
         type: "object",
@@ -513,11 +541,16 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
           externalId: "ext_contact_42",
           phoneNumber: "+14155550123",
         },
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
         content: "Prefers email follow-up.",
         createdAt: "2026-05-23T15:00:00.000Z",
       },
     },
-    notes: [ENVELOPE_NOTE],
+    notes: [ACTOR_NOTE, ENVELOPE_NOTE],
   },
   {
     name: "callback.created",
@@ -545,6 +578,8 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       {
         name: "data.callId",
         type: "string",
@@ -552,7 +587,6 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
       VOICE_AGENT_EXTERNAL_ID,
       { name: "data.note", type: "string", description: "Free-text note." },
-      ENTITY_USER,
     ],
     examplePayload: {
       event: "callback.created",
@@ -569,12 +603,18 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
           externalId: "ext_contact_42",
           phoneNumber: "+14155550123",
         },
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
+        agent: { id: "va_…", name: "Sofia" },
         scheduledAt: "2026-05-24T10:00:00.000Z",
         status: "scheduled",
         createdAt: "2026-05-23T15:05:00.000Z",
       },
     },
-    notes: [ENVELOPE_NOTE],
+    notes: [ACTOR_NOTE, ENVELOPE_NOTE],
   },
   {
     name: "meeting.created",
@@ -602,6 +642,8 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       {
         name: "data.callId",
         type: "string",
@@ -625,7 +667,6 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
         type: "string",
         description: "Calendar provider event id, when synced.",
       },
-      ENTITY_USER,
     ],
     examplePayload: {
       event: "meeting.created",
@@ -642,6 +683,12 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
           externalId: "ext_contact_42",
           phoneNumber: "+14155550123",
         },
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
+        agent: { id: "va_…", name: "Sofia" },
         scheduledAt: "2026-05-30T16:00:00.000Z",
         status: "scheduled",
         title: "Demo with Babbage Engines",
@@ -649,7 +696,7 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
         createdAt: "2026-05-23T15:10:00.000Z",
       },
     },
-    notes: [ENVELOPE_NOTE],
+    notes: [ACTOR_NOTE, ENVELOPE_NOTE],
   },
   {
     name: "recording.ready",
@@ -676,6 +723,8 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       VOICE_AGENT_EXTERNAL_ID,
       {
         name: "data.format",
@@ -703,6 +752,11 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
         recordingId: "r_…",
         callId: "f3b1…",
         externalId: "crm-123",
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
         url: "https://recordings.ringee.app/...",
         format: "mp3",
         durationSec: 142,
@@ -710,6 +764,7 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     },
     notes: [
+      ACTOR_NOTE,
       "Do not assume recording.ready arrives immediately after call.completed.",
     ],
   },
@@ -737,10 +792,11 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       VOICE_AGENT_EXTERNAL_ID,
       ENTITY_CONTACT,
       ENTITY_COMPANY,
-      ENTITY_USER,
       {
         name: "data.reason",
         type: "string",
@@ -755,12 +811,20 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       integrationId: "ci_…",
       data: {
         callId: "c_…",
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
         fromNumber: "+14155550123",
         toNumber: "+14155550100",
         occurredAt: "2026-05-23T15:20:00.000Z",
       },
     },
-    notes: ["Optional event — opt in via the outbound event selector."],
+    notes: [
+      ACTOR_NOTE,
+      "Optional event — opt in via the outbound event selector.",
+    ],
   },
   {
     name: "call.failed",
@@ -787,10 +851,11 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       VOICE_AGENT_EXTERNAL_ID,
       ENTITY_CONTACT,
       ENTITY_COMPANY,
-      ENTITY_USER,
       {
         name: "data.errorCode",
         type: "string",
@@ -811,13 +876,21 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       data: {
         callId: "c_…",
         externalId: "crm-123",
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
         fromNumber: "+14155550100",
         toNumber: "+14155550123",
         occurredAt: "2026-05-23T15:25:00.000Z",
         errorCode: "USER_BUSY",
       },
     },
-    notes: ["Optional event — opt in via the outbound event selector."],
+    notes: [
+      ACTOR_NOTE,
+      "Optional event — opt in via the outbound event selector.",
+    ],
   },
   {
     name: "dnc.created",
@@ -837,6 +910,8 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       },
     ],
     optionalFields: [
+      ENTITY_USER,
+      ENTITY_VOICE_AGENT,
       ENTITY_CONTACT,
       { name: "data.reason", type: "string", description: "Free-text reason." },
       {
@@ -844,7 +919,6 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
         type: "string",
         description: "Channel that triggered the addition.",
       },
-      ENTITY_USER,
     ],
     examplePayload: {
       event: "dnc.created",
@@ -854,10 +928,18 @@ export const OUTBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       integrationId: "ci_…",
       data: {
         phoneNumber: "+14155550123",
+        user: {
+          id: "usr_…",
+          email: "ada@babbage.example.com",
+          fullName: "Ada Lovelace",
+        },
         createdAt: "2026-05-23T15:30:00.000Z",
       },
     },
-    notes: ["Optional event — opt in via the outbound event selector."],
+    notes: [
+      ACTOR_NOTE,
+      "Optional event — opt in via the outbound event selector.",
+    ],
   },
 ];
 

--- a/packages/platform/src/custom-integrations/event-spec.ts
+++ b/packages/platform/src/custom-integrations/event-spec.ts
@@ -33,8 +33,8 @@ const ENVELOPE_NOTE =
   "Outbound events also include workspaceId and integrationId.";
 
 const ACTOR_NOTE =
-  "Every outbound event carries data.user — the Ringee user it belongs to, with their primary email — " +
-  "and data.agent { id, name } when an AI voice agent produced it.";
+  "Outbound events carry data.user — the Ringee user the event belongs to, with their primary email, " +
+  "omitted only when that user can no longer be resolved — and data.agent { id, name } when an AI voice agent produced it.";
 
 // ─── Inbound events ────────────────────────────────────────────────────────
 
@@ -299,7 +299,7 @@ const ENTITY_USER = {
   name: "data.user",
   type: "object",
   description:
-    "The Ringee user responsible for the event: { id, email (primary), fullName }. Present on every outbound event.",
+    "The Ringee user responsible for the event: { id, email (primary), fullName }. Sent on every outbound event whose user can still be resolved.",
 };
 const ENTITY_VOICE_AGENT = {
   name: "data.agent",

--- a/packages/services/src/services/custom-integrations/custom-integration-event-builders.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-event-builders.ts
@@ -17,6 +17,7 @@ import {
   Meeting,
   Recording,
   User,
+  UserEmail,
 } from "@ringee/database";
 import { OwnershipContext } from "@ringee/platform";
 
@@ -73,6 +74,29 @@ export function userRef(
     email: email ?? undefined,
     fullName: fullName || undefined,
   };
+}
+
+/**
+ * A user's addressable email: the primary one, falling back to the first on
+ * file for rows synced before a primary was flagged.
+ */
+export function primaryEmailOf(
+  user:
+    | { emails?: Pick<UserEmail, "email" | "isPrimary">[] }
+    | null
+    | undefined,
+): string | undefined {
+  const emails = user?.emails;
+  if (!emails?.length) return undefined;
+  return emails.find((e) => e.isPrimary)?.email ?? emails[0]?.email;
+}
+
+/** AI voice-agent reference carried by every event the agent's call produces. */
+export function voiceAgentRef(
+  agent: { id: string; name: string } | null | undefined,
+) {
+  if (!agent) return undefined;
+  return { id: agent.id, name: agent.name };
 }
 
 export function buildCallEventData(call: Call): Record<string, unknown> {

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
@@ -614,4 +614,94 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
     assert.equal(deliveries.length, 1);
     assert.equal("user" in deliveries[0]!.payload.data, false);
   });
+  it("still delivers when the agent-call lookup fails", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+      {
+        findByCallId: async () => {
+          throw new Error("database is down");
+        },
+      } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
+    );
+
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "recording_ready",
+      subjectId: "recording-1",
+      data: { callId: "call-1", recordingId: "recording-1" },
+    });
+
+    // The annotation is lost; the delivery — and its retries — are not.
+    assert.equal(deliveries.length, 1);
+    assert.equal("agent" in deliveries[0]!.payload.data, false);
+    assert.equal("externalId" in deliveries[0]!.payload.data, false);
+    assert.equal(deliveries[0]!.payload.data.user.id, "user-1");
+  });
+
+  it("still delivers when the agent name cannot be read", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+      {
+        findByCallId: async () => ({
+          userId: "user-1",
+          organizationId: "org-1",
+          agentId: "agent-1",
+          metadata: { external_id: "crm-contact-42" },
+        }),
+      } as never,
+      USERS_STUB,
+      {
+        findRefForOwner: async () => {
+          throw new Error("database is down");
+        },
+      } as never,
+    );
+
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "recording_ready",
+      subjectId: "recording-1",
+      data: { callId: "call-1", recordingId: "recording-1" },
+    });
+
+    assert.equal(deliveries.length, 1);
+    assert.equal("agent" in deliveries[0]!.payload.data, false);
+    // Everything the failing lookup did not own still made it through.
+    assert.equal(deliveries[0]!.payload.data.externalId, "crm-contact-42");
+    assert.equal(deliveries[0]!.payload.data.user.id, "user-1");
+  });
 });

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts
@@ -86,6 +86,22 @@ describe("call outcome event data", () => {
   });
 });
 
+/** The responsible user, with a non-primary address ahead of the primary. */
+const USERS_STUB = {
+  findById: async (id: string) => ({
+    id,
+    firstName: "Ada",
+    lastName: "Lovelace",
+    emails: [
+      { email: "ada+old@example.com", isPrimary: false },
+      { email: "ada@example.com", isPrimary: true },
+    ],
+  }),
+} as never;
+
+/** No AI voice agent behind the event. */
+const NO_AGENTS_STUB = { findRefForOwner: async () => null } as never;
+
 describe("CustomIntegrationOutboundService call fan-out", () => {
   it("queues a terminal call for every active subscribed integration", async () => {
     const lookups: Array<Record<string, unknown>> = [];
@@ -122,6 +138,8 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
         },
       } as never,
       { findByCallId: async () => null } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
     );
 
     await service.enqueueCallTerminal({
@@ -198,6 +216,8 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
         },
       } as never,
       { findByCallId: async () => null } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
     );
 
     await service.enqueueCallTerminal({
@@ -237,6 +257,8 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
         },
       } as never,
       { findByCallId: async () => null } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
     );
 
     await service.enqueue({
@@ -280,6 +302,8 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
           metadata: { external_id: "crm-contact-42" },
         }),
       } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
     );
 
     await service.enqueue({
@@ -318,6 +342,8 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
           metadata: { external_id: "crm-contact-42" },
         }),
       } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
     );
 
     await service.enqueue({
@@ -357,6 +383,8 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
           metadata: { external_id: "crm-contact-42" },
         }),
       } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
     );
 
     await service.enqueue({
@@ -368,5 +396,222 @@ describe("CustomIntegrationOutboundService call fan-out", () => {
 
     assert.equal(deliveries.length, 1);
     assert.equal("externalId" in deliveries[0]!.payload.data, false);
+  });
+  it("names the responsible user, with their primary email, on every event", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+      { findByCallId: async () => null } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
+    );
+
+    // An event with no call at all still names who is behind it.
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "dnc_created",
+      subjectId: "+14155550123",
+      data: { phoneNumber: "+14155550123" },
+    });
+
+    assert.deepEqual(deliveries[0]!.payload.data.user, {
+      id: "user-1",
+      email: "ada@example.com",
+      fullName: "Ada Lovelace",
+    });
+    assert.equal("agent" in deliveries[0]!.payload.data, false);
+  });
+
+  it("names the AI voice agent behind a call-linked event", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const lookups: Array<Record<string, unknown>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+      {
+        findByCallId: async () => ({
+          userId: "user-1",
+          organizationId: "org-1",
+          agentId: "agent-1",
+          metadata: null,
+        }),
+      } as never,
+      USERS_STUB,
+      {
+        findRefForOwner: async (ctx: Record<string, unknown>, id: string) => {
+          lookups.push({ ctx, id });
+          return { id, name: "Sofia" };
+        },
+      } as never,
+    );
+
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "meeting_created",
+      subjectId: "meeting-1",
+      data: { meetingId: "meeting-1", callId: "call-1" },
+    });
+
+    assert.deepEqual(deliveries[0]!.payload.data.agent, {
+      id: "agent-1",
+      name: "Sofia",
+    });
+    // The agent is read through the workspace-checked lookup, never by id alone.
+    assert.deepEqual(lookups, [
+      { ctx: { userId: "user-1", organizationId: "org-1" }, id: "agent-1" },
+    ]);
+  });
+
+  it("never names an agent behind another workspace's call", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    let agentLookups = 0;
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+      {
+        findByCallId: async () => ({
+          userId: "user-9",
+          organizationId: "org-2",
+          agentId: "agent-9",
+          metadata: null,
+        }),
+      } as never,
+      USERS_STUB,
+      {
+        findRefForOwner: async () => {
+          agentLookups += 1;
+          return { id: "agent-9", name: "Someone else's agent" };
+        },
+      } as never,
+    );
+
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "recording_ready",
+      subjectId: "recording-1",
+      data: { callId: "call-1", recordingId: "recording-1" },
+    });
+
+    assert.equal("agent" in deliveries[0]!.payload.data, false);
+    assert.equal(agentLookups, 0);
+  });
+
+  it("keeps the actor a producer already resolved", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+      { findByCallId: async () => null } as never,
+      USERS_STUB,
+      NO_AGENTS_STUB,
+    );
+
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "note_created",
+      subjectId: "note-1",
+      data: { noteId: "note-1", user: { id: "user-7", fullName: "Grace" } },
+    });
+
+    assert.deepEqual(deliveries[0]!.payload.data.user, {
+      id: "user-7",
+      fullName: "Grace",
+    });
+  });
+
+  it("still delivers when the responsible user cannot be read", async () => {
+    const deliveries: Array<Record<string, any>> = [];
+    const service = new CustomIntegrationOutboundService(
+      {
+        findActiveSubscribed: async () => [
+          {
+            id: "integration-1",
+            userId: "user-1",
+            organizationId: "org-1",
+            outboundUrl: "https://one.example/webhooks",
+          },
+        ],
+      } as never,
+      {
+        enqueue: async (delivery: Record<string, unknown>) => {
+          deliveries.push(delivery);
+          return delivery;
+        },
+      } as never,
+      { findByCallId: async () => null } as never,
+      {
+        findById: async () => {
+          throw new Error("database is down");
+        },
+      } as never,
+      NO_AGENTS_STUB,
+    );
+
+    await service.enqueue({
+      ctx: { userId: "user-1", organizationId: "org-1" },
+      eventEnum: "dnc_created",
+      subjectId: "+14155550123",
+      data: { phoneNumber: "+14155550123" },
+    });
+
+    assert.equal(deliveries.length, 1);
+    assert.equal("user" in deliveries[0]!.payload.data, false);
   });
 });

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
@@ -1,11 +1,16 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { randomUUID } from "crypto";
 import {
+  AiVoiceAgentCall,
   AiVoiceAgentCallRepository,
+  AiVoiceAgentRepository,
   Call,
   CustomIntegrationDeliveryRepository,
   CustomIntegrationEventType,
   CustomIntegrationRepository,
+  User,
+  UserEmail,
+  UserRepository,
 } from "@ringee/database";
 import {
   OUTBOUND_EVENT_ENUM_TO_NAME,
@@ -17,8 +22,14 @@ import {
   buildCallEventData,
   callOwnershipFromCall,
   pickCallTerminalEvent,
+  primaryEmailOf,
+  userRef,
   voiceAgentExternalId,
+  voiceAgentRef,
 } from "./custom-integration-event-builders";
+
+/** `UserRepository.findById` loads the addresses; the model type omits them. */
+type UserWithEmails = User & { emails?: UserEmail[] };
 
 export interface OutboundEventEnvelope {
   event: OutboundEventName;
@@ -37,6 +48,8 @@ export class CustomIntegrationOutboundService {
     private readonly integrations: CustomIntegrationRepository,
     private readonly deliveries: CustomIntegrationDeliveryRepository,
     private readonly agentCalls: AiVoiceAgentCallRepository,
+    private readonly users: UserRepository,
+    private readonly voiceAgents: AiVoiceAgentRepository,
   ) {}
 
   /**
@@ -81,7 +94,7 @@ export class CustomIntegrationOutboundService {
       const eventName =
         OUTBOUND_EVENT_ENUM_TO_NAME[input.eventEnum as OutboundEventEnum];
       const occurredAt = (input.occurredAt ?? new Date()).toISOString();
-      const data = await this.withVoiceAgentExternalId(input.ctx, input.data);
+      const data = await this.withActors(input.ctx, input.data);
 
       for (const integration of integrations) {
         if (!integration.outboundUrl) continue;
@@ -113,28 +126,89 @@ export class CustomIntegrationOutboundService {
   }
 
   /**
-   * Every event tied to an AI voice-agent call carries the caller's external
-   * correlation id at `data.externalId`. Meeting, callback and recording events
-   * all expose their source `callId`, so one central lookup covers the entire
-   * fan-out instead of relying on each producer to remember the metadata.
+   * Every outbound event names who is behind it: `data.user` is the workspace
+   * member the event belongs to, and `data.agent` is the AI voice agent when
+   * one placed the call. Events tied to an agent call also carry the caller's
+   * own correlation id at `data.externalId`.
+   *
+   * Meeting, callback and recording events all expose their source `callId`, so
+   * one central lookup covers the entire fan-out instead of relying on each
+   * producer to remember the agent and the metadata. A producer that already
+   * resolved any of these keeps its own, richer value.
    */
-  private async withVoiceAgentExternalId(
+  private async withActors(
     ctx: OwnershipContext,
     data: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
-    if (typeof data.externalId === "string" && data.externalId.trim()) {
-      return data;
+    const [user, agentCall] = await Promise.all([
+      this.resolveUser(ctx, data),
+      this.resolveAgentCall(ctx, data),
+    ]);
+
+    const enriched = { ...data };
+    if (user) enriched.user = user;
+
+    if (agentCall) {
+      if (
+        typeof enriched.externalId !== "string" ||
+        !enriched.externalId.trim()
+      ) {
+        const externalId = voiceAgentExternalId(agentCall.metadata);
+        if (externalId) enriched.externalId = externalId;
+      }
+      if (!enriched.agent && agentCall.agentId) {
+        const agent = await this.voiceAgents.findRefForOwner(
+          ctx,
+          agentCall.agentId,
+        );
+        const ref = voiceAgentRef(agent);
+        if (ref) enriched.agent = ref;
+      }
     }
+
+    return enriched;
+  }
+
+  /** The workspace member the event belongs to, with their primary email. */
+  private async resolveUser(
+    ctx: OwnershipContext,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (data.user) return undefined;
+    try {
+      const user = (await this.users.findById(
+        ctx.userId,
+      )) as UserWithEmails | null;
+      return userRef(user, primaryEmailOf(user));
+    } catch (err) {
+      // An event with no actor is still worth delivering.
+      this.logger.warn(
+        `Could not resolve event actor ${ctx.userId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * The agent call behind this event, when the event names a call AND that call
+   * belongs to the caller's workspace. The ownership check is what keeps one
+   * workspace's correlation ids and agent names out of another's webhooks.
+   */
+  private async resolveAgentCall(
+    ctx: OwnershipContext,
+    data: Record<string, unknown>,
+  ): Promise<AiVoiceAgentCall | null> {
     const callId = typeof data.callId === "string" ? data.callId : null;
-    if (!callId) return data;
+    if (!callId) return null;
 
     const agentCall = await this.agentCalls.findByCallId(callId);
-    const owned = ctx.organizationId
-      ? agentCall?.organizationId === ctx.organizationId
-      : agentCall?.organizationId === null && agentCall.userId === ctx.userId;
-    if (!owned) return data;
+    if (!agentCall) return null;
 
-    const externalId = voiceAgentExternalId(agentCall?.metadata);
-    return externalId ? { ...data, externalId } : data;
+    const owned = ctx.organizationId
+      ? agentCall.organizationId === ctx.organizationId
+      : agentCall.organizationId === null && agentCall.userId === ctx.userId;
+    return owned ? agentCall : null;
   }
 }

--- a/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts
@@ -126,15 +126,19 @@ export class CustomIntegrationOutboundService {
   }
 
   /**
-   * Every outbound event names who is behind it: `data.user` is the workspace
-   * member the event belongs to, and `data.agent` is the AI voice agent when
-   * one placed the call. Events tied to an agent call also carry the caller's
-   * own correlation id at `data.externalId`.
+   * Names who is behind an outbound event: `data.user` is the workspace member
+   * the event belongs to, and `data.agent` is the AI voice agent when one
+   * placed the call. Events tied to an agent call also carry the caller's own
+   * correlation id at `data.externalId`.
    *
    * Meeting, callback and recording events all expose their source `callId`, so
    * one central lookup covers the entire fan-out instead of relying on each
    * producer to remember the agent and the metadata. A producer that already
    * resolved any of these keeps its own, richer value.
+   *
+   * Every lookup here is best-effort and isolated: one that fails leaves its
+   * field off the payload rather than dropping the event, because the delivery
+   * rows — and the retries behind them — matter more than the annotation.
    */
   private async withActors(
     ctx: OwnershipContext,
@@ -157,12 +161,8 @@ export class CustomIntegrationOutboundService {
         if (externalId) enriched.externalId = externalId;
       }
       if (!enriched.agent && agentCall.agentId) {
-        const agent = await this.voiceAgents.findRefForOwner(
-          ctx,
-          agentCall.agentId,
-        );
-        const ref = voiceAgentRef(agent);
-        if (ref) enriched.agent = ref;
+        const agent = await this.resolveAgentRef(ctx, agentCall.agentId);
+        if (agent) enriched.agent = agent;
       }
     }
 
@@ -203,12 +203,40 @@ export class CustomIntegrationOutboundService {
     const callId = typeof data.callId === "string" ? data.callId : null;
     if (!callId) return null;
 
-    const agentCall = await this.agentCalls.findByCallId(callId);
-    if (!agentCall) return null;
+    try {
+      const agentCall = await this.agentCalls.findByCallId(callId);
+      if (!agentCall) return null;
 
-    const owned = ctx.organizationId
-      ? agentCall.organizationId === ctx.organizationId
-      : agentCall.organizationId === null && agentCall.userId === ctx.userId;
-    return owned ? agentCall : null;
+      const owned = ctx.organizationId
+        ? agentCall.organizationId === ctx.organizationId
+        : agentCall.organizationId === null && agentCall.userId === ctx.userId;
+      return owned ? agentCall : null;
+    } catch (err) {
+      this.logger.warn(
+        `Could not resolve the agent call behind call ${callId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  /** The agent's public reference, read through the workspace-checked lookup. */
+  private async resolveAgentRef(
+    ctx: OwnershipContext,
+    agentId: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    try {
+      return voiceAgentRef(
+        await this.voiceAgents.findRefForOwner(ctx, agentId),
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Could not resolve voice agent ${agentId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return undefined;
+    }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour changes

- Every outbound custom-integration event now attempts to include the workspace user in `data.user`.
- Events with an owned `callId` now include the AI voice agent in `data.agent` and the caller correlation ID in `data.externalId`.
- Existing producer-supplied actor fields remain unchanged.
- Agent lookup includes soft-deleted agents so historical calls retain their agent reference.
- Cross-workspace agent references are rejected.

## Architectural impact

- `CustomIntegrationOutboundService` now owns actor enrichment and depends on `UserRepository` and `AiVoiceAgentRepository`.
- `AiVoiceAgentRepository.findRefForOwner` adds a workspace-scoped, read-only agent reference contract.
- `@ringee/platform` event specifications now define shared user and agent fields for outbound webhook payloads.
- Shared event-builder helpers centralize primary-email fallback and voice-agent reference shaping.

## Risk areas

- Custom Integration webhook payloads change for every outbound event. Consumers must accept `data.user` and event-specific `data.agent` and `data.externalId` fields.
- Workspace isolation depends on both user and agent ownership checks. A lookup failure must not block event delivery.
- Call lifecycle behavior depends on `callId` ownership and retained soft-deleted agent records.
- Existing producer values must not be overwritten during retries or when enrichment runs after partial event construction.

## Review first

- `packages/services/src/services/custom-integrations/custom-integration-outbound.service.ts`
- `packages/services/src/services/custom-integrations/custom-integration-outbound.service.spec.ts`
- `packages/database/src/database/repositories/ai-voice-agent.repository.ts`
- `packages/platform/src/custom-integrations/event-spec.ts`
- `packages/services/src/services/custom-integrations/custom-integration-event-builders.ts`

Localization files only document the new shared fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->