### PR TITLE
feat: add settings dialog and related functionality

### DIFF
--- a/apps/frontend/src/components/layout/app-sidebar.tsx
+++ b/apps/frontend/src/components/layout/app-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger
 } from '@ringee/frontend-shared/components/ui/dropdown-menu';
 import {
@@ -48,6 +49,7 @@ import {
   IconTopologyStar3
 } from '@tabler/icons-react';
 import { useIsSuperAdmin } from '@/features/backoffice/lib/use-is-super-admin';
+import { useSettingsDialogStore } from '@/features/settings/store/settings-dialog.store';
 
 import { SignOutButton } from '@clerk/nextjs';
 import Link from 'next/link';
@@ -214,6 +216,11 @@ export default function AppSidebar({ useMock }: { useMock?: boolean }) {
     : useUser();
 
   const router = useRouter();
+
+  // Settings opens the dialog instead of navigating — Integrations, Recordings
+  // & transcriptions and Desk phones are panes inside it now. The standalone
+  // pages stay reachable for deep links and the command bar.
+  const openSettings = useSettingsDialogStore((s) => s.openSettings);
 
   // Resolved by the API (single allowlist) rather than a copy of the list here.
   // The mock preview keeps showing the backoffice entry as it always did.
@@ -494,20 +501,16 @@ export default function AppSidebar({ useMock }: { useMock?: boolean }) {
                     {tNav('userMenu.recordings')}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => router.push('/dashboard/settings/overview')}
+                    onClick={() =>
+                      useMock
+                        ? router.push('/dashboard/settings/overview')
+                        : openSettings('general')
+                    }
                   >
                     {/* @ts-ignore */}
                     <Icons.settings className='mr-2 h-4 w-4' />
                     {tNav('groups.settings')}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() =>
-                      router.push('/dashboard/settings/integrations')
-                    }
-                  >
-                    {/* @ts-ignore */}
-                    <Icons.plug className='mr-2 h-4 w-4' />
-                    {tNav('items.integrations')}
+                    <DropdownMenuShortcut>⇧⌘,</DropdownMenuShortcut>
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
 
@@ -535,13 +538,6 @@ export default function AppSidebar({ useMock }: { useMock?: boolean }) {
                       >
                         <Icons.billing className='mr-2 h-4 w-4' />
                         {tNav('userMenu.billing')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => router.push('/dashboard/desk-phones')}
-                      >
-                        {/* @ts-ignore */}
-                        <Icons.plug className='mr-2 h-4 w-4' />
-                        Desk Phones
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={() => router.push('/infra')}>
                         <IconTopologyStar3 className='mr-2 h-4 w-4' />

--- a/apps/frontend/src/components/layout/app.main.sidebar.tsx
+++ b/apps/frontend/src/components/layout/app.main.sidebar.tsx
@@ -11,6 +11,7 @@ import { useIncomingCallToasts } from '@/features/calls/hooks/use.incoming.calls
 import { ShowActiveCall } from '@/features/calls/components/show.active.call';
 import { useNotifications } from '@/features/calls/hooks/use.notifications';
 import { useListeners } from '@/features/calls/hooks/use.listeners';
+import { SettingsDialog } from '@/features/settings';
 
 export default function AppMainSidebar({ useMock }: any) {
   useAnalytics({
@@ -37,6 +38,9 @@ export default function AppMainSidebar({ useMock }: any) {
     <>
       {!useMock ? <CallQueuePanel /> : null}
       {!useMock ? <ShowActiveCall /> : null}
+      {/* One instance for the whole dashboard — the sidebar user menu and the
+          ⇧⌘, shortcut both drive it through the settings dialog store. */}
+      {!useMock ? <SettingsDialog /> : null}
 
       <AppSidebar useMock={useMock} />
     </>

--- a/apps/frontend/src/features/integrations/components/integrations-view-page.tsx
+++ b/apps/frontend/src/features/integrations/components/integrations-view-page.tsx
@@ -1,40 +1,15 @@
 'use client';
 
 import {
-  Alert,
-  AlertDescription,
-  AlertTitle
-} from '@ringee/frontend-shared/components/ui/alert';
-import { Button } from '@ringee/frontend-shared/components/ui/button';
-import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
-import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger
 } from '@ringee/frontend-shared/components/ui/tabs';
-import { useApi } from '@ringee/frontend-shared/hooks/use.api';
-import {
-  AlertCircle,
-  Bot,
-  Plug,
-  PlugZap,
-  RefreshCw,
-  Sparkles,
-  Users
-} from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Bot, PlugZap, Sparkles, Users } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useOrgRole } from '@ringee/frontend-shared/hooks/use-org-role';
-import { toast } from 'sonner';
-import { useCrmConnections } from '../hooks/use-crm-connections';
-import type { CrmConnectionSummary, CrmProviderType } from '../types/crm';
-import { PROVIDER_META } from '../types/crm';
-import { AttioAppTokenSection } from './attio-app-token-section';
-import { CrmConnectionCard } from './crm-connection-card';
-import { ProviderCatalog } from './provider-catalog';
-import { ConnectionManagementSheet } from './connection-management-sheet';
+import { CrmTab } from './tabs/crm-tab';
 import { EnrichmentTab } from './tabs/enrichment-tab';
 import { CustomIntegrationsTab } from './tabs/custom-integrations-tab';
 import { ConnectorsTab } from './tabs/connectors-tab';
@@ -42,139 +17,9 @@ import { LeadSearchPanel } from './lead-search-panel';
 
 export default function IntegrationsViewPage() {
   const t = useTranslations('crm');
-  const api = useApi();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const { connections, loading, error, reload } = useCrmConnections();
   // CRM, Data Enrichment and Custom Integrations are admin-only (freelancers
   // count as admin). Members keep the Leads (prospecting) tab.
   const { canAccessAdminFeatures } = useOrgRole();
-  const [manageConnection, setManageConnection] =
-    useState<CrmConnectionSummary | null>(null);
-  const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
-  const [syncingId, setSyncingId] = useState<string | null>(null);
-  const notifiedRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    const crm = searchParams.get('crm');
-    const provider = searchParams.get('provider');
-    const reason = searchParams.get('reason');
-    if (!crm) return;
-    const key = `${crm}:${provider}:${reason}`;
-    if (notifiedRef.current === key) return;
-    notifiedRef.current = key;
-    if (crm === 'connected' && provider) {
-      toast.success(
-        t('toasts.providerConnected', {
-          provider: PROVIDER_META[provider as CrmProviderType]?.name ?? provider
-        })
-      );
-      reload();
-    } else if (crm === 'error') {
-      toast.error(
-        reason
-          ? t('toasts.connectionFailedReason', { reason })
-          : t('toasts.connectionFailed')
-      );
-    }
-    const url = new URL(window.location.href);
-    url.searchParams.delete('crm');
-    url.searchParams.delete('provider');
-    url.searchParams.delete('reason');
-    url.searchParams.delete('connectionId');
-    router.replace(url.pathname + (url.search ? url.search : ''));
-  }, [searchParams, router, reload]);
-
-  const handleConnect = async (
-    provider: CrmProviderType,
-    scope: 'personal' | 'organization'
-  ) => {
-    // Odoo uses credential-based auth (not OAuth) — we show a hint and let
-    // the user re-enter credentials via the dialog in the catalog below.
-    if (provider === 'odoo_14_18' || provider === 'odoo_19_plus') {
-      toast.info(t('toasts.odooHint'));
-      return;
-    }
-    try {
-      const current =
-        typeof window !== 'undefined'
-          ? window.location.href.split('?')[0]
-          : undefined;
-      const res = await api.get<{ url: string }>(
-        `/crm/${provider}/oauth/start`,
-        { scope, ...(current ? { redirect: current } : {}) }
-      );
-      if (res?.url) {
-        window.location.href = res.url;
-      } else {
-        toast.error(t('toasts.authStartError'));
-      }
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : t('toasts.authError'));
-    }
-  };
-
-  const handleDisconnect = async (id: string) => {
-    setDisconnectingId(id);
-    try {
-      await api.delete(`/crm/connections/${id}`);
-      toast.success(t('toasts.disconnected'));
-      await reload();
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t('toasts.disconnectError')
-      );
-    } finally {
-      setDisconnectingId(null);
-    }
-  };
-
-  const handleForget = async (id: string) => {
-    setDisconnectingId(id);
-    try {
-      await api.post(`/crm/connections/${id}/forget`);
-      toast.success(t('toasts.forgotten'));
-      await reload();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : t('toasts.forgetError'));
-    } finally {
-      setDisconnectingId(null);
-    }
-  };
-
-  const handleSync = async (id: string) => {
-    setSyncingId(id);
-    try {
-      await api.post(`/crm/connections/${id}/sync`);
-      toast.success(t('syncSuccess'));
-      await reload();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : t('syncError'));
-    } finally {
-      setSyncingId(null);
-    }
-  };
-
-  const handleManage = (id: string) => {
-    const conn = connections.find((c) => c.id === id) ?? null;
-    setManageConnection(conn);
-  };
-
-  const connectedProviders = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          connections
-            .filter((c) => c.status === 'active')
-            .map((c) => c.provider)
-        )
-      ),
-    [connections]
-  );
-
-  const needsAttention = connections.filter(
-    (c) => c.status === 'error' || c.status === 'revoked'
-  );
 
   return (
     <Tabs
@@ -229,174 +74,9 @@ export default function IntegrationsViewPage() {
 
       {canAccessAdminFeatures && (
         <TabsContent value='crm' className='mt-6'>
-          <CrmTabContent
-            loading={loading}
-            error={error}
-            connections={connections}
-            needsAttention={needsAttention}
-            connectedProviders={connectedProviders}
-            disconnectingId={disconnectingId}
-            syncingId={syncingId}
-            onReload={reload}
-            onConnect={handleConnect}
-            onDisconnect={handleDisconnect}
-            onForget={handleForget}
-            onManage={handleManage}
-            onSync={handleSync}
-            t={t}
-          />
+          <CrmTab />
         </TabsContent>
       )}
-
-      <ConnectionManagementSheet
-        connection={manageConnection}
-        open={!!manageConnection}
-        onOpenChange={(open) => !open && setManageConnection(null)}
-      />
     </Tabs>
-  );
-}
-
-type TFunc = (key: string, values?: Record<string, unknown>) => string;
-
-interface CrmTabContentProps {
-  loading: boolean;
-  error: string | null;
-  connections: CrmConnectionSummary[];
-  needsAttention: CrmConnectionSummary[];
-  connectedProviders: CrmProviderType[];
-  disconnectingId: string | null;
-  syncingId: string | null;
-  onReload: () => void;
-  onConnect: (
-    provider: CrmProviderType,
-    scope: 'personal' | 'organization'
-  ) => Promise<void>;
-  onDisconnect: (id: string) => Promise<void>;
-  onForget: (id: string) => Promise<void>;
-  onManage: (id: string) => void;
-  onSync: (id: string) => Promise<void>;
-  t: TFunc;
-}
-
-function CrmTabContent({
-  loading,
-  error,
-  connections,
-  needsAttention,
-  connectedProviders,
-  disconnectingId,
-  syncingId,
-  onReload,
-  onConnect,
-  onDisconnect,
-  onForget,
-  onManage,
-  onSync,
-  t
-}: CrmTabContentProps) {
-  return (
-    <div className='flex flex-col gap-8'>
-      {needsAttention.length > 0 && (
-        <Alert className='border-amber-500/30 bg-amber-500/5'>
-          <AlertCircle className='h-4 w-4 text-amber-500' />
-          <AlertTitle>
-            {t('connections.needsAttention', { count: needsAttention.length })}
-          </AlertTitle>
-          <AlertDescription>
-            {t('connections.needsAttentionDescription')}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      <section className='flex flex-col gap-4'>
-        <div className='flex items-center justify-between'>
-          <div>
-            <h2 className='text-muted-foreground text-sm font-semibold tracking-wide uppercase'>
-              {t('connections.yourConnections')}
-            </h2>
-          </div>
-          <Button
-            variant='ghost'
-            size='sm'
-            onClick={() => onReload()}
-            disabled={loading}
-            className='h-8'
-          >
-            <RefreshCw
-              className={`mr-1.5 h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
-            />
-            {t('connections.refresh')}
-          </Button>
-        </div>
-
-        {loading ? (
-          <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
-            {Array.from({ length: 2 }).map((_, i) => (
-              <Skeleton key={i} className='h-52 w-full rounded-xl' />
-            ))}
-          </div>
-        ) : error ? (
-          <Alert variant='destructive'>
-            <AlertCircle className='h-4 w-4' />
-            <AlertTitle>{t('connections.loadError')}</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        ) : connections.length === 0 ? (
-          <EmptyState t={t} />
-        ) : (
-          <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
-            {connections.map((c) => (
-              <CrmConnectionCard
-                key={c.id}
-                connection={c}
-                onDisconnect={onDisconnect}
-                onForget={onForget}
-                onReconnect={onConnect}
-                onViewHistory={(id) => onManage(id)}
-                onManage={onManage}
-                onSync={onSync}
-                syncing={syncingId === c.id}
-                disconnecting={disconnectingId === c.id}
-              />
-            ))}
-          </div>
-        )}
-      </section>
-
-      <AttioAppTokenSection />
-
-      <section className='flex flex-col gap-4'>
-        <div>
-          <h2 className='text-muted-foreground text-sm font-semibold tracking-wide uppercase'>
-            {t('connections.available')}
-          </h2>
-          <p className='text-muted-foreground mt-1 text-xs'>
-            {t('connections.availableDescription')}
-          </p>
-        </div>
-        <ProviderCatalog
-          onConnect={onConnect}
-          connectedProviders={connectedProviders}
-          onReload={onReload}
-        />
-      </section>
-    </div>
-  );
-}
-
-function EmptyState({ t }: { t: TFunc }) {
-  return (
-    <div className='bg-muted/20 flex flex-col items-center gap-2 rounded-xl border border-dashed px-6 py-12 text-center'>
-      <div className='bg-muted flex h-12 w-12 items-center justify-center rounded-full'>
-        <Plug className='text-muted-foreground h-5 w-5' />
-      </div>
-      <h3 className='mt-2 text-sm font-semibold'>
-        {t('connections.noConnections')}
-      </h3>
-      <p className='text-muted-foreground max-w-sm text-xs'>
-        {t('connections.noConnectionsDescription')}
-      </p>
-    </div>
   );
 }

--- a/apps/frontend/src/features/integrations/components/tabs/crm-tab.tsx
+++ b/apps/frontend/src/features/integrations/components/tabs/crm-tab.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle
+} from '@ringee/frontend-shared/components/ui/alert';
+import { Button } from '@ringee/frontend-shared/components/ui/button';
+import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
+import { useApi } from '@ringee/frontend-shared/hooks/use.api';
+import { AlertCircle, Plug, RefreshCw } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { useCrmConnections } from '../../hooks/use-crm-connections';
+import type { CrmConnectionSummary, CrmProviderType } from '../../types/crm';
+import { PROVIDER_META } from '../../types/crm';
+import { AttioAppTokenSection } from '../attio-app-token-section';
+import { ConnectionManagementSheet } from '../connection-management-sheet';
+import { CrmConnectionCard } from '../crm-connection-card';
+import { ProviderCatalog } from '../provider-catalog';
+
+interface CrmTabProps {
+  /**
+   * Where the provider sends the browser back after OAuth. Defaults to the
+   * current page, which is what the standalone Integrations page wants. The
+   * settings dialog passes the Integrations page instead, because the dialog
+   * itself is gone by the time the redirect lands and the success toast has to
+   * have somewhere to appear.
+   */
+  oauthReturnUrl?: string;
+}
+
+/**
+ * CRM connections pane: live connections, the Attio app token, and the catalog
+ * of providers still available. Owns the OAuth round-trip for CRM providers.
+ */
+export function CrmTab({ oauthReturnUrl }: CrmTabProps) {
+  const t = useTranslations('crm');
+  const api = useApi();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { connections, loading, error, reload } = useCrmConnections();
+  const [manageConnection, setManageConnection] =
+    useState<CrmConnectionSummary | null>(null);
+  const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
+  const [syncingId, setSyncingId] = useState<string | null>(null);
+  const notifiedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const crm = searchParams.get('crm');
+    const provider = searchParams.get('provider');
+    const reason = searchParams.get('reason');
+    if (!crm) return;
+    const key = `${crm}:${provider}:${reason}`;
+    if (notifiedRef.current === key) return;
+    notifiedRef.current = key;
+    if (crm === 'connected' && provider) {
+      toast.success(
+        t('toasts.providerConnected', {
+          provider: PROVIDER_META[provider as CrmProviderType]?.name ?? provider
+        })
+      );
+      reload();
+    } else if (crm === 'error') {
+      toast.error(
+        reason
+          ? t('toasts.connectionFailedReason', { reason })
+          : t('toasts.connectionFailed')
+      );
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.delete('crm');
+    url.searchParams.delete('provider');
+    url.searchParams.delete('reason');
+    url.searchParams.delete('connectionId');
+    router.replace(url.pathname + (url.search ? url.search : ''));
+  }, [searchParams, router, reload]);
+
+  const handleConnect = async (
+    provider: CrmProviderType,
+    scope: 'personal' | 'organization'
+  ) => {
+    // Odoo uses credential-based auth (not OAuth) — we show a hint and let
+    // the user re-enter credentials via the dialog in the catalog below.
+    if (provider === 'odoo_14_18' || provider === 'odoo_19_plus') {
+      toast.info(t('toasts.odooHint'));
+      return;
+    }
+    try {
+      // The provider needs an absolute URL, and the callback appends its own
+      // `?crm=…` params to whatever we send. So strip both the query and the
+      // fragment: a `#…` left on the end would swallow those params (the
+      // callback's `?` would land inside the fragment) and the success toast
+      // would never fire. `oauthReturnUrl` may be given as a path.
+      const current =
+        typeof window === 'undefined'
+          ? undefined
+          : new URL(
+              oauthReturnUrl ?? window.location.pathname,
+              window.location.origin
+            ).toString();
+      const res = await api.get<{ url: string }>(
+        `/crm/${provider}/oauth/start`,
+        { scope, ...(current ? { redirect: current } : {}) }
+      );
+      if (res?.url) {
+        window.location.href = res.url;
+      } else {
+        toast.error(t('toasts.authStartError'));
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t('toasts.authError'));
+    }
+  };
+
+  const handleDisconnect = async (id: string) => {
+    setDisconnectingId(id);
+    try {
+      await api.delete(`/crm/connections/${id}`);
+      toast.success(t('toasts.disconnected'));
+      await reload();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t('toasts.disconnectError')
+      );
+    } finally {
+      setDisconnectingId(null);
+    }
+  };
+
+  const handleForget = async (id: string) => {
+    setDisconnectingId(id);
+    try {
+      await api.post(`/crm/connections/${id}/forget`);
+      toast.success(t('toasts.forgotten'));
+      await reload();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t('toasts.forgetError'));
+    } finally {
+      setDisconnectingId(null);
+    }
+  };
+
+  const handleSync = async (id: string) => {
+    setSyncingId(id);
+    try {
+      await api.post(`/crm/connections/${id}/sync`);
+      toast.success(t('syncSuccess'));
+      await reload();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t('syncError'));
+    } finally {
+      setSyncingId(null);
+    }
+  };
+
+  const handleManage = (id: string) => {
+    const conn = connections.find((c) => c.id === id) ?? null;
+    setManageConnection(conn);
+  };
+
+  const connectedProviders = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          connections
+            .filter((c) => c.status === 'active')
+            .map((c) => c.provider)
+        )
+      ),
+    [connections]
+  );
+
+  const needsAttention = connections.filter(
+    (c) => c.status === 'error' || c.status === 'revoked'
+  );
+
+  return (
+    <>
+      <div className='flex flex-col gap-8'>
+        {needsAttention.length > 0 && (
+          <Alert className='border-amber-500/30 bg-amber-500/5'>
+            <AlertCircle className='h-4 w-4 text-amber-500' />
+            <AlertTitle>
+              {t('connections.needsAttention', {
+                count: needsAttention.length
+              })}
+            </AlertTitle>
+            <AlertDescription>
+              {t('connections.needsAttentionDescription')}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <section className='flex flex-col gap-4'>
+          <div className='flex items-center justify-between'>
+            <div>
+              <h2 className='text-muted-foreground text-sm font-semibold tracking-wide uppercase'>
+                {t('connections.yourConnections')}
+              </h2>
+            </div>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => reload()}
+              disabled={loading}
+              className='h-8'
+            >
+              <RefreshCw
+                className={`mr-1.5 h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
+              />
+              {t('connections.refresh')}
+            </Button>
+          </div>
+
+          {loading ? (
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+              {Array.from({ length: 2 }).map((_, i) => (
+                <Skeleton key={i} className='h-52 w-full rounded-xl' />
+              ))}
+            </div>
+          ) : error ? (
+            <Alert variant='destructive'>
+              <AlertCircle className='h-4 w-4' />
+              <AlertTitle>{t('connections.loadError')}</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : connections.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+              {connections.map((c) => (
+                <CrmConnectionCard
+                  key={c.id}
+                  connection={c}
+                  onDisconnect={handleDisconnect}
+                  onForget={handleForget}
+                  onReconnect={handleConnect}
+                  onViewHistory={(id) => handleManage(id)}
+                  onManage={handleManage}
+                  onSync={handleSync}
+                  syncing={syncingId === c.id}
+                  disconnecting={disconnectingId === c.id}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <AttioAppTokenSection />
+
+        <section className='flex flex-col gap-4'>
+          <div>
+            <h2 className='text-muted-foreground text-sm font-semibold tracking-wide uppercase'>
+              {t('connections.available')}
+            </h2>
+            <p className='text-muted-foreground mt-1 text-xs'>
+              {t('connections.availableDescription')}
+            </p>
+          </div>
+          <ProviderCatalog
+            onConnect={handleConnect}
+            connectedProviders={connectedProviders}
+            onReload={reload}
+          />
+        </section>
+      </div>
+
+      <ConnectionManagementSheet
+        connection={manageConnection}
+        open={!!manageConnection}
+        onOpenChange={(open) => !open && setManageConnection(null)}
+      />
+    </>
+  );
+}
+
+function EmptyState() {
+  const t = useTranslations('crm');
+
+  return (
+    <div className='bg-muted/20 flex flex-col items-center gap-2 rounded-xl border border-dashed px-6 py-12 text-center'>
+      <div className='bg-muted flex h-12 w-12 items-center justify-center rounded-full'>
+        <Plug className='text-muted-foreground h-5 w-5' />
+      </div>
+      <h3 className='mt-2 text-sm font-semibold'>
+        {t('connections.noConnections')}
+      </h3>
+      <p className='text-muted-foreground max-w-sm text-xs'>
+        {t('connections.noConnectionsDescription')}
+      </p>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/settings/components/panels/general-panel.tsx
+++ b/apps/frontend/src/features/settings/components/panels/general-panel.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useTranslations } from 'next-intl';
+import * as React from 'react';
+
+import { LanguageSelector } from '@/components/i18n/language-selector';
+import { ThemeSelector } from '@ringee/frontend-shared/components/theme-selector';
+import { cn } from '@ringee/frontend-shared/lib/utils';
+
+/** One label/description ↔ control row, the layout used across every pane. */
+export function SettingsRow({
+  label,
+  description,
+  children
+}: {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className='border-border/60 flex flex-col gap-3 border-b py-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between sm:gap-6'>
+      <div className='min-w-0 space-y-0.5'>
+        <p className='text-sm font-medium'>{label}</p>
+        {description && (
+          <p className='text-muted-foreground text-xs leading-relaxed'>
+            {description}
+          </p>
+        )}
+      </div>
+      <div className='shrink-0'>{children}</div>
+    </div>
+  );
+}
+
+/** Group heading inside a pane (`Preferences`, `Workspace`, …). */
+export function SettingsSectionHeading({ children }: { children: string }) {
+  return (
+    <h3 className='text-muted-foreground text-xs font-semibold tracking-wide uppercase'>
+      {children}
+    </h3>
+  );
+}
+
+const MODES = [
+  { value: 'system', icon: Monitor, key: 'system' },
+  { value: 'light', icon: Sun, key: 'light' },
+  { value: 'dark', icon: Moon, key: 'dark' }
+] as const;
+
+/**
+ * Explicit system / light / dark picker. The header's `ModeToggle` stays the
+ * one-tap flip; this is the settings surface where "follow the OS" is a real
+ * choice. Both write through `next-themes`, which owns the value.
+ */
+function AppearanceModeSelector() {
+  const t = useTranslations('settings.appearance');
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  // `theme` is undefined until next-themes reads storage — render the strip
+  // unselected on the server pass instead of flashing the wrong choice.
+  React.useEffect(() => setMounted(true), []);
+
+  return (
+    <div
+      role='radiogroup'
+      aria-label={t('theme')}
+      className='border-border/60 bg-muted/40 inline-flex gap-1 rounded-lg border p-1'
+    >
+      {MODES.map(({ value, icon: Icon, key }) => {
+        const selected = mounted && theme === value;
+        return (
+          <button
+            key={value}
+            type='button'
+            role='radio'
+            aria-checked={selected}
+            title={t(`themes.${key}`)}
+            onClick={() => setTheme(value)}
+            className={cn(
+              'focus-visible:ring-ring flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none',
+              selected
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <Icon className='size-3.5' />
+            <span className='hidden sm:inline'>{t(`themes.${key}`)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Appearance + language — the preferences that are not workspace data. */
+export function GeneralPanel() {
+  const t = useTranslations('settings');
+  const tDialog = useTranslations('settings.dialog.general');
+
+  return (
+    <div className='space-y-4'>
+      <SettingsSectionHeading>{tDialog('preferences')}</SettingsSectionHeading>
+
+      <div className='flex flex-col'>
+        <SettingsRow
+          label={t('appearance.title')}
+          description={t('appearance.description')}
+        >
+          <AppearanceModeSelector />
+        </SettingsRow>
+
+        <SettingsRow
+          label={tDialog('colorTheme')}
+          description={tDialog('colorThemeDescription')}
+        >
+          <ThemeSelector />
+        </SettingsRow>
+
+        <SettingsRow
+          label={t('language.title')}
+          description={t('language.description')}
+        >
+          <LanguageSelector className='w-[200px]' />
+        </SettingsRow>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/settings/components/settings-dialog.tsx
+++ b/apps/frontend/src/features/settings/components/settings-dialog.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle
+} from '@ringee/frontend-shared/components/ui/dialog';
+import { Input } from '@ringee/frontend-shared/components/ui/input';
+import { useOrgRole } from '@ringee/frontend-shared/hooks/use-org-role';
+import { cn } from '@ringee/frontend-shared/lib/utils';
+import { Skeleton } from '@ringee/frontend-shared/components/ui/skeleton';
+import { ChevronLeft, PanelLeft, Search, X } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
+import * as React from 'react';
+
+import { useSettingsDialogUrl } from '../hooks/use-settings-dialog-url';
+import {
+  SETTINGS_SECTIONS,
+  resolveSettingsItem,
+  visibleSettingsItems
+} from '../lib/settings-nav';
+import { useSettingsDialogStore } from '../store/settings-dialog.store';
+import type { SettingsItemId } from '../types';
+import { GeneralPanel } from './panels/general-panel';
+
+/**
+ * Where a CRM OAuth round-trip comes back to. The dialog is gone by then, so
+ * the standalone Integrations page is what shows the result.
+ */
+const CRM_OAUTH_RETURN_URL = '/dashboard/settings/integrations';
+
+function PanelSkeleton() {
+  return (
+    <div className='space-y-3'>
+      <Skeleton className='h-8 w-48' />
+      <Skeleton className='h-28 w-full rounded-xl' />
+      <Skeleton className='h-28 w-full rounded-xl' />
+    </div>
+  );
+}
+
+// The dialog is mounted by the dashboard shell on every page, so the panes stay
+// out of that bundle and are fetched when a pane is actually opened. Only
+// `GeneralPanel` — the default pane, and a small one — is imported eagerly.
+const loading = () => <PanelSkeleton />;
+
+const ScriptEditor = dynamic(
+  () => import('./script-editor').then((m) => m.ScriptEditor),
+  { loading }
+);
+const RecordingSettingsCard = dynamic(
+  () =>
+    import('@/features/transcription/components/recording-settings-card').then(
+      (m) => m.RecordingSettingsCard
+    ),
+  { loading }
+);
+const DeskPhonesView = dynamic(
+  () =>
+    import('@/features/desk-phones/components/desk-phones-view').then(
+      (m) => m.DeskPhonesView
+    ),
+  { loading }
+);
+const CrmTab = dynamic(
+  () =>
+    import('@/features/integrations/components/tabs/crm-tab').then(
+      (m) => m.CrmTab
+    ),
+  { loading }
+);
+const EnrichmentTab = dynamic(
+  () =>
+    import('@/features/integrations/components/tabs/enrichment-tab').then(
+      (m) => m.EnrichmentTab
+    ),
+  { loading }
+);
+const LeadSearchPanel = dynamic(
+  () =>
+    import('@/features/integrations/components/lead-search-panel').then(
+      (m) => m.LeadSearchPanel
+    ),
+  { loading }
+);
+const CustomIntegrationsTab = dynamic(
+  () =>
+    import(
+      '@/features/integrations/components/tabs/custom-integrations-tab'
+    ).then((m) => m.CustomIntegrationsTab),
+  { loading }
+);
+const ConnectorsTab = dynamic(
+  () =>
+    import('@/features/integrations/components/tabs/connectors-tab').then(
+      (m) => m.ConnectorsTab
+    ),
+  { loading }
+);
+
+/**
+ * Ringee's settings surface: one modal, sections in a rail on the left, the
+ * selected pane on the right. Every pane is an existing component — the dialog
+ * only composes and gates them; it owns no settings logic of its own.
+ *
+ * Mounted once by the dashboard shell and driven by `useSettingsDialogStore`,
+ * so any entry point can deep-link into a pane.
+ */
+export function SettingsDialog() {
+  const open = useSettingsDialogStore((s) => s.open);
+  const setOpen = useSettingsDialogStore((s) => s.setOpen);
+  const openSettings = useSettingsDialogStore((s) => s.openSettings);
+  const requestedItem = useSettingsDialogStore((s) => s.requestedItem);
+  const setItem = useSettingsDialogStore((s) => s.setItem);
+
+  const t = useTranslations('settings.dialog');
+  const { canAccessAdminFeatures } = useOrgRole();
+
+  const [query, setQuery] = React.useState('');
+  // Below `md` the rail and the pane share the same space; the rail slides over.
+  const [navOpen, setNavOpen] = React.useState(false);
+  const paneRef = React.useRef<HTMLDivElement>(null);
+
+  const items = React.useMemo(
+    () => visibleSettingsItems(canAccessAdminFeatures),
+    [canAccessAdminFeatures]
+  );
+
+  const activeId = resolveSettingsItem(requestedItem, items);
+  const activeItem = items.find((item) => item.id === activeId) ?? null;
+
+  // Mirrors the open pane into the URL fragment (`#settings/general`) and
+  // reopens from it, so panes are linkable and Back closes the dialog.
+  useSettingsDialogUrl(activeId);
+
+  // ⇧⌘, / ⇧Ctrl+, — the gesture the rest of the category already uses. ⌘K is
+  // taken by the command bar, so settings gets the comma.
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== ',' || !event.shiftKey) return;
+      if (!(event.metaKey || event.ctrlKey)) return;
+      event.preventDefault();
+      openSettings();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [openSettings]);
+
+  // A reopened dialog starts clean rather than on the last search.
+  React.useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setNavOpen(false);
+    }
+  }, [open]);
+
+  // A new pane starts at its top, not at the offset the previous one was at.
+  React.useEffect(() => {
+    paneRef.current?.scrollTo({ top: 0 });
+  }, [activeId]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const sections = SETTINGS_SECTIONS.map((section) => ({
+    id: section,
+    items: items.filter(
+      (item) =>
+        item.section === section &&
+        (!normalizedQuery ||
+          t(`items.${item.id}.label`).toLowerCase().includes(normalizedQuery) ||
+          t(`items.${item.id}.description`)
+            .toLowerCase()
+            .includes(normalizedQuery))
+    )
+  })).filter((section) => section.items.length > 0);
+
+  const selectItem = (id: SettingsItemId) => {
+    setItem(id);
+    setNavOpen(false);
+  };
+
+  // Enter from the search field opens the first match, so a search never needs
+  // the mouse to finish.
+  const onSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') return;
+    const first = sections[0]?.items[0];
+    if (!first) return;
+    event.preventDefault();
+    selectItem(first.id);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        showCloseButton={false}
+        className='h-[min(88vh,760px)] w-[calc(100%-1.5rem)] max-w-[calc(100%-1.5rem)] gap-0 overflow-hidden rounded-xl p-0 sm:max-w-[1040px]'
+      >
+        {/* Radix needs a labelled dialog; the visible title lives in the pane
+            header, so the announced pair is hidden here. */}
+        <DialogTitle className='sr-only'>{t('title')}</DialogTitle>
+        <DialogDescription className='sr-only'>
+          {t('description')}
+        </DialogDescription>
+
+        <div className='relative flex h-full min-h-0'>
+          <aside
+            className={cn(
+              // Opaque while it overlays the pane on small screens; a tint
+              // beside it from `md` up.
+              'bg-sidebar md:bg-sidebar/50 absolute inset-0 z-20 flex flex-col border-r md:relative md:z-auto md:w-[216px] md:shrink-0',
+              !navOpen && 'hidden md:flex'
+            )}
+          >
+            <div className='flex items-center gap-2 p-3'>
+              <div className='relative flex-1'>
+                <Search className='text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2' />
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  onKeyDown={onSearchKeyDown}
+                  placeholder={t('searchPlaceholder')}
+                  aria-label={t('searchPlaceholder')}
+                  className='h-9 pl-8'
+                />
+              </div>
+              <button
+                type='button'
+                onClick={() => setNavOpen(false)}
+                aria-label={t('closeNav')}
+                className='hover:bg-accent text-muted-foreground hover:text-foreground flex size-9 shrink-0 items-center justify-center rounded-md transition-colors md:hidden'
+              >
+                <ChevronLeft className='size-4' />
+              </button>
+            </div>
+
+            <nav className='flex-1 space-y-5 overflow-y-auto px-2 pt-1 pb-4'>
+              {sections.map((section) => (
+                <div key={section.id} className='space-y-1'>
+                  <p className='text-muted-foreground px-3 py-1 text-xs font-medium'>
+                    {t(`sections.${section.id}`)}
+                  </p>
+                  {section.items.map((item) => {
+                    const Icon = item.icon;
+                    const isActive = item.id === activeId;
+                    return (
+                      <button
+                        key={item.id}
+                        type='button'
+                        onClick={() => selectItem(item.id)}
+                        aria-current={isActive ? 'page' : undefined}
+                        className={cn(
+                          'focus-visible:ring-ring flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
+                          isActive
+                            ? 'bg-accent text-accent-foreground font-medium'
+                            : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                        )}
+                      >
+                        <Icon className='size-4 shrink-0' />
+                        <span className='min-w-0 flex-1 text-left leading-snug break-words'>
+                          {t(`items.${item.id}.label`)}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
+
+              {sections.length === 0 && (
+                <p className='text-muted-foreground px-3 py-6 text-center text-xs'>
+                  {t('noResults', { query: query.trim() })}
+                </p>
+              )}
+            </nav>
+          </aside>
+
+          <section className='flex min-w-0 flex-1 flex-col'>
+            <header className='flex items-start gap-3 border-b px-4 py-4 sm:px-6'>
+              <button
+                type='button'
+                onClick={() => setNavOpen(true)}
+                aria-label={t('openNav')}
+                className='hover:bg-accent text-muted-foreground hover:text-foreground -ml-1 flex size-8 shrink-0 items-center justify-center rounded-md transition-colors md:hidden'
+              >
+                <PanelLeft className='size-4' />
+              </button>
+
+              <div className='min-w-0 flex-1'>
+                <h2 className='truncate text-base font-semibold'>
+                  {activeItem ? t(`items.${activeItem.id}.label`) : t('title')}
+                </h2>
+                {activeItem && (
+                  <p className='text-muted-foreground mt-0.5 text-xs'>
+                    {t(`items.${activeItem.id}.description`)}
+                  </p>
+                )}
+              </div>
+
+              <button
+                type='button'
+                onClick={() => setOpen(false)}
+                aria-label={t('close')}
+                className='hover:bg-accent text-muted-foreground hover:text-foreground -mr-1 flex size-8 shrink-0 items-center justify-center rounded-md transition-colors'
+              >
+                <X className='size-4' />
+              </button>
+            </header>
+
+            <div
+              ref={paneRef}
+              className='min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6'
+            >
+              {activeId && <SettingsPanel id={activeId} />}
+            </div>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Only the selected pane mounts, so opening the dialog does not fan out into
+ * every settings and integrations request at once.
+ */
+function SettingsPanel({ id }: { id: SettingsItemId }) {
+  switch (id) {
+    case 'general':
+      return <GeneralPanel />;
+    case 'script':
+      return <ScriptEditor />;
+    case 'recording':
+      return <RecordingSettingsCard className='max-w-2xl' />;
+    case 'desk-phones':
+      return <DeskPhonesView />;
+    case 'crm':
+      return <CrmTab oauthReturnUrl={CRM_OAUTH_RETURN_URL} />;
+    case 'enrichment':
+      return <EnrichmentTab />;
+    case 'leads':
+      return <LeadSearchPanel />;
+    case 'custom':
+      return <CustomIntegrationsTab />;
+    case 'connectors':
+      return <ConnectorsTab />;
+  }
+}

--- a/apps/frontend/src/features/settings/hooks/use-settings-dialog-url.ts
+++ b/apps/frontend/src/features/settings/hooks/use-settings-dialog-url.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import * as React from 'react';
+import {
+  isSettingsHash,
+  settingsHash,
+  settingsItemFromHash
+} from '../lib/settings-nav';
+import { useSettingsDialogStore } from '../store/settings-dialog.store';
+import type { SettingsItemId } from '../types';
+
+/**
+ * Two-way binding between the settings dialog and the URL fragment
+ * (`#settings/general`, `#settings/recording`).
+ *
+ * The dialog overlays whatever page you are on, so it cannot own a route — the
+ * fragment gives it an address anyway: a pane can be linked to, survives a
+ * reload, and Back closes the dialog instead of leaving the page.
+ *
+ * Written with the native History API rather than the Next router: this changes
+ * the URL without a navigation, so no RSC round-trip and no scroll reset.
+ * `pushState` / `replaceState` do not emit `hashchange`, so the two effects
+ * below cannot feed each other.
+ *
+ * @param activeId the pane actually being shown — already resolved against the
+ * caller's role, so an admin-only fragment opened by a member canonicalises to
+ * the pane they landed on.
+ */
+export function useSettingsDialogUrl(activeId: SettingsItemId | null) {
+  const open = useSettingsDialogStore((s) => s.open);
+  const openSettings = useSettingsDialogStore((s) => s.openSettings);
+  const close = useSettingsDialogStore((s) => s.close);
+
+  // Whether the entry currently in history is one we pushed. A fragment the
+  // user arrived with (a shared link, a reload) has nothing behind it, so
+  // closing must rewrite the URL rather than navigate back out of the app.
+  const pushedRef = React.useRef(false);
+  const wasOpenRef = React.useRef(false);
+
+  // URL → dialog. Also covers the first paint, so a shared link opens the pane.
+  React.useEffect(() => {
+    const sync = () => {
+      if (isSettingsHash(window.location.hash)) {
+        openSettings(settingsItemFromHash(window.location.hash) ?? undefined);
+      } else {
+        close();
+      }
+    };
+
+    sync();
+    window.addEventListener('hashchange', sync);
+    return () => window.removeEventListener('hashchange', sync);
+  }, [openSettings, close]);
+
+  // Dialog → URL.
+  React.useEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = open;
+
+    if (open) {
+      if (!activeId) return;
+      const next = settingsHash(activeId);
+      if (window.location.hash === next) return;
+
+      if (isSettingsHash(window.location.hash)) {
+        // Already on a settings fragment — switching panes, or correcting one
+        // that named a pane this account cannot open. Not a new history entry.
+        window.history.replaceState(null, '', next);
+      } else {
+        // Opening from a normal URL: keep that URL in history so Back closes
+        // the dialog and lands back on the page underneath it.
+        window.history.pushState(null, '', next);
+        pushedRef.current = true;
+      }
+      return;
+    }
+
+    // `wasOpen` keeps the first render from stripping a fragment the dialog has
+    // not had the chance to open on yet.
+    if (!wasOpen) return;
+    if (!isSettingsHash(window.location.hash)) return;
+
+    if (pushedRef.current) {
+      pushedRef.current = false;
+      window.history.back();
+    } else {
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search
+      );
+    }
+  }, [open, activeId]);
+}

--- a/apps/frontend/src/features/settings/index.ts
+++ b/apps/frontend/src/features/settings/index.ts
@@ -1,0 +1,3 @@
+export { SettingsDialog } from './components/settings-dialog';
+export { useSettingsDialogStore } from './store/settings-dialog.store';
+export type { SettingsItemId, SettingsSectionId } from './types';

--- a/apps/frontend/src/features/settings/lib/settings-nav.ts
+++ b/apps/frontend/src/features/settings/lib/settings-nav.ts
@@ -1,0 +1,110 @@
+import {
+  Bot,
+  FileText,
+  Mic,
+  Phone,
+  Plug,
+  PlugZap,
+  SlidersHorizontal,
+  Sparkles,
+  Users
+} from 'lucide-react';
+import type {
+  SettingsItemId,
+  SettingsNavItem,
+  SettingsSectionId
+} from '../types';
+
+/** Section order in the rail. */
+export const SETTINGS_SECTIONS: SettingsSectionId[] = [
+  'settings',
+  'integrations'
+];
+
+/**
+ * Single source of truth for the settings dialog navigation. Panels are looked
+ * up by id in `settings-dialog.tsx`; labels live in `settings.dialog.items`.
+ */
+export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
+  { id: 'general', section: 'settings', icon: SlidersHorizontal },
+  { id: 'script', section: 'settings', icon: FileText },
+  { id: 'recording', section: 'settings', icon: Mic, adminOnly: true },
+  { id: 'desk-phones', section: 'settings', icon: Phone, adminOnly: true },
+  { id: 'crm', section: 'integrations', icon: Plug, adminOnly: true },
+  {
+    id: 'enrichment',
+    section: 'integrations',
+    icon: Sparkles,
+    adminOnly: true
+  },
+  { id: 'leads', section: 'integrations', icon: Users },
+  { id: 'custom', section: 'integrations', icon: PlugZap, adminOnly: true },
+  { id: 'connectors', section: 'integrations', icon: Bot }
+];
+
+/** The items a given role may open. */
+export function visibleSettingsItems(
+  canAccessAdminFeatures: boolean
+): SettingsNavItem[] {
+  return SETTINGS_NAV_ITEMS.filter(
+    (item) => canAccessAdminFeatures || !item.adminOnly
+  );
+}
+
+/**
+ * Resolves the pane to show for a requested id. A member deep-linking into an
+ * admin-only pane (the "Integrations" entry points at CRM) lands on the first
+ * pane of the same section they can actually open, never on an empty dialog.
+ */
+export function resolveSettingsItem(
+  requested: SettingsItemId | null,
+  items: SettingsNavItem[]
+): SettingsItemId | null {
+  if (items.length === 0) return null;
+  if (!requested) return items[0].id;
+
+  const exact = items.find((item) => item.id === requested);
+  if (exact) return exact.id;
+
+  const section = SETTINGS_NAV_ITEMS.find(
+    (item) => item.id === requested
+  )?.section;
+  const sameSection = items.find((item) => item.section === section);
+
+  return (sameSection ?? items[0]).id;
+}
+
+/**
+ * The dialog addresses itself through the URL fragment — `#settings/general`,
+ * `#settings/recording` — so a pane can be linked to, reloaded and reached with
+ * the browser's Back button, without the modal needing a route of its own.
+ */
+export const SETTINGS_HASH_PREFIX = 'settings';
+
+const KNOWN_ITEM_IDS = new Set<string>(SETTINGS_NAV_ITEMS.map((i) => i.id));
+
+/** The fragment that addresses a pane, ready for `history.pushState`. */
+export function settingsHash(id: SettingsItemId): string {
+  return `#${SETTINGS_HASH_PREFIX}/${id}`;
+}
+
+/** Whether a fragment belongs to the settings dialog at all. */
+export function isSettingsHash(hash: string): boolean {
+  const [prefix, , ...rest] = stripHash(hash).split('/');
+  return prefix === SETTINGS_HASH_PREFIX && rest.length === 0;
+}
+
+/**
+ * The pane a fragment names, or `null` for a bare `#settings` and for a pane id
+ * that no longer exists — both of which fall back to the first pane, and get
+ * the URL rewritten to the canonical form.
+ */
+export function settingsItemFromHash(hash: string): SettingsItemId | null {
+  if (!isSettingsHash(hash)) return null;
+  const item = stripHash(hash).split('/')[1];
+  return item && KNOWN_ITEM_IDS.has(item) ? (item as SettingsItemId) : null;
+}
+
+function stripHash(hash: string): string {
+  return hash.startsWith('#') ? hash.slice(1) : hash;
+}

--- a/apps/frontend/src/features/settings/store/settings-dialog.store.ts
+++ b/apps/frontend/src/features/settings/store/settings-dialog.store.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { create } from 'zustand';
+import type { SettingsItemId } from '../types';
+
+interface SettingsDialogState {
+  open: boolean;
+  /**
+   * The pane the caller asked for. The dialog resolves it against the panes the
+   * current role may open, so this stays a request, not a guarantee.
+   */
+  requestedItem: SettingsItemId | null;
+  openSettings: (item?: SettingsItemId) => void;
+  setItem: (item: SettingsItemId) => void;
+  setOpen: (open: boolean) => void;
+  close: () => void;
+}
+
+/**
+ * Drives the single settings dialog mounted by the dashboard shell. Kept in a
+ * store (not local state) so any surface — the sidebar user menu, a keyboard
+ * shortcut — can open it on a specific pane without prop-drilling.
+ */
+export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
+  open: false,
+  requestedItem: null,
+  // Without an argument the dialog reopens on the pane it was last showing —
+  // the keyboard shortcut and a bare `#settings` fragment both rely on that.
+  openSettings: (item) =>
+    set((state) => ({
+      open: true,
+      requestedItem: item ?? state.requestedItem
+    })),
+  setItem: (item) => set({ requestedItem: item }),
+  setOpen: (open) => set({ open }),
+  close: () => set({ open: false })
+}));

--- a/apps/frontend/src/features/settings/types.ts
+++ b/apps/frontend/src/features/settings/types.ts
@@ -1,0 +1,32 @@
+import type { ComponentType } from 'react';
+
+/** Sections rendered in the settings dialog's left rail, in display order. */
+export type SettingsSectionId = 'settings' | 'integrations';
+
+/**
+ * Every pane the settings dialog can show. The id is the stable handle used by
+ * the store, the deep-link callers (sidebar user menu) and the translations
+ * under `settings.dialog.items.<id>`.
+ */
+export type SettingsItemId =
+  | 'general'
+  | 'script'
+  | 'recording'
+  | 'desk-phones'
+  | 'crm'
+  | 'enrichment'
+  | 'leads'
+  | 'custom'
+  | 'connectors';
+
+export interface SettingsNavItem {
+  id: SettingsItemId;
+  section: SettingsSectionId;
+  /** Icon component (lucide) rendered in the rail. */
+  icon: ComponentType<{ className?: string }>;
+  /**
+   * Mirrors the gating already applied by the standalone settings pages.
+   * Cosmetic only — the API enforces the same boundary.
+   */
+  adminOnly?: boolean;
+}

--- a/apps/frontend/src/i18n/locales/de/settings.json
+++ b/apps/frontend/src/i18n/locales/de/settings.json
@@ -264,6 +264,62 @@
     "script": "Gesprächsleitfaden",
     "recording": "Aufzeichnung"
   },
