### PR TITLE
feat: enhance custom integrations with campaign management and validation

### DIFF
--- a/apps/backend/src/api/routes/custom-integrations.webhook.controller.ts
+++ b/apps/backend/src/api/routes/custom-integrations.webhook.controller.ts
@@ -15,13 +15,6 @@ import {
 
 const API_KEY_HEADER = "x-ringee-api-key";
 
-interface InboundBody {
-  event?: string;
-  eventId?: string;
-  occurredAt?: string;
-  data?: Record<string, unknown>;
-}
-
 interface ClickToCallBody {
   contactExternalId?: string;
   phoneNumber?: string;
@@ -39,16 +32,17 @@ export class CustomIntegrationsWebhookController {
     private readonly clickToCall: CustomIntegrationClickToCallService,
   ) {}
 
+  /**
+   * The envelope is validated by the service, which reports every problem in
+   * one response instead of one per round trip.
+   */
   @Public()
   @Post("webhook")
   @HttpCode(202)
   async receive(
     @Headers(API_KEY_HEADER) apiKey: string | undefined,
-    @Body() body: InboundBody,
+    @Body() body: unknown,
   ) {
-    if (!body || typeof body !== "object") {
-      throw new BadRequestException("body must be a JSON object");
-    }
     const { integration } = await this.auth.resolveApiKey(apiKey);
     return this.inbound.handle(integration, body);
   }

--- a/packages/platform/AGENTS.md
+++ b/packages/platform/AGENTS.md
@@ -73,6 +73,19 @@ hard-coded secret was removed. Do not reintroduce one without configuration.
 - Compare secrets with `timingSafeEqual`. Store hashes, never plaintext tokens.
 - Fail closed when a key is missing or a signature does not verify.
 
+## Custom Integrations
+
+`custom-integrations/event-spec.ts` is the contract _and_ the validator. Inbound
+payloads are checked against it by `inbound-payload.ts`, and the frontend's
+Documentation tab renders the same array — so a field only exists once it is in
+the spec, and one that is missing from it comes back to the sender as an ignored
+field. Add the field there first, then read it in the service.
+
+A documented `type` drives the check: `"object"` and `"number"` are enforced as
+such, anything containing `uuid` is validated as one **and is fatal when
+malformed** (an id changes what an event does, so it is never dropped quietly),
+and everything else is a string.
+
 ## Temporal
 
 `temporal/contracts.ts` must stay **import-free** — it is pulled into the

--- a/packages/platform/src/custom-integrations/event-spec.ts
+++ b/packages/platform/src/custom-integrations/event-spec.ts
@@ -118,6 +118,12 @@ export const INBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
         type: "object",
         description: "Provider-specific metadata stored on the Contact.",
       },
+      {
+        name: "data.campaignId",
+        type: "string (UUID)",
+        description:
+          "Ringee campaign id — the contact is added to that campaign as a lead.",
+      },
     ],
     examplePayload: {
       event: "contact.upserted",
@@ -139,6 +145,14 @@ export const INBOUND_EVENT_SPECS: CustomIntegrationEventSpec[] = [
       "phoneNumber is required because Ringee needs to be able to dial the contact.",
       "Sending null / undefined / empty strings will NOT overwrite existing values.",
       "Dedup order: externalId first, then phoneNumber within the same workspace.",
+      "campaignId adds the contact to that campaign as a pending lead, and queues it " +
+        "immediately if the campaign is already running. A contact that is already a " +
+        "lead of the campaign is left untouched, so its attempts and dispositions " +
+        "survive every re-sync.",
+      "campaignId must belong to the same workspace as the integration, and campaigns " +
+        "only exist in organization workspaces. An id that does not resolve fails the " +
+        "event — the contact itself is still synced, so a corrected re-send only needs " +
+        "a fresh eventId.",
     ],
   },
   {

--- a/packages/platform/src/custom-integrations/inbound-payload.test.ts
+++ b/packages/platform/src/custom-integrations/inbound-payload.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateInboundEnvelope,
+  validateInboundEventData,
+} from "./inbound-payload";
+
+const CAMPAIGN_ID = "3f8a1c54-9d2b-4e7a-b1c6-5a0d9e8f7c21";
+
+describe("validateInboundEnvelope", () => {
+  it("accepts a complete envelope", () => {
+    const result = validateInboundEnvelope({
+      event: "contact.upserted",
+      eventId: "evt_1",
+      occurredAt: "2026-05-23T14:30:00.000Z",
+      data: { externalId: "ext_1" },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      envelope: {
+        event: "contact.upserted",
+        eventId: "evt_1",
+        occurredAt: "2026-05-23T14:30:00.000Z",
+        data: { externalId: "ext_1" },
+      },
+    });
+  });
+
+  it("reports every missing field in one answer", () => {
+    const result = validateInboundEnvelope({ event: "contact.upserted" });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.errors).toEqual([
+      "eventId is required",
+      "occurredAt is required",
+      "data must be an object",
+    ]);
+  });
+
+  it("names the supported events when the event is unknown", () => {
+    const result = validateInboundEnvelope({
+      event: "contact.created",
+      eventId: "evt_1",
+      occurredAt: "2026-05-23T14:30:00.000Z",
+      data: {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.errors[0]).toContain(
+      "Unsupported event: contact.created",
+    );
+    expect(result.ok === false && result.errors[0]).toContain(
+      "contact.upserted",
+    );
+  });
+
+  it("rejects a body that is not a JSON object", () => {
+    for (const body of [null, undefined, "{}", 42, []]) {
+      const result = validateInboundEnvelope(body);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.errors).toEqual([
+        "body must be a JSON object",
+      ]);
+    }
+  });
+});
+
+describe("validateInboundEventData", () => {
+  it("accepts a documented payload with no remarks", () => {
+    const issues = validateInboundEventData("contact.upserted", {
+      externalId: "ext_1",
+      phoneNumber: "+14155550123",
+      firstName: "Ada",
+      customFields: { tier: "vip" },
+      campaignId: CAMPAIGN_ID,
+    });
+
+    expect(issues).toEqual({ errors: [], warnings: [] });
+  });
+
+  it("reports every missing required field at once", () => {
+    const issues = validateInboundEventData("contact.upserted", {});
+
+    expect(issues.errors).toEqual([
+      "data.externalId is required",
+      "data.phoneNumber is required",
+    ]);
+  });
+
+  it("treats a blank required field as missing", () => {
+    const issues = validateInboundEventData("contact.upserted", {
+      externalId: "   ",
+      phoneNumber: "+14155550123",
+    });
+
+    expect(issues.errors).toEqual(["data.externalId is required"]);
+  });
+
+  it("fails a malformed id instead of dropping it silently", () => {
+    const issues = validateInboundEventData("contact.upserted", {
+      externalId: "ext_1",
+      phoneNumber: "+14155550123",
+      campaignId: "campaign-42",
+    });
+
+    expect(issues.errors).toEqual(["data.campaignId must be a UUID"]);
+  });
+
+  it("warns about an optional field of the wrong type instead of failing", () => {
+    const issues = validateInboundEventData("contact.upserted", {
+      externalId: "ext_1",
+      phoneNumber: "+14155550123",
+      email: 42,
+      customFields: ["not", "an", "object"],
+    });
+
+    expect(issues.errors).toEqual([]);
+    expect(issues.warnings).toEqual([
+      "data.email was ignored: expected a string, received a number",
+      "data.customFields was ignored: expected an object, received an array",
+    ]);
+  });
+
+  it("treats null and empty strings as 'leave it alone', not as errors", () => {
+    const issues = validateInboundEventData("contact.upserted", {
+      externalId: "ext_1",
+      phoneNumber: "+14155550123",
+      email: null,
+      jobTitle: "",
+    });
+
+    expect(issues).toEqual({ errors: [], warnings: [] });
+  });
+
+  it("warns about unknown fields so a typo is visible", () => {
+    const issues = validateInboundEventData("contact.upserted", {
+      externalId: "ext_1",
+      phoneNumber: "+14155550123",
+      campagnId: CAMPAIGN_ID,
+      phone_number: "+14155550123",
+    });
+
+    expect(issues.errors).toEqual([]);
+    expect(issues.warnings).toEqual([
+      "Unknown contact.upserted fields were ignored: campagnId, phone_number. Check them for typos.",
+    ]);
+  });
+
+  it("summarizes instead of listing an unbounded number of unknown fields", () => {
+    const data: Record<string, unknown> = {
+      externalId: "ext_1",
+      phoneNumber: "+14155550123",
+    };
+    for (let i = 0; i < 14; i += 1) data[`extra${i}`] = i;
+
+    const issues = validateInboundEventData("contact.upserted", data);
+
+    expect(issues.warnings).toHaveLength(1);
+    expect(issues.warnings[0]).toContain("extra9");
+    expect(issues.warnings[0]).toContain("and 4 more");
+  });
+
+  it("validates the delete events against their own single field", () => {
+    expect(
+      validateInboundEventData("contact.deleted", { externalId: "ext_1" }),
+    ).toEqual({ errors: [], warnings: [] });
+
+    expect(validateInboundEventData("company.deleted", {}).errors).toEqual([
+      "data.externalId is required",
+    ]);
+  });
+
+  it("requires a company name on company.upserted", () => {
+    expect(
+      validateInboundEventData("company.upserted", { externalId: "ext_1" })
+        .errors,
+    ).toEqual(["data.name is required"]);
+  });
+});

