### PR TITLE
feat: implement machine view and claims document rendering

### DIFF
--- a/apps/frontend/src/app/(marketing)/machine/page.tsx
+++ b/apps/frontend/src/app/(marketing)/machine/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { ArrowUpRight } from 'lucide-react';
+
+import { buildMetadata } from '@/features/marketing/seo';
+import { AgentSession } from '@/features/marketing/components/agent-session';
+import { CodeBlock } from '@/features/marketing/components/code-block';
+import { RenderingSwitch } from '@/features/marketing/components/rendering-switch';
+import {
+  ButtonLink,
+  Card,
+  Container,
+  Eyebrow,
+  Section
+} from '@/features/marketing/components/primitives';
+import {
+  AGENT_SESSION,
+  MACHINE_MD_PATH,
+  MACHINE_SURFACES,
+  TOOL_SURFACE,
+  buildClaimsDocument
+} from '@/features/marketing/content/machine-view';
+import {
+  DOCS_MCP_CONNECT_URL,
+  DOCS_URL,
+  SITE_URL
+} from '@/features/marketing/site';
+
+export const metadata: Metadata = buildMetadata({
+  title: 'Machine view — what an AI agent sees on Ringee',
+  description:
+    'The machine rendering of ringee.io: a replay of the outbound loop against the surfaces Ringee actually serves — llms.txt, Agent Skills, the MCP server — and the generated claims document behind them.',
+  path: '/machine'
+});
+
+/**
+ * `/machine` — the same site, rendered for the thing that reads it.
+ *
+ * Ringee is driven by agents, so the marketing site owes them a page that is
+ * not a brochure: what an agent finds when it lands on the domain, the loop it
+ * would actually run, and the claims document it can fetch as bytes at
+ * `/machine.md`. Everything on the page comes from the same content modules
+ * that render the human home page, so the two cannot disagree.
+ *
+ * The page itself is an ordinary marketing page — same theme, same primitives
+ * as every other route. Only the transcript and the document are dark, the way
+ * a terminal and a code block are dark everywhere else on the site.
+ */
+export default function MachineViewPage() {
+  const claims = buildClaimsDocument();
+
+  return (
+    <Section className='pt-14 pb-20 sm:pt-16 sm:pb-24'>
+      <Container className='flex flex-col gap-14'>
+        <div className='flex flex-col gap-10'>
+          <RenderingSwitch active='machine' />
+
+          <div className='flex max-w-3xl flex-col gap-5'>
+            <h1 className='text-4xl font-bold tracking-tight text-balance sm:text-5xl'>
+              Machine view
+            </h1>
+            <p className='text-muted-foreground font-mono text-sm leading-6 italic'>
+              {'// '}parity by construction: everything below is generated from
+              the same objects that render the human page. Same truth, two
+              renderings. The session is a replay of the outbound loop —
+              discover, install, connect, prospect, dial, follow up — against
+              the surfaces Ringee actually serves.
+            </p>
+            <p className='text-muted-foreground/70 font-mono text-sm italic'>
+              what an agent sees · {TOOL_SURFACE.total} tools · one step that is
+              still a person&rsquo;s
+            </p>
+          </div>
+        </div>
+
+        <AgentSession lines={AGENT_SESSION} />
+
+        <div className='flex flex-col gap-6'>
+          <Eyebrow>Surfaces · no account required</Eyebrow>
+          <ul className='grid gap-4 sm:grid-cols-2'>
+            {MACHINE_SURFACES.map((surface) => (
+              <li key={surface.href}>
+                <Link
+                  href={surface.href}
+                  {...(surface.external
+                    ? { target: '_blank', rel: 'noreferrer noopener' }
+                    : {})}
+                  className='block h-full'
+                >
+                  <Card className='hover:border-foreground/30 flex h-full flex-col gap-2 transition-colors'>
+                    <span className='flex items-center gap-1.5 font-mono text-sm font-medium break-all text-emerald-600 dark:text-emerald-400'>
+                      {surface.label}
+                      <ArrowUpRight
+                        className='h-3.5 w-3.5 shrink-0'
+                        aria-hidden
+                      />
+                    </span>
+                    <span className='text-muted-foreground text-sm'>
+                      {surface.blurb}
+                    </span>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className='flex flex-col gap-6'>
+          <div className='flex flex-wrap items-center justify-between gap-3'>
+            <Eyebrow>Claims document</Eyebrow>
+            <Link
+              href={MACHINE_MD_PATH}
+              className='text-muted-foreground hover:text-foreground inline-flex items-center gap-1 font-mono text-xs transition-colors'
+            >
+              View raw
+              <ArrowUpRight className='h-3.5 w-3.5' aria-hidden />
+            </Link>
+          </div>
+          <CodeBlock
+            code={claims}
+            label={`GET ${SITE_URL.replace('https://', '')}${MACHINE_MD_PATH}`}
+            language='markdown'
+            bodyClassName='max-h-[34rem] overflow-y-auto'
+          />
+        </div>
+
+        <div className='border-border/70 flex flex-col gap-6 border-t pt-12'>
+          <h2 className='max-w-2xl text-2xl font-bold tracking-tight text-balance sm:text-3xl'>
+            Connect an agent, then let a person take the call
+          </h2>
+          <p className='text-muted-foreground max-w-2xl text-pretty'>
+            Install the skills from this domain, point your MCP client at your
+            workspace URL, and the loop above runs on your own contacts.
+          </p>
+          <div className='flex flex-col gap-3 sm:flex-row sm:gap-4'>
+            <ButtonLink href={DOCS_MCP_CONNECT_URL} external withArrow>
+              Connect the MCP server
+            </ButtonLink>
+            <ButtonLink href={DOCS_URL} variant='secondary' external withArrow>
+              Developer docs
+            </ButtonLink>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/frontend/src/app/(marketing)/page.tsx
+++ b/apps/frontend/src/app/(marketing)/page.tsx
@@ -16,6 +16,7 @@ import {
   SectionHeading
 } from '@/features/marketing/components/primitives';
 import { CtaSection } from '@/features/marketing/components/cta-section';
+import { RenderingSwitch } from '@/features/marketing/components/rendering-switch';
 import { RunsFrom } from '@/features/marketing/components/agent-marks';
 import { AgenticMode } from '@/features/marketing/components/agentic-mode';
 import { EverywhereMode } from '@/features/marketing/components/everywhere-mode';
@@ -63,6 +64,9 @@ export default async function HomePage() {
         <Container className='grid items-center gap-12 lg:grid-cols-2 lg:gap-16'>
           {/* Copy */}
           <div className='flex flex-col items-center text-center lg:items-start lg:text-left'>
+            {/* Which rendering you are reading. The other one is /machine. */}
+            <RenderingSwitch active='human' className='mb-10' />
+
             <Link
               href='/open-source'
               className='border-border/70 bg-background/60 text-muted-foreground hover:text-foreground mb-7 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium backdrop-blur-sm'

--- a/apps/frontend/src/app/machine.md/route.ts
+++ b/apps/frontend/src/app/machine.md/route.ts
@@ -1,0 +1,27 @@
+import { buildClaimsDocument } from '@/features/marketing/content/machine-view';
+
+/**
+ * `/machine.md` — the claims document shown on `/machine`, as bytes.
+ *
+ * The page renders this string; an agent fetches it. Same generator, so the
+ * rendering an agent reads and the one a person sees cannot disagree. Served
+ * as a route handler (like `robots.txt` and `/SKILL.md`) so the content type,
+ * caching and CORS headers are set explicitly.
+ *
+ * Prerendered at build time — the body is generated from static content
+ * modules, never from the request.
+ */
+export const dynamic = 'force-static';
+
+export function GET() {
+  return new Response(buildClaimsDocument(), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      // A public document meant to be read cross-origin by browser-based
+      // clients, the same policy the Agent Skills artifacts carry.
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS'
+    }
+  });
+}

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -28,6 +28,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/open-source', priority: 0.7 },
     { path: '/self-hosted', priority: 0.7 },
     { path: '/about', priority: 0.6 },
+    // The machine rendering of the home page — indexable, and the entry point
+    // an AI crawler is most likely to quote from.
+    { path: '/machine', priority: 0.6 },
     { path: '/privacy', priority: 0.3 },
     { path: '/terms', priority: 0.3 },
     { path: '/support', priority: 0.4 }

--- a/apps/frontend/src/features/marketing/components/agent-session.tsx
+++ b/apps/frontend/src/features/marketing/components/agent-session.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+import { RotateCw } from 'lucide-react';
+
+import { cn } from '@ringee/frontend-shared/lib/utils';
+
+import { WindowDots } from './flow-primitives';
+import type { SessionLine, SessionLineKind } from '../content/machine-view';
+
+/**
+ * The agent session on `/machine`: the outbound loop replayed as a terminal.
+ *
+ * Lines are in the initial HTML — a crawler or an agent reads the whole
+ * transcript as plain text, the animation is only the order a person reads it
+ * in. Each line fades in on its own delay; REPLAY restarts the run by
+ * remounting the block, which is all a CSS animation needs.
+ *
+ * The surface is opaque black in both themes, like `CodeBlock` and the terminal
+ * panels in Agentic mode: a terminal does not follow the page theme. Everything
+ * around it does.
+ */
+
+/** One colour per kind of line. The one human step is deliberately not green. */
+const LINE_STYLES: Record<SessionLineKind, string> = {
+  cmd: 'text-emerald-300',
+  out: 'text-zinc-400',
+  ok: 'text-emerald-400',
+  tool: 'text-orange-200',
+  note: 'text-zinc-500 italic',
+  human: 'text-sky-300',
+  done: 'text-zinc-400'
+};
+
+/** Milliseconds between two lines appearing. */
+const STAGGER = 130;
+
+const KEYFRAMES = `
+@keyframes ringee-session-line-in { from { opacity: 0 } }
+.ringee-session-line { animation: ringee-session-line-in 200ms ease-out backwards }
+@media (prefers-reduced-motion: reduce) {
+  .ringee-session-line { animation: none }
+}
+`;
+
+export function AgentSession({
+  lines,
+  className
+}: {
+  lines: readonly SessionLine[];
+  className?: string;
+}) {
+  const [run, setRun] = useState(0);
+
+  return (
+    <div
+      className={cn(
+        // `min-w-0` for the same reason `CodeBlock` carries it: inside a flex
+        // or grid track a long transcript line widens the page instead of
+        // scrolling itself.
+        'w-full min-w-0 overflow-hidden rounded-2xl bg-black',
+        // A dark panel on a light page needs the lift; on a dark page the hair
+        // line does the work. Same treatment as the hero screenshot.
+        'shadow-2xl ring-1 shadow-black/10 ring-black/5 dark:shadow-black/40 dark:ring-white/10',
+        className
+      )}
+    >
+      <style dangerouslySetInnerHTML={{ __html: KEYFRAMES }} />
+      <div className='flex items-center gap-3 border-b border-white/10 px-5 py-3.5 sm:px-6'>
+        <WindowDots onDark />
+        <span className='font-mono text-[11px] tracking-widest text-zinc-500 uppercase'>
+          Agent session
+        </span>
+        <button
+          type='button'
+          onClick={() => setRun((current) => current + 1)}
+          className='ml-auto flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[11px] tracking-widest text-zinc-400 uppercase transition-colors hover:bg-white/5 hover:text-zinc-100'
+        >
+          <RotateCw className='h-3 w-3' aria-hidden />
+          Replay
+        </button>
+      </div>
+      <div
+        role='region'
+        aria-label='Agent session replay'
+        tabIndex={0}
+        className='overflow-x-auto px-5 py-5 sm:px-6 sm:py-6'
+      >
+        <pre key={run} className='font-mono text-[13px] leading-6 sm:text-sm'>
+          <code>
+            {lines.map((line, index) => (
+              <span
+                key={`${line.text}-${index}`}
+                className={cn(
+                  'ringee-session-line block',
+                  LINE_STYLES[line.kind]
+                )}
+                style={{ animationDelay: `${index * STAGGER}ms` }}
+              >
+                {line.text}
+                {'\n'}
+              </span>
+            ))}
+          </code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/marketing/components/code-block.tsx
+++ b/apps/frontend/src/features/marketing/components/code-block.tsx
@@ -12,7 +12,8 @@ export function CodeBlock({
   code,
   label,
   language,
-  className
+  className,
+  bodyClassName
 }: {
   code: string;
   /** Filename or short caption shown in the header bar. */
@@ -20,6 +21,8 @@ export function CodeBlock({
   /** Language tag shown on the right of the header bar. */
   language?: string;
   className?: string;
+  /** Extra classes on the `<pre>` — a long document caps and scrolls here. */
+  bodyClassName?: string;
 }) {
   return (
     <div
@@ -40,7 +43,12 @@ export function CodeBlock({
           ) : null}
         </div>
       ) : null}
-      <pre className='overflow-x-auto px-4 py-4 text-[13px] leading-relaxed text-slate-100'>
+      <pre
+        className={cn(
+          'overflow-x-auto px-4 py-4 text-[13px] leading-relaxed text-slate-100',
+          bodyClassName
+        )}
+      >
         <code className='font-mono'>{code}</code>
       </pre>
     </div>

--- a/apps/frontend/src/features/marketing/components/rendering-switch.tsx
+++ b/apps/frontend/src/features/marketing/components/rendering-switch.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link';
+
+import { cn } from '@ringee/frontend-shared/lib/utils';
+
+/**
+ * "Human | Machine" — which rendering of the site you are reading.
+ *
+ * Ringee publishes the same facts twice: the page you are on, written for a
+ * person, and `/machine`, which is what an agent gets — a replay of the
+ * outbound loop against the surfaces we actually serve, plus the generated
+ * claims document behind them. The switch says out loud that both exist, and
+ * that they are built from the same objects.
+ */
+
+export type Rendering = 'human' | 'machine';
+
+const TABS: { id: Rendering; label: string; href: string }[] = [
+  { id: 'human', label: 'Human', href: '/' },
+  { id: 'machine', label: 'Machine', href: '/machine' }
+];
+
+export function RenderingSwitch({
+  active,
+  className
+}: {
+  active: Rendering;
+  className?: string;
+}) {
+  return (
+    <nav
+      aria-label='Page rendering'
+      className={cn('flex items-start gap-8', className)}
+    >
+      {TABS.map((tab) => {
+        const isActive = tab.id === active;
+        return (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={isActive ? 'page' : undefined}
+            className='group flex flex-col gap-2 transition-transform duration-300 ease-out hover:-translate-y-0.5'
+          >
+            <span
+              className={cn(
+                'text-lg font-semibold whitespace-nowrap transition-colors sm:text-xl',
+                isActive
+                  ? 'text-foreground'
+                  : 'text-muted-foreground group-hover:text-foreground'
+              )}
+            >
+              {tab.label}
+            </span>
+            <span
+              aria-hidden
+              className={cn(
+                'h-[3px] w-full rounded-full transition-colors',
+                isActive
+                  ? 'bg-emerald-600 dark:bg-emerald-400'
+                  : 'bg-transparent'
+              )}
+            />
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/frontend/src/features/marketing/content/machine-view.ts
+++ b/apps/frontend/src/features/marketing/content/machine-view.ts
@@ -1,0 +1,357 @@
+import {
+  CHROME_EXTENSION_URL,
+  CLI_NPM_URL,
+  DOCS_API_URL,
+  DOCS_MCP_URL,
+  DOCS_URL,
+  GITHUB_URL,
+  PRICING,
+  SDK_NPM_URL,
+  SITE_LAST_MODIFIED,
+  SITE_URL
+} from '../site';
+import { PUBLISHED_SKILLS } from './skills.generated';
+import { FEATURES } from './features';
+import { INTEGRATION_CATEGORIES, INTEGRATIONS } from './integrations';
+import { USE_CASES } from './use-cases';
+
+/**
+ * The machine rendering of the marketing site: what `/machine` shows and what
+ * `/machine.md` serves.
+ *
+ * Everything here is derived from the same content modules that render the
+ * human pages — features, integrations, use cases, pricing — so the two
+ * renderings cannot drift apart. Only the facts that live nowhere else (the
+ * shape of the tool surface, the constraints an agent has to plan around) are
+ * written down, and each of those names where it is enforced.
+ *
+ * Keep this module framework-agnostic (no React): it is imported by the page
+ * and by the `/machine.md` route handler.
+ */
+
+/** Canonical path of the generated claims document. */
+export const MACHINE_MD_PATH = '/machine.md';
+
+/* ------------------------------------------------------------------ */
+/* the agent session                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * How a transcript line is coloured. `human` is the one line in the replay
+ * that is not a call — Ringee's whole position is that the conversation stays
+ * a person's, so it gets its own mark.
+ */
+export type SessionLineKind =
+  | 'cmd'
+  | 'out'
+  | 'ok'
+  | 'tool'
+  | 'note'
+  | 'human'
+  | 'done';
+
+export type SessionLine = { kind: SessionLineKind; text: string };
+
+const SKILL_NAMES = PUBLISHED_SKILLS.map((skill) => skill.name).join(', ');
+
+/**
+ * The tool surface, as catalogued in `packages/agent/src/tools/catalog.ts`
+ * (the source of truth — these counts mirror it, they do not define it).
+ */
+export const TOOL_SURFACE = {
+  total: 37,
+  read: 19,
+  write: 10,
+  sensitive: 4,
+  destructive: 4
+} as const;
+
+/**
+ * A replay of the outbound loop as an agent runs it: discover the site, install
+ * the skills, connect the MCP, prospect, queue the call, then log what happened.
+ *
+ * Tool names and argument keys are the real ones (`packages/agent/src/schemas`);
+ * ids and provider results are elided with `…` because they belong to a
+ * workspace, not to a marketing page.
+ */
+export const AGENT_SESSION: readonly SessionLine[] = [
+  { kind: 'cmd', text: `$ curl -s ${SITE_URL}/llms.txt` },
+  { kind: 'out', text: '# Ringee' },
+  {
+    kind: 'out',
+    text: '> Ringee is low-cost, pay-as-you-go outbound calling software built for the AI era.'
+  },
+  { kind: 'out', text: '## Key facts' },
+  { kind: 'cmd', text: `$ npx skills add ${SITE_URL}` },
+  {
+    kind: 'ok',
+    text: `✓ ${PUBLISHED_SKILLS.length} skills · ${SKILL_NAMES}`
+  },
+  {
+    kind: 'note',
+    text: '// discovery index: /.well-known/agent-skills/index.json · entry skill: /SKILL.md'
+  },
+  {
+    kind: 'cmd',
+    text: '$ claude mcp add --transport sse ringee "$RINGEE_MCP_URL"'
+  },
+  {
+    kind: 'ok',
+    text: `✓ connected · ${TOOL_SURFACE.total} tools · ${TOOL_SURFACE.read} read · ${TOOL_SURFACE.write} write · ${TOOL_SURFACE.sensitive} sensitive · ${TOOL_SURFACE.destructive} destructive`
+  },
+  {
+    kind: 'note',
+    text: '// the URL is the credential: minted in the dashboard, bound to one workspace, never guessed'
+  },
+  { kind: 'note', text: '// tools run inside the session, not in the shell' },
+  {
+    kind: 'tool',
+    text: 'search_leads {"jobTitles":["VP Sales"],"personCountries":["Spain"],"industries":["fintech"],"hasPhone":true}'
+  },
+  {
+    kind: 'out',
+    text: '{"jobId":"…","provider":"apollo","candidates":[{"externalId":"…","name":"…","company":"…"}]}'
+  },
+  {
+    kind: 'tool',
+    text: 'reveal_lead {"jobId":"…","externalId":"…","revealPhone":true}'
+  },
+  {
+    kind: 'note',
+    text: '// spends provider credits — the skill stops and asks a person before this one'
+  },
+  { kind: 'out', text: '{"email":"…","phoneNumber":"+34 6·· ··· ···"}' },
+  {
+    kind: 'tool',
+    text: 'import_leads_as_contacts {"jobId":"…","externalIds":["…"]}'
+  },
+  { kind: 'out', text: '{"imported":1,"skippedDuplicatePhone":0}' },
+  {
+    kind: 'tool',
+    text: 'create_call_session {"title":"Tuesday outbound","contacts":[{"contactId":"…"}]}'
+  },
+  {
+    kind: 'out',
+    text: `{"callSessionId":"…","joinUrl":"${SITE_URL}/dialer/session?token=…"}`
+  },
+  {
+    kind: 'note',
+    text: '// the token is returned once and cannot be re-fetched'
+  },
+  {
+    kind: 'human',
+    text: '▸ a person opens the link and has the conversation. this step has no endpoint.'
+  },
+  {
+    kind: 'tool',
+    text: 'log_call_outcome {"callId":"…","outcome":"meeting_booked","outcomeNote":"Demo Friday"}'
+  },
+  {
+    kind: 'tool',
+    text: 'schedule_meeting {"contactId":"…","scheduledAt":"2026-09-16T10:00:00+02:00","callId":"…"}'
+  },
+  {
+    kind: 'out',
+    text: '{"meetingId":"…","calendarProvider":"google","status":"scheduled"}'
+  },
+  {
+    kind: 'done',
+    text: '# 6 tools · 1 vendor · humans involved: 1 — the one on the call. that is the product.'
+  }
+];
+
+/* ------------------------------------------------------------------ */
+/* the machine-readable surfaces                                       */
+/* ------------------------------------------------------------------ */
+
+export type MachineSurface = {
+  label: string;
+  href: string;
+  blurb: string;
+  /** Off-site (npm, GitHub, docs) rather than a path on this domain. */
+  external?: boolean;
+};
+
+/** Every artifact an agent can read without an account. */
+export const MACHINE_SURFACES: readonly MachineSurface[] = [
+  {
+    label: '/llms.txt',
+    href: '/llms.txt',
+    blurb: 'The index: what Ringee is, and every page worth reading.'
+  },
+  {
+    label: '/llms-full.txt',
+    href: '/llms-full.txt',
+    blurb: 'The long form: facts, pricing, limits, in one document.'
+  },
+  {
+    label: MACHINE_MD_PATH,
+    href: MACHINE_MD_PATH,
+    blurb: 'The claims below, as bytes. Generated from this page’s objects.'
+  },
+  {
+    label: '/SKILL.md',
+    href: '/SKILL.md',
+    blurb: 'The entry skill — how to drive Ringee, safety rules included.'
+  },
+  {
+    label: '/.well-known/agent-skills/index.json',
+    href: '/.well-known/agent-skills/index.json',
+    blurb: `Discovery index for all ${PUBLISHED_SKILLS.length} skills, per the Agent Skills spec.`
+  },
+  {
+    label: '/robots.txt',
+    href: '/robots.txt',
+    blurb: 'Every major AI crawler allowed: search, retrieval and training.'
+  },
+  {
+    label: 'MCP server',
+    href: DOCS_MCP_URL,
+    blurb: `${TOOL_SURFACE.total} tools over SSE. The URL is minted per workspace.`,
+    external: true
+  },
+  {
+    label: 'REST API',
+    href: DOCS_API_URL,
+    blurb: 'The same operations, for anything that is not an agent.',
+    external: true
+  }
+];
+
+/* ------------------------------------------------------------------ */
+/* the claims document                                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Facts that are not derivable from the content modules. Each one is either
+ * public elsewhere on the site (`llms.txt`, `/pricing`, `/security`) or an
+ * invariant of the system, and the limits are stated as plainly as the wins —
+ * an agent evaluating Ringee should be able to rule it out from this document.
+ */
+const CLAIMS: string[] = [
+  'category: open-source, pay-as-you-go outbound calling software',
+  `pricing: ${PRICING.freelancer.name} $${PRICING.freelancer.price}/${PRICING.freelancer.period} · ${PRICING.organization.name} $${PRICING.organization.price}/${PRICING.organization.period} per organization, unlimited members`,
+  'calling: pay-as-you-go credits from $0.012/min, billed separately from the plan',
+  'seats: none. team price is flat, not per user',
+  'surfaces: web app, Chrome extension, iOS and Android apps, CLI, Dialer SDK, MCP',
+  'transcription: real time, works with or without recording',
+  'licence: MIT, self-hostable',
+  'certifications: none claimed. Ringee has not completed SOC 2 or ISO',
+  'humans: agents prepare the work; a person takes the call'
+];
+
+/**
+ * Constraints an agent has to plan around, each named where it is enforced.
+ * These are the reasons a plan fails, so they are worth as much as the claims.
+ */
+const CONSTRAINTS: string[] = [
+  'one call at a time per user — a second dial is refused with 409',
+  'credit spend is idempotent and requires a reference; a retry never double-charges',
+  'every read and write is scoped to one workspace (personal or organization)',
+  'revealing a lead spends provider credits and asks for confirmation first',
+  'a call session magic link returns its token once; it cannot be re-fetched',
+  'deleting a contact requires the stored phone number as a second confirmation',
+  'phone numbers are E.164; datetimes are ISO-8601 with an offset'
+];
+
+const line = (label: string, value: string) => `- ${label}: ${value}`;
+
+/**
+ * Builds the claims document. Same objects as the human page, rendered as
+ * Markdown instead of React — that is the entire trick, and it is why the two
+ * renderings agree by construction rather than by discipline.
+ */
+export function buildClaimsDocument(): string {
+  const sections: string[] = [];
+
+  sections.push(
+    [
+      '# Ringee',
+      '',
+      '> Low-cost, pay-as-you-go outbound calling software. Agents prospect, queue and follow up; a person makes the call.',
+      '',
+      `source: ${SITE_URL}${MACHINE_MD_PATH}`,
+      `human rendering: ${SITE_URL}/`,
+      `generated: ${SITE_LAST_MODIFIED}`
+    ].join('\n')
+  );
+
+  sections.push(['## Claims', '', ...CLAIMS.map((c) => `- ${c}`)].join('\n'));
+
+  sections.push(
+    [
+      '## Interfaces',
+      '',
+      line('mcp', `SSE, ${TOOL_SURFACE.total} tools — ${DOCS_MCP_URL}`),
+      line('rest api', DOCS_API_URL),
+      line('cli', `npx ringee — ${CLI_NPM_URL}`),
+      line('dialer sdk', `@ringee/dialer-sdk — ${SDK_NPM_URL}`),
+      line('chrome extension', CHROME_EXTENSION_URL),
+      line('docs', DOCS_URL),
+      line('source', GITHUB_URL)
+    ].join('\n')
+  );
+
+  sections.push(
+    [
+      `## Tool surface (${TOOL_SURFACE.total})`,
+      '',
+      line('read', String(TOOL_SURFACE.read)),
+      line('write', String(TOOL_SURFACE.write)),
+      line(
+        'sensitive (spends credits or mints access)',
+        String(TOOL_SURFACE.sensitive)
+      ),
+      line('destructive (double-confirmed)', String(TOOL_SURFACE.destructive)),
+      '',
+      `Skills that drive them: ${SKILL_NAMES}.`
+    ].join('\n')
+  );
+
+  sections.push(
+    [
+      `## Features (${FEATURES.length})`,
+      '',
+      ...FEATURES.map(
+        (feature) =>
+          `- ${feature.name} · ${feature.category}: ${feature.tagline} → ${SITE_URL}/features/${feature.slug}`
+      )
+    ].join('\n')
+  );
+
+  sections.push(
+    [
+      `## Integrations (${INTEGRATIONS.length})`,
+      '',
+      ...INTEGRATION_CATEGORIES.flatMap((category) => [
+        `### ${category.name}`,
+        ...INTEGRATIONS.filter(
+          (integration) => integration.category === category.name
+        ).map(
+          (integration) =>
+            `- ${integration.name}: ${integration.tagline} → ${SITE_URL}/integrations/${integration.slug}`
+        ),
+        ''
+      ])
+    ]
+      .join('\n')
+      .trimEnd()
+  );
+
+  sections.push(
+    [
+      `## Use cases (${USE_CASES.length})`,
+      '',
+      ...USE_CASES.map(
+        (useCase) =>
+          `- ${useCase.name}: ${useCase.tagline} → ${SITE_URL}/use-cases/${useCase.slug}`
+      )
+    ].join('\n')
+  );
+
+  sections.push(
+    ['## Constraints', '', ...CONSTRAINTS.map((c) => `- ${c}`)].join('\n')
+  );
+
+  return `${sections.join('\n\n')}\n`;
+}

--- a/apps/frontend/src/features/marketing/content/machine-view.ts
+++ b/apps/frontend/src/features/marketing/content/machine-view.ts
@@ -120,7 +120,7 @@ export const AGENT_SESSION: readonly SessionLine[] = [
     kind: 'note',
     text: '// spends provider credits — the skill stops and asks a person before this one'
   },
-  { kind: 'out', text: '{"email":"…","phoneNumber":"+34 6·· ··· ···"}' },
+  { kind: 'out', text: '{"email":"…","phoneNumber":"+346········"}' },
   {
     kind: 'tool',
     text: 'import_leads_as_contacts {"jobId":"…","externalIds":["…"]}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour

- Adds `/machine` and `/machine.md` as public machine-facing marketing surfaces.
- Publishes claims about calling, credits, provider spend, workspace scope, MCP tools, REST, CLI, and SDK access.
- Adds explicit constraints for call concurrency, idempotent debit retries, lead reveal spend, session tokens, contact deletion, and input formats.

## Architectural impact

- Adds `features/marketing/content/machine-view.ts` as the shared source for the page and markdown route.
- Adds a static Next.js route with public CORS headers.
- No changes to service, platform, database, auth, webhook, or workspace contracts.

## Risk areas

- `TOOL_SURFACE` hard-codes `37/19/10/4/4` while comments identify `packages/agent/src/tools/catalog.ts` as the source of truth. Catalog changes can make the public claims incorrect.
- `AGENT_SESSION` reports “6 tools” although the declared tool surface contains 37 tools. This can mislead agents about available capabilities.
- `CLAIMS` and `CONSTRAINTS` publish operational and pricing claims without compile-time linkage to enforcement code. A changed debit, call-lifecycle, or tenancy rule can leave `/machine.md` stale.
- `dynamic = 'force-static'` and one-hour caching delay corrections to public claims.
- The public contract is carried by `apps/frontend/src/features/marketing/content/machine-view.ts` and `apps/frontend/src/app/machine.md/route.ts`. The page and replay rendering are secondary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->