+  "dialog": {
+    "title": "Einstellungen",
+    "description": "Verwalten Sie Ihre Präferenzen und die mit Ringee verbundenen Tools.",
+    "searchPlaceholder": "Suchen",
+    "noResults": "Keine Treffer für „{query}“.",
+    "close": "Einstellungen schließen",
+    "openNav": "Bereiche anzeigen",
+    "closeNav": "Bereiche ausblenden",
+    "sections": {
+      "settings": "Einstellungen",
+      "integrations": "Integrationen"
+    },
+    "items": {
+      "general": {
+        "label": "Allgemein",
+        "description": "Darstellung und Sprache Ihres Kontos."
+      },
+      "script": {
+        "label": "Gesprächsleitfaden",
+        "description": "Der Leitfaden, den Ihr Dialer während Anrufen anzeigt."
+      },
+      "recording": {
+        "label": "Aufzeichnungen und Transkripte",
+        "description": "Wählen Sie, welche Anrufe aufgezeichnet und transkribiert werden."
+      },
+      "desk-phones": {
+        "label": "Tischtelefone",
+        "description": "Registrieren Sie ein Yealink, Grandstream, Cisco oder ein beliebiges SIP-Telefon für Ihre Nummer."
+      },
+      "crm": {
+        "label": "CRM",
+        "description": "Anrufe, Ergebnisse und Notizen an Ihr CRM übertragen."
+      },
+      "enrichment": {
+        "label": "Datenanreicherung",
+        "description": "Apollo oder Prospeo verbinden, um Lead-Daten aufzudecken."
+      },
+      "leads": {
+        "label": "Leads finden",
+        "description": "Prospects suchen und als Kontakte importieren."
+      },
+      "custom": {
+        "label": "Benutzerdefinierte Integrationen",
+        "description": "Ringee-Events an Ihre eigenen Endpunkte senden."
+      },
+      "connectors": {
+        "label": "Connectors",
+        "description": "Ringee mit KI-Assistenten und Agent-Tools verbinden."
+      }
+    },
+    "general": {
+      "preferences": "Präferenzen",
+      "colorTheme": "Farbthema",
+      "colorThemeDescription": "Farb- und Schriftsatz, den Ringee überall verwendet."
+    }
+  },
   "overview": {
     "title": "Übersicht",
     "description": "Personalisieren Sie Ihr Konto und Ihren Gesprächsleitfaden."

--- a/apps/frontend/src/i18n/locales/en/settings.json
+++ b/apps/frontend/src/i18n/locales/en/settings.json
@@ -264,6 +264,62 @@
     "script": "Script",
     "recording": "Recording"
   },