--- a/packages/platform/src/custom-integrations/inbound-payload.test.ts
+++ b/packages/platform/src/custom-integrations/inbound-payload.test.ts
@@ -170,6 +170,14 @@ describe("validateInboundEventData", () => {
     ]);
   });
 
+  it("fails closed for an event name that has no spec", () => {
+    // Only reachable by adding a name to INBOUND_EVENT_NAMES without the
+    // matching spec entry. Validating nothing would be the worse answer.
+    const issues = validateInboundEventData("contact.merged" as never, {});
+
+    expect(issues.errors).toEqual(["Unsupported event: contact.merged"]);
+  });
+
   it("requires a company name on company.upserted", () => {
     expect(
       validateInboundEventData("company.upserted", { externalId: "ext_1" })

--- a/packages/platform/src/custom-integrations/inbound-payload.ts
+++ b/packages/platform/src/custom-integrations/inbound-payload.ts
@@ -202,7 +202,10 @@ export function validateInboundEventData(
   const errors: string[] = [];
   const warnings: string[] = [];
 
-  if (!index) return { errors, warnings };
+  // Unreachable while every name in INBOUND_EVENT_NAMES has a spec beside it,
+  // which is the point: an event added to the list without one would otherwise
+  // be applied with no field validation at all. Fail closed instead.
+  if (!index) return { errors: [`Unsupported event: ${event}`], warnings };
 
   for (const { key, kind } of index.required) {
     const value = data[key];

--- a/packages/platform/src/custom-integrations/inbound-payload.ts
+++ b/packages/platform/src/custom-integrations/inbound-payload.ts
@@ -1,0 +1,271 @@
+import {
+  INBOUND_EVENT_NAMES,
+  INBOUND_EVENT_SPECS,
+  type EventFieldSpec,
+  type InboundEventName,
+} from "./event-spec";
+
+/**
+ * Validation for the inbound half of the Public API.
+ *
+ * Driven by {@link INBOUND_EVENT_SPECS}, so the reference an integrator reads
+ * and the rules their payload is judged by cannot drift apart: documenting a
+ * field is what makes it accepted, and removing one is what makes it rejected.
+ *
+ * Everything here is pure. The caller validates a whole event before it writes
+ * anything, which is what keeps a rejected payload from leaving a half-applied
+ * contact behind in Ringee.
+ */
+
+/** A well-formed envelope — every field present and the event name known. */
+export interface InboundEnvelope {
+  event: InboundEventName;
+  eventId: string;
+  occurredAt: string;
+  data: Record<string, unknown>;
+}
+
+export type InboundEnvelopeResult =
+  | { ok: true; envelope: InboundEnvelope }
+  | { ok: false; errors: string[] };
+
+export interface InboundDataIssues {
+  /** Fatal: the event is not applied at all. */
+  errors: string[];
+  /** Applied anyway, but something the sender wrote had no effect. */
+  warnings: string[];
+}
+
+/**
+ * What a documented `type` string means to the validator. Anything unrecognized
+ * is treated as a string, which is what every free-form label in the spec
+ * ("string (ISO-8601)") describes.
+ */
+type FieldKind = "string" | "uuid" | "object" | "number";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** How many unknown field names a single warning lists before it summarizes. */
+const MAX_LISTED_UNKNOWN_FIELDS = 10;
+
+function fieldKind(type: string): FieldKind {
+  const normalized = type.toLowerCase();
+  if (normalized.startsWith("object")) return "object";
+  if (normalized.startsWith("number")) return "number";
+  if (normalized.includes("uuid")) return "uuid";
+  return "string";
+}
+
+function describeKind(kind: FieldKind): string {
+  switch (kind) {
+    case "object":
+      return "an object";
+    case "number":
+      return "a number";
+    case "uuid":
+      return "a UUID";
+    default:
+      return "a string";
+  }
+}
+
+function matchesKind(value: unknown, kind: FieldKind): boolean {
+  switch (kind) {
+    case "object":
+      return (
+        typeof value === "object" && value !== null && !Array.isArray(value)
+      );
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "uuid":
+      return typeof value === "string" && UUID_PATTERN.test(value.trim());
+    default:
+      return typeof value === "string";
+  }
+}
+
+/** `data.externalId` → `externalId`; anything else is not a `data` field. */
+function dataKey(field: EventFieldSpec): string | null {
+  return field.name.startsWith("data.")
+    ? field.name.slice("data.".length)
+    : null;
+}
+
+interface EventFieldIndex {
+  required: Array<{ key: string; kind: FieldKind }>;
+  optional: Array<{ key: string; kind: FieldKind }>;
+  known: Set<string>;
+}
+
+const FIELD_INDEX: Record<string, EventFieldIndex> = Object.fromEntries(
+  INBOUND_EVENT_SPECS.map((spec) => {
+    const index = (fields: EventFieldSpec[]) =>
+      fields
+        .map((field) => {
+          const key = dataKey(field);
+          return key ? { key, kind: fieldKind(field.type) } : null;
+        })
+        .filter((entry): entry is { key: string; kind: FieldKind } => !!entry);
+
+    const required = index(spec.requiredFields);
+    const optional = index(spec.optionalFields);
+
+    return [
+      spec.name,
+      {
+        required,
+        optional,
+        known: new Set([...required, ...optional].map((entry) => entry.key)),
+      },
+    ];
+  }),
+);
+
+export function isInboundEventName(value: unknown): value is InboundEventName {
+  return (
+    typeof value === "string" &&
+    (INBOUND_EVENT_NAMES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Check the shared envelope, reporting every problem at once.
+ *
+ * One round trip should be enough to learn everything wrong with a request —
+ * an integrator fixing a payload one rejection at a time is the slowest way to
+ * discover four missing fields.
+ */
+export function validateInboundEnvelope(body: unknown): InboundEnvelopeResult {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, errors: ["body must be a JSON object"] };
+  }
+
+  const envelope = body as Record<string, unknown>;
+  const errors: string[] = [];
+
+  const event = envelope.event;
+  if (typeof event !== "string" || event.trim() === "") {
+    errors.push("event is required");
+  } else if (!isInboundEventName(event)) {
+    errors.push(
+      `Unsupported event: ${event}. Supported events: ${INBOUND_EVENT_NAMES.join(", ")}`,
+    );
+  }
+
+  const eventId = envelope.eventId;
+  if (typeof eventId !== "string" || eventId.trim() === "") {
+    errors.push("eventId is required");
+  }
+
+  const occurredAt = envelope.occurredAt;
+  if (typeof occurredAt !== "string" || occurredAt.trim() === "") {
+    errors.push("occurredAt is required");
+  }
+
+  const data = envelope.data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    errors.push("data must be an object");
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    envelope: {
+      event: event as InboundEventName,
+      eventId: (eventId as string).trim(),
+      occurredAt: occurredAt as string,
+      data: data as Record<string, unknown>,
+    },
+  };
+}
+
+/**
+ * Check one event's `data` against its spec.
+ *
+ * A missing or mistyped **required** field is fatal. A mistyped optional field
+ * is not: Ringee has always ignored those, and failing a whole contact sync
+ * over a stray `null` would be a worse trade than syncing the rest. What
+ * changes is that the sender is now told, instead of watching a field silently
+ * vanish.
+ *
+ * The exception is an id: a malformed UUID is always fatal, because it changes
+ * what the event *does* rather than what it stores — dropping it would quietly
+ * skip the campaign the sender asked for.
+ */
+export function validateInboundEventData(
+  event: InboundEventName,
+  data: Record<string, unknown>,
+): InboundDataIssues {
+  const index = FIELD_INDEX[event];
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!index) return { errors, warnings };
+
+  for (const { key, kind } of index.required) {
+    const value = data[key];
+    if (value === undefined || value === null) {
+      errors.push(`data.${key} is required`);
+      continue;
+    }
+    if (typeof value === "string" && value.trim() === "") {
+      errors.push(`data.${key} is required`);
+      continue;
+    }
+    if (!matchesKind(value, kind)) {
+      errors.push(`data.${key} must be ${describeKind(kind)}`);
+    }
+  }
+
+  for (const { key, kind } of index.optional) {
+    const value = data[key];
+
+    // Omitting a field and blanking it are the same request: leave it alone.
+    if (value === undefined || value === null) continue;
+    if (typeof value === "string" && value.trim() === "") continue;
+
+    if (matchesKind(value, kind)) continue;
+
+    if (kind === "uuid") {
+      errors.push(`data.${key} must be ${describeKind(kind)}`);
+    } else {
+      warnings.push(
+        `data.${key} was ignored: expected ${describeKind(kind)}, received ${typeName(value)}`,
+      );
+    }
+  }
+
+  const unknown = Object.keys(data).filter((key) => !index.known.has(key));
+  if (unknown.length > 0) {
+    warnings.push(
+      `Unknown ${event} fields were ignored: ${summarize(unknown)}. Check them for typos.`,
+    );
+  }
+
+  return { errors, warnings };
+}
+
+function typeName(value: unknown): string {
+  if (Array.isArray(value)) return "an array";
+  if (value === null) return "null";
+  switch (typeof value) {
+    case "string":
+      return "a string";
+    case "number":
+      return "a number";
+    case "boolean":
+      return "a boolean";
+    case "object":
+      return "an object";
+    default:
+      return typeof value;
+  }
+}
+
+function summarize(names: string[]): string {
+  if (names.length <= MAX_LISTED_UNKNOWN_FIELDS) return names.join(", ");
+  const listed = names.slice(0, MAX_LISTED_UNKNOWN_FIELDS).join(", ");
+  return `${listed} and ${names.length - MAX_LISTED_UNKNOWN_FIELDS} more`;
+}

--- a/packages/platform/src/custom-integrations/index.ts
+++ b/packages/platform/src/custom-integrations/index.ts
@@ -1,3 +1,4 @@
 export * from "./api-key.util";
 export * from "./webhook-signing.util";
 export * from "./event-spec";
+export * from "./inbound-payload";

--- a/packages/services/src/services/campaign.service.spec.ts
+++ b/packages/services/src/services/campaign.service.spec.ts
@@ -1,0 +1,169 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CampaignService } from "./campaign.service";
+
+const ORG_CTX = { userId: "user-1", organizationId: "org-1" };
+const CAMPAIGN_ID = "3f8a1c54-9d2b-4e7a-b1c6-5a0d9e8f7c21";
+
+interface BuildOptions {
+  campaign?: { id: string; organizationId: string; status: string } | null;
+  contactInWorkspace?: boolean;
+  /** Rows `createMany` actually inserted — 0 when the lead already existed. */
+  inserted?: number;
+}
+
+function build(options: BuildOptions = {}) {
+  const campaign =
+    options.campaign === undefined
+      ? { id: CAMPAIGN_ID, organizationId: "org-1", status: "draft" }
+      : options.campaign;
+
+  // Every repository call the service makes, in order. The stubs expose only
+  // the methods `addContactToCampaign` is allowed to use, so an attempt to
+  // touch an existing lead any other way fails the test by throwing.
+  const calls: string[] = [];
+  const createManyPayloads: Array<Array<{ contactId: string }>> = [];
+
+  const service = new CampaignService(
+    {
+      findById: async (id: string) => {
+        calls.push(`campaign.findById:${id}`);
+        return campaign;
+      },
+    } as never,
+    {
+      createMany: async (
+        campaignId: string,
+        leads: Array<{ contactId: string }>,
+      ) => {
+        calls.push(`lead.createMany:${campaignId}`);
+        createManyPayloads.push(leads);
+        return options.inserted ?? 1;
+      },
+      queueAllPending: async (campaignId: string) => {
+        calls.push(`lead.queueAllPending:${campaignId}`);
+        return 1;
+      },
+    } as never,
+    {} as never,
+    {
+      findByIdForOwner: async (_ctx: unknown, id: string) => {
+        calls.push(`contact.findByIdForOwner:${id}`);
+        return options.contactInWorkspace === false
+          ? null
+          : { id, phoneNumber: "+14155550123" };
+      },
+    } as never,
+    {} as never,
+    {} as never,
+  );
+
+  return { service, calls, createManyPayloads };
+}
+
+describe("CampaignService.addContactToCampaign", () => {
+  it("adds the contact as a lead", async () => {
+    const { service, calls, createManyPayloads } = build();
+
+    const result = await service.addContactToCampaign(
+      ORG_CTX,
+      CAMPAIGN_ID,
+      "contact-1",
+    );
+
+    assert.deepEqual(result, { added: true });
+    assert.deepEqual(createManyPayloads, [[{ contactId: "contact-1" }]]);
+    assert.deepEqual(calls, [
+      `campaign.findById:${CAMPAIGN_ID}`,
+      "contact.findByIdForOwner:contact-1",
+      `lead.createMany:${CAMPAIGN_ID}`,
+      `campaign.findById:${CAMPAIGN_ID}`,
+    ]);
+  });
+
+  it("queues the new lead when the campaign is already running", async () => {
+    const { service, calls } = build({
+      campaign: { id: CAMPAIGN_ID, organizationId: "org-1", status: "active" },
+    });
+
+    await service.addContactToCampaign(ORG_CTX, CAMPAIGN_ID, "contact-1");
+
+    assert.equal(calls.at(-1), `lead.queueAllPending:${CAMPAIGN_ID}`);
+  });
+
+  it("reports a contact that is already a lead without touching it", async () => {
+    // What the repository does on a duplicate: `@@unique([campaignId,
+    // contactId])` + skipDuplicates inserts nothing and counts nothing.
+    const { service, calls, createManyPayloads } = build({ inserted: 0 });
+
+    const result = await service.addContactToCampaign(
+      ORG_CTX,
+      CAMPAIGN_ID,
+      "contact-1",
+    );
+
+    assert.deepEqual(result, { added: false });
+
+    // The one write attempted is the insert itself — no update, no delete, no
+    // status reset. That is what keeps a re-sync from resetting a lead's
+    // attempts and dispositions.
+    assert.deepEqual(
+      calls.filter((call) => call.startsWith("lead.")),
+      [`lead.createMany:${CAMPAIGN_ID}`],
+    );
+    assert.deepEqual(createManyPayloads, [[{ contactId: "contact-1" }]]);
+  });
+
+  it("refuses a campaign that does not exist", async () => {
+    const { service, calls } = build({ campaign: null });
+
+    await assert.rejects(
+      () => service.addContactToCampaign(ORG_CTX, CAMPAIGN_ID, "contact-1"),
+      /Campaign not found/,
+    );
+    assert.deepEqual(calls, [`campaign.findById:${CAMPAIGN_ID}`]);
+  });
+
+  it("refuses a campaign in another organization", async () => {
+    const { service, calls } = build({
+      campaign: { id: CAMPAIGN_ID, organizationId: "org-2", status: "active" },
+    });
+
+    await assert.rejects(
+      () => service.addContactToCampaign(ORG_CTX, CAMPAIGN_ID, "contact-1"),
+      /Access denied/,
+    );
+    // The foreign campaign is rejected before the contact is even loaded.
+    assert.deepEqual(calls, [`campaign.findById:${CAMPAIGN_ID}`]);
+  });
+
+  it("refuses a contact from outside the workspace", async () => {
+    const { service, calls } = build({ contactInWorkspace: false });
+
+    await assert.rejects(
+      () => service.addContactToCampaign(ORG_CTX, CAMPAIGN_ID, "contact-1"),
+      /Contact not found/,
+    );
+    assert.equal(
+      calls.some((call) => call.startsWith("lead.")),
+      false,
+    );
+  });
+
+  it("refuses a personal workspace, which has no campaigns", async () => {
+    const { service, calls } = build();
+
+    await assert.rejects(
+      () =>
+        service.addContactToCampaign(
+          { userId: "user-1", organizationId: null },
+          CAMPAIGN_ID,
+          "contact-1",
+        ),
+      /Campaigns require an organization/,
+    );
+    assert.deepEqual(calls, []);
+  });
+});

--- a/packages/services/src/services/campaign.service.ts
+++ b/packages/services/src/services/campaign.service.ts
@@ -386,6 +386,70 @@ export class CampaignService {
     };
   }
 
+  /**
+   * Add a contact that already exists in the workspace to a campaign.
+   *
+   * The counterpart to {@link addLeadsManually} for callers that already own
+   * the Contact row — a CRM sync, not a CSV upload — so nothing here touches
+   * contact fields.
+   *
+   * Idempotent by design: a contact that is already a lead of the campaign is
+   * left exactly as it is, keeping its attempts, status and disposition
+   * history across every re-sync of the same contact.
+   */
+  async addContactToCampaign(
+    ctx: OwnershipContext,
+    campaignId: string,
+    contactId: string,
+  ): Promise<{ added: boolean }> {
+    await this.assertCampaignForLeadWrite(ctx, campaignId);
+
+    // The campaign belongs to the caller; the contact still has to. Without
+    // this check a foreign contact id would surface its name, phone and e-mail
+    // in this campaign's lead table.
+    const contact = await this.contactRepo.findByIdForOwner(ctx, contactId);
+    if (!contact) {
+      throw new NotFoundException("Contact not found");
+    }
+
+    // `@@unique([campaignId, contactId])` + skipDuplicates is what makes the
+    // re-add a no-op instead of a reset of the existing lead.
+    const added = await this.campaignLeadRepo.createMany(campaignId, [
+      { contactId },
+    ]);
+
+    // Same reasoning as in `addLeadsManually`: released unconditionally, so a
+    // lead left `pending` by an earlier interrupted write still reaches the
+    // live queue.
+    await this.releaseLeadsIfRunning(campaignId);
+
+    return { added: added > 0 };
+  }
+
+  /**
+   * Ownership gate for writing leads into a campaign: it has to exist and it
+   * has to be in the caller's organization.
+   *
+   * Public because a caller that writes other rows in the same request needs to
+   * know the campaign resolves *before* it starts writing — a CRM sync should
+   * not leave a contact behind because the campaign it named was a typo.
+   */
+  async assertCampaignForLeadWrite(
+    ctx: OwnershipContext,
+    campaignId: string,
+  ): Promise<Campaign> {
+    this.ensureOrganization(ctx);
+
+    const campaign = await this.campaignRepo.findById(campaignId);
+    if (!campaign) {
+      throw new NotFoundException("Campaign not found");
+    }
+    if (campaign.organizationId !== ctx.organizationId) {
+      throw new ForbiddenException("Access denied");
+    }
+    return campaign;
+  }
+
   async importLeadsFromCsv(
     ctx: OwnershipContext,
     campaignId: string,

--- a/packages/services/src/services/custom-integrations/custom-integration-inbound.service.spec.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-inbound.service.spec.ts
@@ -1,0 +1,312 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CustomIntegrationInboundService } from "./custom-integration-inbound.service";
+
+const INTEGRATION = {
+  id: "integration-1",
+  userId: "user-1",
+  organizationId: "org-1",
+} as never;
+
+const STORED_CONTACT = {
+  id: "contact-1",
+  phoneNumber: "+14155550123",
+} as never;
+
+const CAMPAIGN_ID = "3f8a1c54-9d2b-4e7a-b1c6-5a0d9e8f7c21";
+
+interface BuildOptions {
+  /** Contact already known to this integration, resolved through the link. */
+  existingContact?: boolean;
+  /** Campaign resolution, which runs before anything is written. */
+  campaignResolves?: boolean;
+  /** What `addContactToCampaign` reports — a new lead by default. */
+  leadAdded?: boolean;
+  /** Workspace member behind `data.ownerEmail`, when one matches. */
+  ownerMember?: { userId: string } | null;
+}
+
+function build(options: BuildOptions = {}) {
+  const inboundStatuses: Array<{ status: string; error?: string }> = [];
+  const campaignCalls: string[] = [];
+  const contactWrites: Array<Record<string, unknown>> = [];
+
+  const service = new CustomIntegrationInboundService(
+    {
+      insertReceived: async () => ({ id: "inbound-1" }),
+      markStatus: async (_id: string, status: string, error?: string) => {
+        inboundStatuses.push({ status, error });
+      },
+    } as never,
+    {
+      findByExternalId: async () =>
+        options.existingContact
+          ? { id: "link-1", contactId: "contact-1" }
+          : null,
+      upsert: async () => undefined,
+    } as never,
+    {
+      findByExternalId: async () => null,
+      upsert: async () => undefined,
+    } as never,
+    {
+      findById: async () => STORED_CONTACT,
+      findByPhone: async () => null,
+      create: async (_ctx: unknown, data: Record<string, unknown>) => {
+        contactWrites.push(data);
+        return STORED_CONTACT;
+      },
+      update: async (_id: string, data: Record<string, unknown>) => {
+        contactWrites.push(data);
+        return STORED_CONTACT;
+      },
+    } as never,
+    {} as never,
+    {
+      assertCampaignForLeadWrite: async (_ctx: unknown, id: string) => {
+        campaignCalls.push(`assert:${id}`);
+        if (options.campaignResolves === false) {
+          throw new Error("Campaign not found");
+        }
+        return { id };
+      },
+      addContactToCampaign: async (
+        _ctx: unknown,
+        campaignId: string,
+        contactId: string,
+      ) => {
+        campaignCalls.push(`add:${campaignId}:${contactId}`);
+        return { added: options.leadAdded ?? true };
+      },
+    } as never,
+    {
+      organizationMembership: {
+        findFirst: async () => options.ownerMember ?? null,
+      },
+    } as never,
+  );
+
+  return { service, inboundStatuses, campaignCalls, contactWrites };
+}
+
+function envelope(data: Record<string, unknown>) {
+  return {
+    event: "contact.upserted",
+    eventId: "evt_1",
+    occurredAt: "2026-05-23T14:30:00.000Z",
+    data: {
+      externalId: "ext_contact_42",
+      phoneNumber: "+1 (415) 555-0123",
+      ...data,
+    },
+  };
+}
+
+describe("contact.upserted campaign membership", () => {
+  it("adds the synced contact to the campaign the payload names", async () => {
+    const { service, campaignCalls, inboundStatuses } = build();
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ campaignId: CAMPAIGN_ID }),
+    );
+
+    assert.equal(result.status, "processed");
+    assert.deepEqual(campaignCalls, [
+      `assert:${CAMPAIGN_ID}`,
+      `add:${CAMPAIGN_ID}:contact-1`,
+    ]);
+    assert.equal(inboundStatuses.at(-1)?.status, "processed");
+  });
+
+  it("re-syncing a contact that is already a lead changes nothing", async () => {
+    const { service, campaignCalls } = build({
+      existingContact: true,
+      leadAdded: false,
+    });
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ campaignId: CAMPAIGN_ID }),
+    );
+
+    assert.equal(result.status, "processed");
+    assert.deepEqual(campaignCalls, [
+      `assert:${CAMPAIGN_ID}`,
+      `add:${CAMPAIGN_ID}:contact-1`,
+    ]);
+  });
+
+  it("leaves campaigns alone when the payload names none", async () => {
+    const { service, campaignCalls } = build();
+
+    const result = await service.handle(INTEGRATION, envelope({}));
+
+    assert.equal(result.status, "processed");
+    assert.deepEqual(campaignCalls, []);
+  });
+
+  it("rejects a campaignId that is not a UUID before touching campaigns", async () => {
+    const { service, campaignCalls, contactWrites } = build();
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ campaignId: "campaign-42" }),
+    );
+
+    assert.equal(result.status, "failed");
+    assert.equal(result.message, "data.campaignId must be a UUID");
+    assert.deepEqual(campaignCalls, []);
+    assert.deepEqual(contactWrites, []);
+  });
+
+  it("does not half-sync a contact when the campaign does not resolve", async () => {
+    const { service, contactWrites, inboundStatuses } = build({
+      campaignResolves: false,
+    });
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ campaignId: CAMPAIGN_ID }),
+    );
+
+    assert.equal(result.status, "failed");
+    assert.equal(result.message, "Campaign not found");
+    assert.deepEqual(contactWrites, []);
+    assert.deepEqual(inboundStatuses.at(-1), {
+      status: "failed",
+      error: "Campaign not found",
+    });
+  });
+
+  it("never writes campaignId onto the contact itself", async () => {
+    const { service, contactWrites } = build();
+
+    await service.handle(INTEGRATION, envelope({ campaignId: CAMPAIGN_ID }));
+
+    assert.equal(contactWrites.length, 1);
+    assert.equal(contactWrites[0]?.campaignId, undefined);
+  });
+});
+
+describe("inbound envelope validation", () => {
+  it("reports every envelope problem in one rejection", async () => {
+    const { service } = build();
+
+    await assert.rejects(
+      () => service.handle(INTEGRATION, { event: "contact.upserted" }),
+      /eventId is required; occurredAt is required; data must be an object/,
+    );
+  });
+
+  it("rejects a body that is not a JSON object", async () => {
+    const { service } = build();
+
+    await assert.rejects(
+      () => service.handle(INTEGRATION, "not json"),
+      /body must be a JSON object/,
+    );
+  });
+
+  it("reports every missing data field in one answer", async () => {
+    const { service, contactWrites } = build();
+
+    const result = await service.handle(INTEGRATION, {
+      event: "contact.upserted",
+      eventId: "evt_1",
+      occurredAt: "2026-05-23T14:30:00.000Z",
+      data: {},
+    });
+
+    assert.equal(result.status, "failed");
+    assert.equal(
+      result.message,
+      "data.externalId is required; data.phoneNumber is required",
+    );
+    assert.deepEqual(contactWrites, []);
+  });
+});
+
+describe("inbound warnings", () => {
+  it("tells the sender which fields it ignored", async () => {
+    const { service } = build();
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ campagnId: CAMPAIGN_ID }),
+    );
+
+    assert.equal(result.status, "processed");
+    assert.deepEqual(result.warnings, [
+      "Unknown contact.upserted fields were ignored: campagnId. Check them for typos.",
+    ]);
+  });
+
+  it("says which country a number without a prefix was read as", async () => {
+    const { service, contactWrites } = build();
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ phoneNumber: "(415) 555-0123" }),
+    );
+
+    assert.equal(result.status, "processed");
+    assert.equal(contactWrites[0]?.phoneNumber, "+14155550123");
+    assert.match(result.warnings?.[0] ?? "", /has no country code/);
+  });
+
+  it("normalizes through real numbering plans, not a digit strip", async () => {
+    const { service, contactWrites } = build();
+
+    await service.handle(
+      INTEGRATION,
+      envelope({ phoneNumber: "+34 911 23 45 67" }),
+    );
+
+    assert.equal(contactWrites[0]?.phoneNumber, "+34911234567");
+  });
+
+  it("fails a number nothing can dial instead of storing it", async () => {
+    const { service, contactWrites } = build();
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ phoneNumber: "n/a" }),
+    );
+
+    assert.equal(result.status, "failed");
+    assert.match(result.message ?? "", /not a dialable number/);
+    assert.deepEqual(contactWrites, []);
+  });
+
+  it("warns when ownerEmail matches nobody in the workspace", async () => {
+    const { service } = build({ ownerMember: null });
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({ ownerEmail: "nobody@example.com" }),
+    );
+
+    assert.equal(result.status, "processed");
+    assert.match(result.warnings?.[0] ?? "", /does not match a member/);
+  });
+
+  it("stays quiet when the payload is exactly what the spec documents", async () => {
+    const { service } = build({ ownerMember: { userId: "user-2" } });
+
+    const result = await service.handle(
+      INTEGRATION,
+      envelope({
+        campaignId: CAMPAIGN_ID,
+        ownerEmail: "rep@example.com",
+        email: "ada@example.com",
+        customFields: { tier: "vip" },
+      }),
+    );
+
+    assert.equal(result.status, "processed");
+    assert.equal(result.warnings, undefined);
+  });
+});

