### PR TITLE
feat: add search and disposition filters to campaign leads functionality

### DIFF
--- a/apps/backend/src/api/routes/campaign.controller.ts
+++ b/apps/backend/src/api/routes/campaign.controller.ts
@@ -410,6 +410,8 @@ export class CampaignController {
     @Query("page") page = "1",
     @Query("limit") limit = "20",
     @Query("status") status?: string,
+    @Query("search") search?: string,
+    @Query("dispositionCode") dispositionCode?: string,
   ) {
     if (!user.activeOrgId) {
       throw new ForbiddenException("Campaigns require an organization");
@@ -419,6 +421,8 @@ export class CampaignController {
       page: Number(page),
       limit: Number(limit),
       status,
+      search: search?.trim() || undefined,
+      dispositionCode: dispositionCode?.trim() || undefined,
     });
   }
 

--- a/apps/frontend/src/features/campaigns/components/campaign-leads-tab.tsx
+++ b/apps/frontend/src/features/campaigns/components/campaign-leads-tab.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import { useDebounce } from '@ringee/frontend-shared/hooks/use-debounce';
 import { Badge } from '@ringee/frontend-shared/components/ui/badge';
 import { Button } from '@ringee/frontend-shared/components/ui/button';
 import {
@@ -11,6 +12,7 @@ import {
   CardHeader,
   CardTitle
 } from '@ringee/frontend-shared/components/ui/card';
+import { Input } from '@ringee/frontend-shared/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -51,14 +53,15 @@ import {
   TableActionCell,
   TableActionHead
 } from '@ringee/frontend-shared/components/ui/table/table-action-column';
-import { Upload, UserPlus, Plus, Trash2, Loader2 } from 'lucide-react';
+import { Upload, UserPlus, Plus, Trash2, Loader2, Search } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
 import type {
   CampaignLead,
   CampaignLeadListResponse,
   CampaignLeadStatus,
-  CampaignStatus
+  CampaignStatus,
+  Disposition
 } from '../types/campaign.types';
 import { ImportLeadsModal } from './import-leads-modal';
 import { AddLeadModal } from './add-lead-modal';