+  "dialog": {
+    "title": "Settings",
+    "description": "Manage your preferences and the tools connected to Ringee.",
+    "searchPlaceholder": "Search",
+    "noResults": "Nothing matches “{query}”.",
+    "close": "Close settings",
+    "openNav": "Show sections",
+    "closeNav": "Hide sections",
+    "sections": {
+      "settings": "Settings",
+      "integrations": "Integrations"
+    },
+    "items": {
+      "general": {
+        "label": "General",
+        "description": "Appearance and language for your account."
+      },
+      "script": {
+        "label": "Call script",
+        "description": "The script your dialer reads on calls."
+      },
+      "recording": {
+        "label": "Recordings and transcriptions",
+        "description": "Choose which calls are recorded and transcribed."
+      },
+      "desk-phones": {
+        "label": "Desk phones",
+        "description": "Register a Yealink, Grandstream, Cisco or any SIP phone to your number."
+      },
+      "crm": {
+        "label": "CRM",
+        "description": "Push calls, outcomes and notes to your CRM."
+      },
+      "enrichment": {
+        "label": "Data enrichment",
+        "description": "Connect Apollo or Prospeo to reveal lead details."
+      },
+      "leads": {
+        "label": "Find leads",
+        "description": "Search prospects and import them as contacts."
+      },
+      "custom": {
+        "label": "Custom integrations",
+        "description": "Send Ringee events to your own endpoints."
+      },
+      "connectors": {
+        "label": "Connectors",
+        "description": "Connect Ringee to AI assistants and agent tools."
+      }
+    },
+    "general": {
+      "preferences": "Preferences",
+      "colorTheme": "Color theme",
+      "colorThemeDescription": "The accent and typography set used across Ringee."
+    }
+  },
   "overview": {
     "title": "Overview",
     "description": "Personalize your account and your call script."

--- a/apps/frontend/src/i18n/locales/es/settings.json
+++ b/apps/frontend/src/i18n/locales/es/settings.json
@@ -264,6 +264,62 @@
     "script": "Guion",
     "recording": "Grabación"
   },