--- a/packages/services/src/services/custom-integrations/custom-integration-inbound.service.spec.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-inbound.service.spec.ts
@@ -121,7 +121,10 @@ describe("contact.upserted campaign membership", () => {
     assert.equal(inboundStatuses.at(-1)?.status, "processed");
   });
 
-  it("re-syncing a contact that is already a lead changes nothing", async () => {
+  // Whether a duplicate lead is a no-op is CampaignService's guarantee, tested
+  // in campaign.service.spec.ts. What belongs here is that a re-sync still goes
+  // through it rather than writing leads on its own.
+  it("routes a re-synced contact through the same campaign call", async () => {
     const { service, campaignCalls } = build({
       existingContact: true,
       leadAdded: false,

--- a/packages/services/src/services/custom-integrations/custom-integration-inbound.service.ts
+++ b/packages/services/src/services/custom-integrations/custom-integration-inbound.service.ts
@@ -11,26 +11,40 @@ import {
   Prisma,
 } from "@ringee/database";
 import {
-  INBOUND_EVENT_NAMES,
   InboundEventName,
   OwnershipContext,
-  buildOwnershipFilter,
+  normalizePhoneE164,
+  validateInboundEnvelope,
+  validateInboundEventData,
 } from "@ringee/platform";
 import { PrismaService } from "@ringee/database";
-
-interface InboundEnvelope {
-  event?: string;
-  eventId?: string;
-  occurredAt?: string;
-  data?: Record<string, unknown>;
-}
+import { CampaignService } from "../campaign.service";
 
 export interface InboundResult {
   status: "processed" | "skipped" | "failed";
   eventId: string;
   message?: string;
+  /**
+   * Non-fatal remarks about the payload — a field that was ignored, a phone
+   * number read with an assumed country. The event still applied.
+   */
+  warnings?: string[];
 }
 
+/**
+ * The inbound half of the Public API: a CRM's view of a contact or company,
+ * turned into Ringee records.
+ *
+ * Two properties every handler below is built around:
+ *
+ *  - **Validate, resolve, then write.** Everything that can reject the event —
+ *    payload shape, phone normalization, the campaign it names — is settled
+ *    before the first row is written, so a rejected event never leaves a
+ *    half-synced contact behind.
+ *  - **Say what was ignored.** A field Ringee silently drops is the most
+ *    expensive kind of integration bug, so anything skipped comes back as a
+ *    warning on the response.
+ */
 @Injectable()
 export class CustomIntegrationInboundService {
   private readonly logger = new Logger(CustomIntegrationInboundService.name);
@@ -41,39 +55,36 @@ export class CustomIntegrationInboundService {
     private readonly companyLinkRepo: CustomIntegrationCompanyLinkRepository,
     private readonly contactRepo: ContactRepository,
     private readonly companyRepo: CompanyRepository,
+    private readonly campaignService: CampaignService,
     private readonly prisma: PrismaService,
   ) {}
 
   async handle(
     integration: CustomIntegration,
-    envelope: InboundEnvelope,
+    body: unknown,
   ): Promise<InboundResult> {
-    const event = envelope.event;
-    const eventId = envelope.eventId;
-    const data = envelope.data;
-
-    if (!event) throw new BadRequestException("event is required");
-    if (!eventId) throw new BadRequestException("eventId is required");
-    if (!envelope.occurredAt)
-      throw new BadRequestException("occurredAt is required");
-    if (!data || typeof data !== "object") {
-      throw new BadRequestException("data must be an object");
+    // The envelope is checked before anything is recorded: without an eventId
+    // there is nothing to deduplicate against, and without an event name there
+    // is nothing to log the request as.
+    const parsed = validateInboundEnvelope(body);
+    if (!parsed.ok) {
+      throw new BadRequestException(parsed.errors.join("; "));
     }
-    if (!(INBOUND_EVENT_NAMES as readonly string[]).includes(event)) {
-      throw new BadRequestException(`Unsupported event: ${event}`);
-    }
+    const { event, eventId, data } = parsed.envelope;
 
     const inserted = await this.inboundRepo.insertReceived({
       integrationId: integration.id,
       eventType: event,
       externalEventId: eventId,
-      rawPayload: envelope as unknown as Record<string, unknown>,
+      rawPayload: parsed.envelope as unknown as Record<string, unknown>,
     });
 
     if (!inserted) {
       return { status: "skipped", eventId, message: "duplicate eventId" };
     }
 
+    // Recorded first, validated second: a malformed payload is exactly what an
+    // integrator needs to find in the event log afterwards.
     await this.inboundRepo.markStatus(inserted.id, "processing");
 
     const ctx: OwnershipContext = {
@@ -82,22 +93,9 @@ export class CustomIntegrationInboundService {
     };
 
     try {
-      switch (event as InboundEventName) {
-        case "contact.upserted":
-          await this.handleContactUpserted(integration, ctx, data);
-          break;
-        case "company.upserted":
-          await this.handleCompanyUpserted(integration, ctx, data);
-          break;
-        case "contact.deleted":
-          await this.handleContactDeleted(integration, data);
-          break;
-        case "company.deleted":
-          await this.handleCompanyDeleted(integration, data);
-          break;
-      }
+      const warnings = await this.apply(integration, ctx, event, data);
       await this.inboundRepo.markStatus(inserted.id, "processed");
-      return { status: "processed", eventId };
+      return withWarnings({ status: "processed", eventId }, warnings);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.error(
@@ -108,43 +106,63 @@ export class CustomIntegrationInboundService {
     }
   }
 
+  /** Validate the event's `data`, then apply it. Returns its warnings. */
+  private async apply(
+    integration: CustomIntegration,
+    ctx: OwnershipContext,
+    event: InboundEventName,
+    data: Record<string, unknown>,
+  ): Promise<string[]> {
+    const issues = validateInboundEventData(event, data);
+    if (issues.errors.length > 0) {
+      throw new BadRequestException(issues.errors.join("; "));
+    }
+
+    switch (event) {
+      case "contact.upserted":
+        return [
+          ...issues.warnings,
+          ...(await this.handleContactUpserted(integration, ctx, data)),
+        ];
+      case "company.upserted":
+        await this.handleCompanyUpserted(integration, ctx, data);
+        return issues.warnings;
+      case "contact.deleted":
+        await this.handleContactDeleted(integration, data);
+        return issues.warnings;
+      case "company.deleted":
+        await this.handleCompanyDeleted(integration, data);
+        return issues.warnings;
+    }
+  }
+
   // ── contact.upserted ─────────────────────────────────────────────
 
   private async handleContactUpserted(
     integration: CustomIntegration,
     ctx: OwnershipContext,
     data: Record<string, unknown>,
-  ): Promise<void> {
+  ): Promise<string[]> {
+    const warnings: string[] = [];
     const externalId = requireString(data, "externalId");
-    const phoneNumber = normalizePhone(requireString(data, "phoneNumber"));
+    const phoneNumber = this.resolvePhoneNumber(data, warnings);
+
+    // Resolved, not written, before anything else: an unknown campaign is a
+    // payload mistake, and the sender should get it back with their contact
+    // untouched rather than half-synced. `addContactToCampaign` re-checks it —
+    // it is a public service method and cannot take our word for it.
+    const campaignId = pickString(data, "campaignId");
+    if (campaignId) {
+      await this.campaignService.assertCampaignForLeadWrite(ctx, campaignId);
+    }
+
+    const ownerId = await this.resolveOwnerId(ctx, data, warnings);
 
     // Resolve / create company association first, so the contact's `company`
-    // text field and crmMetadata can reference it.
-    let companyName: string | null = pickString(data, "companyName");
-    let resolvedCompanyId: string | null = null;
-    const companyExternalId = pickString(data, "companyExternalId");
-    if (companyExternalId) {
-      const companyLink = await this.companyLinkRepo.findByExternalId(
-        integration.id,
-        companyExternalId,
-      );
-      if (companyLink?.companyId) {
-        resolvedCompanyId = companyLink.companyId;
-        const co = await this.companyRepo.findById(companyLink.companyId);
-        if (co && !companyName) companyName = co.name;
-      } else if (companyName) {
-        const created = await this.companyRepo.create(ctx, {
-          name: companyName,
-        });
-        await this.companyLinkRepo.upsert({
-          integrationId: integration.id,
-          externalId: companyExternalId,
-          companyId: created.id,
-          clearArchived: true,
-        });
-        resolvedCompanyId = created.id;
-      }
-    }
+    // text field and crmMetadata can reference it. The proper Ringee model is
+    // ContactAffiliation, but for MVP this mirrors the other integrations and
+    // only sets the Contact's `company` text field.
+    const companyName = await this.resolveCompanyName(integration, ctx, data);
 
     // Resolve existing contact: link → externalId, fallback → phone within workspace.
     const link = await this.contactLinkRepo.findByExternalId(
@@ -161,7 +179,7 @@ export class CustomIntegrationInboundService {
     const fields = this.buildContactWriteFields(data, {
       phoneNumber,
       companyName,
-      ownerId: await this.resolveOwnerId(ctx, data),
+      ownerId,
     });
     const writeFields = stripEmpty(fields);
 
@@ -186,11 +204,76 @@ export class CustomIntegrationInboundService {
       clearArchived: true,
     });
 
-    if (resolvedCompanyId) {
-      // ContactAffiliation link is the proper Ringee model, but for MVP we
-      // mirror what other integrations do: set the `company` text field on
-      // the Contact (already handled by buildContactWriteFields above).
+    // Campaign membership is the external system's call, not ours: it names a
+    // campaign, we put the contact in it. Adding an existing lead again is a
+    // no-op, so a CRM that replays `contact.upserted` on every edit never
+    // resets the attempts or dispositions the lead has already accumulated.
+    if (campaignId) {
+      await this.campaignService.addContactToCampaign(
+        ctx,
+        campaignId,
+        contact.id,
+      );
     }
+
+    return warnings;
+  }
+
+  /**
+   * E.164 through the canonical normalizer, which knows real numbering plans.
+   * A number Ringee cannot turn into something dialable fails the event: the
+   * whole point of a synced contact is that someone can call it.
+   */
+  private resolvePhoneNumber(
+    data: Record<string, unknown>,
+    warnings: string[],
+  ): string {
+    const raw = requireString(data, "phoneNumber");
+    const normalized = normalizePhoneE164(raw);
+    if (!normalized) {
+      throw new BadRequestException(
+        `data.phoneNumber is not a dialable number: ${raw}`,
+      );
+    }
+    if (!raw.startsWith("+")) {
+      warnings.push(
+        `data.phoneNumber "${raw}" has no country code and was read as ${normalized}. Send E.164 to be sure.`,
+      );
+    }
+    return normalized;
+  }
+
+  /** The company text this contact should carry, creating the link if needed. */
+  private async resolveCompanyName(
+    integration: CustomIntegration,
+    ctx: OwnershipContext,
+    data: Record<string, unknown>,
+  ): Promise<string | null> {
+    const companyName = pickString(data, "companyName");
+    const companyExternalId = pickString(data, "companyExternalId");
+    if (!companyExternalId) return companyName;
+
+    const companyLink = await this.companyLinkRepo.findByExternalId(
+      integration.id,
+      companyExternalId,
+    );
+
+    if (companyLink?.companyId) {
+      if (companyName) return companyName;
+      const company = await this.companyRepo.findById(companyLink.companyId);
+      return company?.name ?? null;
+    }
+
+    if (!companyName) return null;
+
+    const created = await this.companyRepo.create(ctx, { name: companyName });
+    await this.companyLinkRepo.upsert({
+      integrationId: integration.id,
+      externalId: companyExternalId,
+      companyId: created.id,
+      clearArchived: true,
+    });
+    return companyName;
   }
 
   private buildContactWriteFields(
@@ -224,6 +307,7 @@ export class CustomIntegrationInboundService {
   private async resolveOwnerId(
     ctx: OwnershipContext,
     data: Record<string, unknown>,
+    warnings: string[],
   ): Promise<string | null> {
     // Freelancer workspace: owner is always the workspace user.
     if (!ctx.organizationId) return ctx.userId;
@@ -238,7 +322,17 @@ export class CustomIntegrationInboundService {
       },
       include: { user: true },
     });
-    return member?.userId ?? null;
+
+    if (!member) {
+      // Not fatal — an unassigned contact is still callable — but it is the
+      // one thing an integrator cannot see from the outside.
+      warnings.push(
+        `data.ownerEmail "${ownerEmail}" does not match a member of this workspace; the contact was left unassigned.`,
+      );
+      return null;
+    }
+
+    return member.userId;
   }
 
   // ── company.upserted ─────────────────────────────────────────────
@@ -340,6 +434,18 @@ export class CustomIntegrationInboundService {
 
 // ── helpers ────────────────────────────────────────────────────────
 
+function withWarnings(
+  result: InboundResult,
+  warnings: string[],
+): InboundResult {
+  return warnings.length > 0 ? { ...result, warnings } : result;
+}
+
+/**
+ * Required fields are already guaranteed by `validateInboundEventData`; this
+ * narrows the type for the handlers and stays as the last line of defence for
+ * a field the spec has not caught up with.
+ */
 function requireString(data: Record<string, unknown>, key: string): string {
   const v = data[key];
   if (typeof v !== "string" || v.trim() === "") {
@@ -372,12 +478,4 @@ function stripEmpty<T extends Record<string, unknown>>(obj: T): Partial<T> {
     out[k] = v;
   }
   return out as Partial<T>;
-}
-
-function normalizePhone(input: string): string {
-  // Minimal best-effort: keep leading +, strip spaces/dashes/parens.
-  const cleaned = input.replace(/[\s\-().]/g, "");
-  if (cleaned.startsWith("+")) return cleaned;
-  if (/^\d+$/.test(cleaned)) return `+${cleaned}`;
-  return cleaned;
 }


### PR DESCRIPTION


- Refactor inbound webhook controller to validate payloads and handle unknown fields.
- Introduce campaignId handling in the inbound payload specification and validation.
- Implement comprehensive tests for inbound payload validation and campaign integration.
- Add new service methods for adding contacts to campaigns and validating event data.
- Ensure warnings are returned for ignored fields and malformed data in the integration process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour

- Inbound custom integration webhooks now reject malformed envelopes and required fields before processing.
- Unknown fields and invalid optional fields produce warnings instead of failing the event.
- `contact.upserted` supports optional `data.campaignId`.
- A valid campaign ID must belong to the integration workspace. The contact sync fails if the campaign cannot be resolved.
- Valid contacts are added to campaigns idempotently. Active campaigns release pending leads.
- Contact data is not persisted with `campaignId`.
- Phone numbers are normalized to E.164. Missing country codes and unmatched `ownerEmail` values produce warnings.

## Architectural impact

- `@ringee/platform` now owns shared inbound envelope and event-data validation through `INBOUND_EVENT_SPECS`.
- `@ringee/services` now owns campaign existence, workspace ownership, and contact-to-campaign writes.
- The webhook controller passes `unknown` request bodies to the inbound service.
- Inbound processing returns non-fatal warnings with its result.
- `@ringee/platform` exports the new validation module as part of the custom integrations API.

## Risk areas

- Custom Integration webhook payloads now have a public validation contract. Changes to event specs can reject existing integrations.
- Campaign validation occurs before campaign membership writes. A failed campaign lookup can fail the event after other contact-sync work unless processing remains atomic.
- Idempotent campaign writes and retry behaviour require verification because webhook delivery can be repeated.
- Workspace ownership checks must prevent cross-tenant campaign access.
- Warning-only handling can hide producer errors when optional fields have incorrect types.

## Files to inspect first

- `packages/services/src/services/custom-integrations/custom-integration-inbound.service.ts`
- `packages/platform/src/custom-integrations/inbound-payload.ts`
- `packages/services/src/services/campaign.service.ts`
- `packages/services/src/services/custom-integrations/custom-integration-inbound.service.spec.ts`
- `packages/platform/src/custom-integrations/event-spec.ts`
- `apps/backend/src/api/routes/custom-integrations.webhook.controller.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->