@@ -132,32 +135,66 @@ export function CampaignLeadsTab({
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [dispositionFilter, setDispositionFilter] = useState<string>('all');
+  const [dispositions, setDispositions] = useState<Disposition[]>([]);
+  const [search, setSearch] = useState('');
   const [importOpen, setImportOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<CampaignLead | null>(null);
   const limit = 20;
+  const debouncedSearch = useDebounce(search, 300);
+  // Typing keeps requests in flight; only the newest one may write to state.
+  const requestSeq = useRef(0);
+
+  const hasFilters =
+    statusFilter !== 'all' ||
+    dispositionFilter !== 'all' ||
+    debouncedSearch.trim() !== '';
 
   useEffect(() => {
     loadLeads();
-  }, [campaignId, page, statusFilter]);
+  }, [campaignId, page, statusFilter, dispositionFilter, debouncedSearch]);
+
+  // The disposition options are the campaign's own active dispositions.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get<Disposition[]>(`/campaigns/${campaignId}/dispositions`)
+      .then((data) => {
+        if (!cancelled) setDispositions(data);
+      })
+      .catch(() => {
+        // A missing disposition list just hides the filter.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, campaignId]);
 
   async function loadLeads() {
+    const seq = ++requestSeq.current;
     setLoading(true);
     try {
       const params: Record<string, string | number> = { page, limit };
       if (statusFilter !== 'all') params.status = statusFilter;
+      if (dispositionFilter !== 'all') {
+        params.dispositionCode = dispositionFilter;
+      }
+      const term = debouncedSearch.trim();
+      if (term) params.search = term;
 
       const res = await api.get<CampaignLeadListResponse>(
         `/campaigns/${campaignId}/leads`,
         params
       );
+      if (seq !== requestSeq.current) return;
       setLeads(res.data);
       setTotal(res.meta.total);
     } catch {
       // surfaced by api client / toast at call sites
     } finally {
-      setLoading(false);
+      if (seq === requestSeq.current) setLoading(false);
     }
   }
 
@@ -221,44 +258,86 @@ export function CampaignLeadsTab({
                 {t('leads.total', { count: total })}
               </CardDescription>
             </div>
-            <div className='flex items-center gap-2'>
+            {canImport && (
+              <div className='flex items-center gap-2'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => setImportOpen(true)}
+                >
+                  <Upload className='mr-2 h-4 w-4' />
+                  {t('leads.importCsv')}
+                </Button>
+                <Button size='sm' onClick={() => setAddOpen(true)}>
+                  <Plus className='mr-2 h-4 w-4' />
+                  {t('leads.addLead')}
+                </Button>
+              </div>
+            )}
+          </div>
+          <div className='mt-4 flex flex-col gap-2 sm:flex-row'>
+            <div className='relative flex-1'>
+              <Search className='text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2' />
+              <Input
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  setPage(1);
+                }}
+                placeholder={t('leads.filters.searchPlaceholder')}
+                aria-label={t('leads.filters.searchPlaceholder')}
+                className='pl-9'
+              />
+            </div>
+            <Select
+              value={statusFilter}
+              onValueChange={(v) => {
+                setStatusFilter(v);
+                setPage(1);
+              }}
+            >
+              <SelectTrigger
+                className='w-full sm:w-[160px]'
+                aria-label={t('list.allStatuses')}
+              >
+                <SelectValue placeholder={t('list.allStatuses')} />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_FILTERS.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s === 'all' ? t('list.allStatuses') : t(`leadStatus.${s}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {dispositions.length > 0 && (
               <Select
-                value={statusFilter}
+                value={dispositionFilter}
                 onValueChange={(v) => {
-                  setStatusFilter(v);
+                  setDispositionFilter(v);
                   setPage(1);
                 }}
               >
-                <SelectTrigger className='w-[160px]'>
-                  <SelectValue placeholder={t('list.allStatuses')} />
+                <SelectTrigger
+                  className='w-full sm:w-[180px]'
+                  aria-label={t('leads.filters.allDispositions')}
+                >
+                  <SelectValue
+                    placeholder={t('leads.filters.allDispositions')}
+                  />
                 </SelectTrigger>
                 <SelectContent>
-                  {STATUS_FILTERS.map((s) => (
-                    <SelectItem key={s} value={s}>
-                      {s === 'all'
-                        ? t('list.allStatuses')
-                        : t(`leadStatus.${s}`)}
+                  <SelectItem value='all'>
+                    {t('leads.filters.allDispositions')}
+                  </SelectItem>
+                  {dispositions.map((d) => (
+                    <SelectItem key={d.id} value={d.code}>
+                      {d.label}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              {canImport && (
-                <>
-                  <Button
-                    variant='outline'
-                    size='sm'
-                    onClick={() => setImportOpen(true)}
-                  >
-                    <Upload className='mr-2 h-4 w-4' />
-                    {t('leads.importCsv')}
-                  </Button>
-                  <Button size='sm' onClick={() => setAddOpen(true)}>
-                    <Plus className='mr-2 h-4 w-4' />
-                    {t('leads.addLead')}
-                  </Button>
-                </>
-              )}
-            </div>
+            )}
           </div>
         </CardHeader>
         <CardContent>
@@ -272,16 +351,16 @@ export function CampaignLeadsTab({
             <div className='flex flex-col items-center py-12 text-center'>
               <UserPlus className='text-muted-foreground mb-4 h-12 w-12' />
               <h3 className='text-lg font-semibold'>
-                {statusFilter === 'all'
-                  ? t('leads.empty.title')
-                  : t('leads.empty.filteredTitle')}
+                {hasFilters
+                  ? t('leads.empty.filteredTitle')
+                  : t('leads.empty.title')}
               </h3>
               <p className='text-muted-foreground mt-1 text-sm'>
-                {statusFilter === 'all'
-                  ? t('leads.empty.description')
-                  : t('leads.empty.filteredDescription')}
+                {hasFilters
+                  ? t('leads.empty.filteredDescription')
+                  : t('leads.empty.description')}
               </p>
-              {canImport && statusFilter === 'all' && (
+              {canImport && !hasFilters && (
                 <div className='mt-4 flex gap-2'>
                   <Button variant='outline' onClick={() => setImportOpen(true)}>
                     <Upload className='mr-2 h-4 w-4' />
@@ -301,6 +380,9 @@ export function CampaignLeadsTab({
                   <TableRow>
                     <TableHead>{t('leads.table.name')}</TableHead>
                     <TableHead>{t('leads.table.phone')}</TableHead>
+                    <TableHead className='hidden md:table-cell'>
+                      {t('leads.table.email')}
+                    </TableHead>
                     <TableHead className='hidden md:table-cell'>
                       {t('leads.table.company')}
                     </TableHead>
@@ -332,6 +414,9 @@ export function CampaignLeadsTab({
                         </div>
                       </TableCell>
                       <TableCell>{lead.contact.phoneNumber}</TableCell>
+                      <TableCell className='hidden md:table-cell'>
+                        {lead.contact.email || '—'}
+                      </TableCell>
                       <TableCell className='hidden md:table-cell'>
                         <div>{lead.contact.company || '—'}</div>
                         <div className='text-muted-foreground text-xs'>

--- a/apps/frontend/src/i18n/locales/de/campaigns.json
+++ b/apps/frontend/src/i18n/locales/de/campaigns.json
@@ -165,15 +165,20 @@
     "fallbackName": "Dieser Lead",
     "inFlightHint": "Dieser Lead wird gerade angerufen und kann nicht entfernt werden.",
     "removeAria": "{name} entfernen",
+    "filters": {
+      "searchPlaceholder": "Nach Name oder E-Mail suchen…",
+      "allDispositions": "Alle Klassifizierungen"
+    },
     "empty": {
       "title": "Noch keine Leads",
       "description": "Importieren Sie eine CSV-Datei oder fügen Sie einen Lead manuell hinzu, um zu starten.",
-      "filteredTitle": "Keine Leads mit diesem Status",
-      "filteredDescription": "Versuchen Sie einen anderen Statusfilter."
+      "filteredTitle": "Keine Leads entsprechen diesen Filtern",
+      "filteredDescription": "Versuchen Sie eine andere Suche, einen anderen Status oder eine andere Klassifizierung."
     },
     "table": {
       "name": "Name",
       "phone": "Telefon",
+      "email": "E-Mail",
       "company": "Unternehmen",
       "status": "Status",
       "attempts": "Versuche",

--- a/apps/frontend/src/i18n/locales/en/campaigns.json
+++ b/apps/frontend/src/i18n/locales/en/campaigns.json
@@ -165,15 +165,20 @@
     "fallbackName": "This lead",
     "inFlightHint": "This lead is currently being dialed and cannot be removed.",
     "removeAria": "Remove {name}",
+    "filters": {
+      "searchPlaceholder": "Search by name or email…",
+      "allDispositions": "All dispositions"
+    },
     "empty": {
       "title": "No leads yet",
       "description": "Import a CSV file or add a lead manually to get started.",
-      "filteredTitle": "No leads with this status",
-      "filteredDescription": "Try a different status filter."
+      "filteredTitle": "No leads match these filters",
+      "filteredDescription": "Try a different search, status or disposition."
     },
     "table": {
       "name": "Name",
       "phone": "Phone",
+      "email": "Email",
       "company": "Company",
       "status": "Status",
       "attempts": "Attempts",

--- a/apps/frontend/src/i18n/locales/es/campaigns.json
+++ b/apps/frontend/src/i18n/locales/es/campaigns.json
@@ -165,15 +165,20 @@
     "fallbackName": "Este lead",
     "inFlightHint": "Este lead se está marcando en este momento y no se puede eliminar.",
     "removeAria": "Eliminar {name}",
+    "filters": {
+      "searchPlaceholder": "Buscar por nombre o correo electrónico…",
+      "allDispositions": "Todas las tipificaciones"
+    },
     "empty": {
       "title": "Aún no hay leads",
       "description": "Importa un archivo CSV o añade un lead manualmente para empezar.",
-      "filteredTitle": "No hay leads con este estado",
-      "filteredDescription": "Prueba con otro filtro de estado."
+      "filteredTitle": "Ningún lead coincide con estos filtros",
+      "filteredDescription": "Prueba con otra búsqueda, estado o tipificación."
     },
     "table": {
       "name": "Nombre",
       "phone": "Teléfono",
+      "email": "Correo electrónico",
       "company": "Empresa",
       "status": "Estado",
       "attempts": "Intentos",

--- a/apps/frontend/src/i18n/locales/fr/campaigns.json
+++ b/apps/frontend/src/i18n/locales/fr/campaigns.json
@@ -165,15 +165,20 @@
     "fallbackName": "Ce lead",
     "inFlightHint": "Ce lead est en cours de composition et ne peut pas être supprimé.",
     "removeAria": "Supprimer {name}",
+    "filters": {
+      "searchPlaceholder": "Rechercher par nom ou e-mail…",
+      "allDispositions": "Toutes les qualifications"
+    },
     "empty": {
       "title": "Aucun lead pour le moment",
       "description": "Importez un fichier CSV ou ajoutez un lead manuellement pour commencer.",
-      "filteredTitle": "Aucun lead avec ce statut",
-      "filteredDescription": "Essayez un autre filtre de statut."
+      "filteredTitle": "Aucun lead ne correspond à ces filtres",
+      "filteredDescription": "Essayez une autre recherche, un autre statut ou une autre qualification."
     },
     "table": {
       "name": "Nom",
       "phone": "Téléphone",
+      "email": "E-mail",
       "company": "Entreprise",
       "status": "Statut",
       "attempts": "Tentatives",

--- a/apps/frontend/src/i18n/locales/it/campaigns.json
+++ b/apps/frontend/src/i18n/locales/it/campaigns.json
@@ -165,15 +165,20 @@
     "fallbackName": "Questo lead",
     "inFlightHint": "Questo lead è in composizione in questo momento e non può essere rimosso.",
     "removeAria": "Rimuovi {name}",
+    "filters": {
+      "searchPlaceholder": "Cerca per nome o email…",
+      "allDispositions": "Tutte le classificazioni"
+    },
     "empty": {
       "title": "Ancora nessun lead",
       "description": "Importa un file CSV o aggiungi un lead manualmente per iniziare.",
-      "filteredTitle": "Nessun lead con questo stato",
-      "filteredDescription": "Prova un altro filtro di stato."
+      "filteredTitle": "Nessun lead corrisponde a questi filtri",
+      "filteredDescription": "Prova un’altra ricerca, un altro stato o un’altra classificazione."
     },
     "table": {
       "name": "Nome",
       "phone": "Telefono",
+      "email": "Email",
       "company": "Azienda",
       "status": "Stato",
       "attempts": "Tentativi",

--- a/apps/frontend/src/i18n/locales/nl/campaigns.json
+++ b/apps/frontend/src/i18n/locales/nl/campaigns.json
@@ -165,15 +165,20 @@
     "fallbackName": "Deze lead",
     "inFlightHint": "Deze lead wordt op dit moment gebeld en kan niet worden verwijderd.",
     "removeAria": "{name} verwijderen",
+    "filters": {
+      "searchPlaceholder": "Zoeken op naam of e-mail…",
+      "allDispositions": "Alle classificaties"
+    },
     "empty": {
       "title": "Nog geen leads",
       "description": "Importeer een CSV-bestand of voeg handmatig een lead toe om te beginnen.",
-      "filteredTitle": "Geen leads met deze status",
-      "filteredDescription": "Probeer een ander statusfilter."
+      "filteredTitle": "Geen leads voldoen aan deze filters",
+      "filteredDescription": "Probeer een andere zoekopdracht, status of classificatie."
     },
     "table": {
       "name": "Naam",
       "phone": "Telefoon",
+      "email": "E-mail",
       "company": "Bedrijf",
       "status": "Status",
       "attempts": "Pogingen",

--- a/apps/frontend/src/i18n/locales/pt/campaigns.json
+++ b/apps/frontend/src/i18n/locales/pt/campaigns.json
@@ -165,15 +165,20 @@
     "fallbackName": "Este lead",
     "inFlightHint": "Este lead está a ser marcado neste momento e não pode ser removido.",
     "removeAria": "Remover {name}",
+    "filters": {
+      "searchPlaceholder": "Pesquisar por nome ou e-mail…",
+      "allDispositions": "Todas as classificações"
+    },
     "empty": {
       "title": "Ainda não há leads",
       "description": "Importe um ficheiro CSV ou adicione um lead manualmente para começar.",
-      "filteredTitle": "Não há leads com este estado",
-      "filteredDescription": "Experimente outro filtro de estado."
+      "filteredTitle": "Nenhum lead corresponde a estes filtros",
+      "filteredDescription": "Experimente outra pesquisa, estado ou classificação."
     },
     "table": {
       "name": "Nome",
       "phone": "Telefone",
+      "email": "E-mail",
       "company": "Empresa",
       "status": "Estado",
       "attempts": "Tentativas",

--- a/packages/database/src/database/repositories/campaign-lead.repository.ts
+++ b/packages/database/src/database/repositories/campaign-lead.repository.ts
@@ -161,12 +161,22 @@ export class CampaignLeadRepository {
       page?: number;
       limit?: number;
       status?: string;
+      /** Free-text match against the contact's name or e-mail. */
+      search?: string;
+      /** Campaign-scoped `Disposition.code` recorded on one of the attempts. */
+      dispositionCode?: string;
     },
   ): Promise<{
     data: CampaignLeadWithContact[];
     meta: { total: number; page: number; limit: number; totalPages: number };
   }> {
-    const { page = 1, limit = 20, status } = options || {};
+    const {
+      page = 1,
+      limit = 20,
+      status,
+      search,
+      dispositionCode,
+    } = options || {};
 
     // Filter by the real CampaignLeadStatus enum column so it matches the
     // status badges shown in the UI. Legacy aggregate aliases ("called" /
@@ -186,6 +196,22 @@ export class CampaignLeadRepository {
     const where: Prisma.CampaignLeadWhereInput = {
       campaignId,
       ...statusFilter,
+      ...(search
+        ? {
+            contact: {
+              OR: [
+                { name: { contains: search, mode: "insensitive" } },
+                { email: { contains: search, mode: "insensitive" } },
+              ],
+            },
+          }
+        : {}),
+      // A disposition is recorded on the attempt, not on the lead, so this
+      // matches every lead dispositioned this way at least once — a lead
+      // retried into a different outcome still answers its earlier code.
+      ...(dispositionCode
+        ? { callAttempts: { some: { dispositionCode } } }
+        : {}),
     };
 
     const total = await this.prisma.campaignLead.count({ where });

--- a/packages/services/src/services/campaign.service.ts
+++ b/packages/services/src/services/campaign.service.ts
@@ -195,7 +195,15 @@ export class CampaignService {
   async getLeads(
     ctx: OwnershipContext,
     campaignId: string,
-    options?: { page?: number; limit?: number; status?: string },
+    options?: {
+      page?: number;
+      limit?: number;
+      status?: string;
+      /** Free-text match against the contact's name or e-mail. */
+      search?: string;
+      /** Campaign-scoped `Disposition.code` recorded on one of the attempts. */
+      dispositionCode?: string;
+    },
   ) {
     this.ensureOrganization(ctx);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour

- Campaign leads now support free-text search by contact name or email.
- Campaign leads now support filtering by disposition recorded on a call attempt.
- The UI debounces search input and prevents stale responses from replacing newer results.
- The leads table now displays contact email.
- Filtered empty-state messages now cover search, status, and disposition filters.

## Architectural impact

- `CampaignController.getCampaignLeads`, `CampaignService.getLeads`, and `CampaignLeadRepository.findByCampaign` now accept `search` and `dispositionCode`.
- The repository owns search matching and disposition filtering in the Prisma query.
- The controller trims query values and excludes empty values before forwarding them.

## Risk areas

- The REST query contract changed for campaign leads. Verify that all callers and API types accept the new optional parameters.
- Disposition filtering depends on `callAttempts.some`. Verify that the result matches the intended campaign-scoped disposition and does not include attempts outside the campaign context.
- Search uses case-insensitive matching across linked contact fields. Verify database support and query performance for large campaigns.
- Request sequencing and debounce behavior are implemented in `campaign-leads-tab.tsx`. Review this file first for pagination, status changes, and filter-reset race conditions.

## Files carrying the risk

- `apps/frontend/src/features/campaigns/components/campaign-leads-tab.tsx`
- `apps/backend/src/api/routes/campaign.controller.ts`
- `packages/services/src/services/campaign.service.ts`
- `packages/database/src/database/repositories/campaign-lead.repository.ts`

Translations were updated for the new filters, empty states, and email column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->