+  "dialog": {
+    "title": "Ajustes",
+    "description": "Gestiona tus preferencias y las herramientas conectadas a Ringee.",
+    "searchPlaceholder": "Buscar",
+    "noResults": "No hay resultados para «{query}».",
+    "close": "Cerrar ajustes",
+    "openNav": "Mostrar secciones",
+    "closeNav": "Ocultar secciones",
+    "sections": {
+      "settings": "Ajustes",
+      "integrations": "Integraciones"
+    },
+    "items": {
+      "general": {
+        "label": "General",
+        "description": "Apariencia e idioma de tu cuenta."
+      },
+      "script": {
+        "label": "Guion de llamada",
+        "description": "El guion que tu marcador muestra durante las llamadas."
+      },
+      "recording": {
+        "label": "Grabaciones y transcripciones",
+        "description": "Elige qué llamadas se graban y se transcriben."
+      },
+      "desk-phones": {
+        "label": "Teléfonos de escritorio",
+        "description": "Registra un Yealink, Grandstream, Cisco o cualquier teléfono SIP a tu número."
+      },
+      "crm": {
+        "label": "CRM",
+        "description": "Envía llamadas, resultados y notas a tu CRM."
+      },
+      "enrichment": {
+        "label": "Enriquecimiento de datos",
+        "description": "Conecta Apollo o Prospeo para revelar los datos de los leads."
+      },
+      "leads": {
+        "label": "Buscar leads",
+        "description": "Busca prospectos e impórtalos como contactos."
+      },
+      "custom": {
+        "label": "Integraciones personalizadas",
+        "description": "Envía los eventos de Ringee a tus propios endpoints."
+      },
+      "connectors": {
+        "label": "Conectores",
+        "description": "Conecta Ringee con asistentes de IA y herramientas de agentes."
+      }
+    },
+    "general": {
+      "preferences": "Preferencias",
+      "colorTheme": "Tema de color",
+      "colorThemeDescription": "El conjunto de color y tipografía que usa Ringee."
+    }
+  },
   "overview": {
     "title": "Resumen",
     "description": "Personaliza tu cuenta y tu guion de llamadas."

--- a/apps/frontend/src/i18n/locales/fr/settings.json
+++ b/apps/frontend/src/i18n/locales/fr/settings.json
@@ -264,6 +264,62 @@
     "script": "Script",
     "recording": "Enregistrement"
   },
+  "dialog": {
+    "title": "Paramètres",
+    "description": "Gérez vos préférences et les outils connectés à Ringee.",
+    "searchPlaceholder": "Rechercher",
+    "noResults": "Aucun résultat pour « {query} ».",
+    "close": "Fermer les paramètres",
+    "openNav": "Afficher les sections",
+    "closeNav": "Masquer les sections",
+    "sections": {
+      "settings": "Paramètres",
+      "integrations": "Intégrations"
+    },
+    "items": {
+      "general": {
+        "label": "Général",
+        "description": "Apparence et langue de votre compte."
+      },
+      "script": {
+        "label": "Script d'appel",
+        "description": "Le script que votre composeur affiche pendant les appels."
+      },
+      "recording": {
+        "label": "Enregistrements et transcriptions",
+        "description": "Choisissez quels appels sont enregistrés et transcrits."
+      },
+      "desk-phones": {
+        "label": "Téléphones de bureau",
+        "description": "Enregistrez un Yealink, Grandstream, Cisco ou tout téléphone SIP sur votre numéro."
+      },
+      "crm": {
+        "label": "CRM",
+        "description": "Envoyez appels, résultats et notes vers votre CRM."
+      },
+      "enrichment": {
+        "label": "Enrichissement des données",
+        "description": "Connectez Apollo ou Prospeo pour révéler les coordonnées des prospects."
+      },
+      "leads": {
+        "label": "Trouver des prospects",
+        "description": "Recherchez des prospects et importez-les comme contacts."
+      },
+      "custom": {
+        "label": "Intégrations personnalisées",
+        "description": "Envoyez les événements Ringee vers vos propres endpoints."
+      },
+      "connectors": {
+        "label": "Connecteurs",
+        "description": "Connectez Ringee aux assistants IA et aux outils d'agents."
+      }
+    },
+    "general": {
+      "preferences": "Préférences",
+      "colorTheme": "Thème de couleur",
+      "colorThemeDescription": "La palette et la typographie utilisées dans Ringee."
+    }
+  },
   "overview": {
     "title": "Aperçu",
     "description": "Personnalisez votre compte et votre script d'appel."

--- a/apps/frontend/src/i18n/locales/it/settings.json
+++ b/apps/frontend/src/i18n/locales/it/settings.json
@@ -264,6 +264,62 @@
     "script": "Script",
     "recording": "Registrazione"
   },
+  "dialog": {
+    "title": "Impostazioni",
+    "description": "Gestisci le tue preferenze e gli strumenti collegati a Ringee.",
+    "searchPlaceholder": "Cerca",
+    "noResults": "Nessun risultato per «{query}».",
+    "close": "Chiudi impostazioni",
+    "openNav": "Mostra sezioni",
+    "closeNav": "Nascondi sezioni",
+    "sections": {
+      "settings": "Impostazioni",
+      "integrations": "Integrazioni"
+    },
+    "items": {
+      "general": {
+        "label": "Generale",
+        "description": "Aspetto e lingua del tuo account."
+      },
+      "script": {
+        "label": "Script di chiamata",
+        "description": "Lo script che il dialer mostra durante le chiamate."
+      },
+      "recording": {
+        "label": "Registrazioni e trascrizioni",
+        "description": "Scegli quali chiamate vengono registrate e trascritte."
+      },
+      "desk-phones": {
+        "label": "Telefoni da scrivania",
+        "description": "Registra un Yealink, Grandstream, Cisco o qualsiasi telefono SIP sul tuo numero."
+      },
+      "crm": {
+        "label": "CRM",
+        "description": "Invia chiamate, esiti e note al tuo CRM."
+      },
+      "enrichment": {
+        "label": "Arricchimento dati",
+        "description": "Collega Apollo o Prospeo per rivelare i dati dei lead."
+      },
+      "leads": {
+        "label": "Trova prospect",
+        "description": "Cerca prospect e importali come contatti."
+      },
+      "custom": {
+        "label": "Integrazioni personalizzate",
+        "description": "Invia gli eventi Ringee ai tuoi endpoint."
+      },
+      "connectors": {
+        "label": "Connettori",
+        "description": "Collega Ringee ad assistenti IA e strumenti per agenti."
+      }
+    },
+    "general": {
+      "preferences": "Preferenze",
+      "colorTheme": "Tema colore",
+      "colorThemeDescription": "Il set di colori e caratteri usato in Ringee."
+    }
+  },
   "overview": {
     "title": "Panoramica",
     "description": "Personalizza il tuo account e il tuo script di chiamata."

--- a/apps/frontend/src/i18n/locales/nl/settings.json
+++ b/apps/frontend/src/i18n/locales/nl/settings.json
@@ -264,6 +264,62 @@
     "script": "Belscript",
     "recording": "Opname"
   },
+  "dialog": {
+    "title": "Instellingen",
+    "description": "Beheer je voorkeuren en de tools die met Ringee zijn verbonden.",
+    "searchPlaceholder": "Zoeken",
+    "noResults": "Geen resultaten voor ‘{query}’.",
+    "close": "Instellingen sluiten",
+    "openNav": "Secties tonen",
+    "closeNav": "Secties verbergen",
+    "sections": {
+      "settings": "Instellingen",
+      "integrations": "Integraties"
+    },
+    "items": {
+      "general": {
+        "label": "Algemeen",
+        "description": "Weergave en taal van je account."
+      },
+      "script": {
+        "label": "Belscript",
+        "description": "Het script dat je dialer tijdens gesprekken toont."
+      },
+      "recording": {
+        "label": "Opnames en transcripties",
+        "description": "Kies welke gesprekken worden opgenomen en getranscribeerd."
+      },
+      "desk-phones": {
+        "label": "Bureautelefoons",
+        "description": "Registreer een Yealink, Grandstream, Cisco of elke SIP-telefoon op je nummer."
+      },
+      "crm": {
+        "label": "CRM",
+        "description": "Stuur gesprekken, resultaten en notities naar je CRM."
+      },
+      "enrichment": {
+        "label": "Gegevensverrijking",
+        "description": "Koppel Apollo of Prospeo om leadgegevens te onthullen."
+      },
+      "leads": {
+        "label": "Leads zoeken",
+        "description": "Zoek prospects en importeer ze als contacten."
+      },
+      "custom": {
+        "label": "Aangepaste integraties",
+        "description": "Stuur Ringee-events naar je eigen endpoints."
+      },
+      "connectors": {
+        "label": "Connectors",
+        "description": "Koppel Ringee aan AI-assistenten en agent-tools."
+      }
+    },
+    "general": {
+      "preferences": "Voorkeuren",
+      "colorTheme": "Kleurthema",
+      "colorThemeDescription": "De kleuren- en typografieset die Ringee gebruikt."
+    }
+  },
   "overview": {
     "title": "Overzicht",
     "description": "Personaliseer je account en je belscript."

--- a/apps/frontend/src/i18n/locales/pt/settings.json
+++ b/apps/frontend/src/i18n/locales/pt/settings.json
@@ -264,6 +264,62 @@
     "script": "Script",
     "recording": "Gravação"
   },
+  "dialog": {
+    "title": "Definições",
+    "description": "Gere as tuas preferências e as ferramentas ligadas ao Ringee.",
+    "searchPlaceholder": "Pesquisar",
+    "noResults": "Sem resultados para «{query}».",
+    "close": "Fechar definições",
+    "openNav": "Mostrar secções",
+    "closeNav": "Ocultar secções",
+    "sections": {
+      "settings": "Definições",
+      "integrations": "Integrações"
+    },
+    "items": {
+      "general": {
+        "label": "Geral",
+        "description": "Aparência e idioma da tua conta."
+      },
+      "script": {
+        "label": "Script de chamada",
+        "description": "O script que o teu marcador mostra durante as chamadas."
+      },
+      "recording": {
+        "label": "Gravações e transcrições",
+        "description": "Escolhe que chamadas são gravadas e transcritas."
+      },
+      "desk-phones": {
+        "label": "Telefones de secretária",
+        "description": "Regista um Yealink, Grandstream, Cisco ou qualquer telefone SIP no teu número."
+      },
+      "crm": {
+        "label": "CRM",
+        "description": "Envia chamadas, resultados e notas para o teu CRM."
+      },
+      "enrichment": {
+        "label": "Enriquecimento de dados",
+        "description": "Liga o Apollo ou o Prospeo para revelar os dados dos leads."
+      },
+      "leads": {
+        "label": "Encontrar leads",
+        "description": "Procura prospetos e importa-os como contactos."
+      },
+      "custom": {
+        "label": "Integrações personalizadas",
+        "description": "Envia os eventos do Ringee para os teus endpoints."
+      },
+      "connectors": {
+        "label": "Conectores",
+        "description": "Liga o Ringee a assistentes de IA e ferramentas de agentes."
+      }
+    },
+    "general": {
+      "preferences": "Preferências",
+      "colorTheme": "Tema de cor",
+      "colorThemeDescription": "O conjunto de cores e tipografia usado no Ringee."
+    }
+  },
   "overview": {
     "title": "Resumo",
     "description": "Personaliza a tua conta e o teu script de chamada."


### PR DESCRIPTION
- Implemented the SettingsDialog component for managing user preferences and integrations.
- Created hooks for URL synchronization with the settings dialog.
- Established a Zustand store for managing the dialog's open state and requested items.
- Defined settings navigation structure and items with corresponding icons.
- Added localization support for the settings dialog in multiple languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changed behavior

- The sidebar Settings action now opens a shared settings dialog. Mock mode still navigates to `/dashboard/settings/overview`.
- The dialog supports searchable navigation, keyboard shortcuts, URL hash synchronization, and role-based visibility.
- CRM integration handling moved into `CrmTab`, including OAuth callback processing, connection actions, provider-specific Odoo behavior, and error-state alerts.
- General preferences now expose appearance, color theme, and language controls.
- Settings dialog text was added for English, German, Spanish, French, Italian, Dutch, and Portuguese.

## Architectural impact

- Added a Zustand store as the owner of dialog visibility and selected-pane state.
- Added a settings navigation model with section and pane identifiers, admin filtering, fallback resolution, and `#settings/<pane>` hash helpers.
- Added a URL synchronization hook that uses `pushState`, `replaceState`, and `history.back()`.
- Added lazy-loaded settings panels behind the new `SettingsDialog` component.
- CRM UI ownership moved from `integrations-view-page.tsx` to `CrmTab`; inspect this boundary for duplicated or missing integration behavior.

## Risk areas

- Browser history can become inconsistent when users open, close, or directly navigate to settings hashes. Verify back-button behavior and first-render handling.
- OAuth callback parameters are removed from the URL after toast handling. Verify that refreshes and failed callbacks cannot lose actionable error context.
- Admin-only pane filtering must remain consistent with requested pane resolution. A restricted hash or stored pane must not expose or mount an unauthorized panel.
- The new absolute OAuth return URL must preserve the expected origin and path across deployments.
- The CRM refactor can change disconnect, forget, sync, manage, loading, and error behavior even though the integration API contract is unchanged.

## Files to review first

- `apps/frontend/src/features/settings/hooks/use-settings-dialog-url.ts`
- `apps/frontend/src/features/settings/components/settings-dialog.tsx`
- `apps/frontend/src/features/settings/lib/settings-nav.ts`
- `apps/frontend/src/features/integrations/components/tabs/crm-tab.tsx`
- `apps/frontend/src/features/integrations/components/integrations-view-page.tsx`
- `apps/frontend/src/components/layout/app-sidebar.tsx`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->