### PR TITLE
fix: realtime transcriptions

### DIFF
--- a/packages/platform/src/telephony/telnyx/telnyx.error.test.ts
+++ b/packages/platform/src/telephony/telnyx/telnyx.error.test.ts
@@ -1,6 +1,6 @@
 import { HttpException } from "@nestjs/common";
 import { describe, expect, it } from "vitest";
-import { describeTelnyxError } from "./telnyx.error";
+import { describeTelnyxError, isTelnyxCallEndedError } from "./telnyx.error";
 
 const FALLBACK = "The voice provider rejected this configuration.";
 
@@ -90,5 +90,43 @@ describe("describeTelnyxError", () => {
   it("falls back for anything unrecognisable", () => {
     expect(describeTelnyxError(undefined, FALLBACK)).toBe(FALLBACK);
     expect(describeTelnyxError({}, FALLBACK)).toBe(FALLBACK);
+  });
+});
+
+describe("isTelnyxCallEndedError", () => {
+  /** What a `streaming_stop` racing a hangup actually comes back as. */
+  const callEnded = new HttpException(
+    {
+      errors: [
+        {
+          code: "90018",
+          title: "Call has already ended",
+          detail: "This call is no longer active and can't receive commands.",
+        },
+      ],
+    },
+    422,
+  );
+
+  it("recognises the provider's 'call has already ended' rejection", () => {
+    expect(isTelnyxCallEndedError(callEnded)).toBe(true);
+  });
+
+  it("recognises it before TelnyxClient wraps the axios error", () => {
+    expect(
+      isTelnyxCallEndedError({
+        response: { status: 422, data: { errors: [{ code: 90018 }] } },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not swallow any other provider failure", () => {
+    expect(
+      isTelnyxCallEndedError(
+        new HttpException({ errors: [{ code: "10015" }] }, 422),
+      ),
+    ).toBe(false);
+    expect(isTelnyxCallEndedError(new Error("socket hang up"))).toBe(false);
+    expect(isTelnyxCallEndedError(undefined)).toBe(false);
   });
 });

--- a/packages/platform/src/telephony/telnyx/telnyx.error.ts
+++ b/packages/platform/src/telephony/telnyx/telnyx.error.ts
@@ -80,3 +80,38 @@ function nonGenericMessage(message: string | undefined): string | null {
   if (normalized.startsWith("request failed with status code")) return null;
   return message;
 }
+
+/** Telnyx's code for "this command reached a leg that is no longer active". */
+const CALL_ALREADY_ENDED = "90018";
+
+/**
+ * True when Telnyx rejected a call command because the leg is already down.
+ *
+ * Telnyx tears a call's resources down with the call itself, so a teardown
+ * command that arrives after the hangup is answered with 422 / `90018`. For a
+ * caller that is winding something down, that is the state it asked for — not
+ * a failure.
+ */
+export function isTelnyxCallEndedError(error: unknown): boolean {
+  return telnyxErrorCodes(error).includes(CALL_ALREADY_ENDED);
+}
+
+/** Reads `{ errors: [{ code }] }` out of whatever wrapper carries the body. */
+function telnyxErrorCodes(error: unknown): string[] {
+  const body =
+    error instanceof HttpException
+      ? error.getResponse()
+      : ((error as { response?: { data?: unknown } })?.response?.data ?? error);
+  if (!body || typeof body !== "object") return [];
+
+  const errors = (body as Record<string, unknown>).errors;
+  if (!Array.isArray(errors)) return [];
+
+  return errors
+    .map((entry) => (entry as Record<string, unknown> | null)?.code)
+    .filter(
+      (code): code is string | number =>
+        typeof code === "string" || typeof code === "number",
+    )
+    .map(String);
+}

--- a/packages/platform/src/telephony/telnyx/telnyx.service.test.ts
+++ b/packages/platform/src/telephony/telnyx/telnyx.service.test.ts
@@ -1,0 +1,58 @@
+import { HttpException } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import type { TelnyxClient } from "./telnyx.client";
+
+/**
+ * `@ringee/configuration` validates the whole app environment on import and
+ * calls `process.exit(1)` when anything is missing. Nothing under test reads
+ * it, so it is replaced rather than satisfied with eighteen fake variables.
+ */
+vi.mock("@ringee/configuration", () => ({ apiConfiguration: {} }));
+
+/** The module builds a real SDK client at import time; it is never called. */
+vi.mock("telnyx", () => ({ default: class {} }));
+
+const { TelnyxService } = await import("./telnyx.service");
+
+/** What Telnyx answers a teardown command with once the leg is gone. */
+const CALL_ENDED = {
+  errors: [
+    {
+      code: "90018",
+      title: "Call has already ended",
+      detail: "This call is no longer active and can't receive commands.",
+    },
+  ],
+};
+
+function build(reason: unknown) {
+  const post = vi.fn(() => Promise.reject(reason));
+  const service = new TelnyxService({ post } as unknown as TelnyxClient);
+  return { service, post };
+}
+
+describe("TelnyxService.stopStreaming", () => {
+  /**
+   * The shape that actually reaches the service: `TelnyxClient.handleError`
+   * rethrows the provider's body as an `HttpException` under its own status.
+   */
+  it("treats a leg that already ended as the outcome it asked for", async () => {
+    const { service, post } = build(new HttpException(CALL_ENDED, 422));
+
+    await expect(service.stopStreaming("v3:cc-1")).resolves.toBeUndefined();
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it("recognises it unwrapped too, in case the client stops mapping it", async () => {
+    const { service } = build({ response: { status: 422, data: CALL_ENDED } });
+
+    await expect(service.stopStreaming("v3:cc-1")).resolves.toBeUndefined();
+  });
+
+  it("still surfaces every other provider failure", async () => {
+    const rejection = new HttpException({ errors: [{ code: "10015" }] }, 422);
+    const { service } = build(rejection);
+
+    await expect(service.stopStreaming("v3:cc-1")).rejects.toBe(rejection);
+  });
+});

--- a/packages/platform/src/telephony/telnyx/telnyx.service.ts
+++ b/packages/platform/src/telephony/telnyx/telnyx.service.ts
@@ -1,6 +1,7 @@
 import { HttpException, Injectable, Logger } from "@nestjs/common";
 import { TelephonyCountryRate } from "../interfaces/telephony.rate";
 import { TelnyxClient } from "./telnyx.client";
+import { isTelnyxCallEndedError } from "./telnyx.error";
 import {
   AddressValidationInput,
   AddressValidationResult,
@@ -957,11 +958,25 @@ export class TelnyxService implements TelephonyService {
     }
   }
 
+  /**
+   * Stop the media stream on a leg.
+   *
+   * Telnyx ends the stream with the call, so a `streaming_stop` that races a
+   * hangup comes back as 422 / `90018`. Every caller is winding transcription
+   * down, so a leg that is already gone is the outcome they asked for.
+   */
   async stopStreaming(callControlId: string): Promise<void> {
-    await this.telnyxClient.post(
-      `/calls/${callControlId}/actions/streaming_stop`,
-      { command_id: crypto.randomUUID() },
-    );
+    try {
+      await this.telnyxClient.post(
+        `/calls/${callControlId}/actions/streaming_stop`,
+        { command_id: crypto.randomUUID() },
+      );
+    } catch (error) {
+      if (!isTelnyxCallEndedError(error)) throw error;
+      this.logger.debug(
+        `streaming_stop for ${callControlId}: the call had already ended`,
+      );
+    }
   }
 
   async playbackStart(

--- a/packages/platform/vitest.config.ts
+++ b/packages/platform/vitest.config.ts
@@ -1,13 +1,32 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 /**
- * Runs the pure units in this package — helpers with no NestJS or
- * workspace-alias dependencies, so no app bootstrap is needed: the Dialer SDK
- * crypto/token helpers, the CRM provider mappers and phone normalization, and
- * the carrier event normalizer.
+ * Runs the units in this package that need no app bootstrap: the Dialer SDK
+ * crypto/token helpers, the CRM provider mappers and phone normalization, the
+ * carrier event normalizer, and the provider services that can be driven with
+ * a stubbed client.
  * `APP_ENCRYPTION_SECRET` is provided so key derivation works.
  */
 export default defineConfig({
+  resolve: {
+    alias: {
+      /**
+       * `@ringee/configuration` declares no `main`/`exports`, so vite cannot
+       * find an entry for it and any module that reads configuration fails to
+       * collect. Resolving it to its source makes it reachable without
+       * building a sibling package first.
+       *
+       * Resolving it is not the same as loading it: the module validates the
+       * whole app environment on import and calls `process.exit(1)` when a
+       * variable is missing, so a test that pulls one in still has to stub it
+       * (see `telnyx.service.test.ts`).
+       */
+      "@ringee/configuration": fileURLToPath(
+        new URL("../configuration/src/index.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     // Any `*.test.ts` under src/. The previous per-directory allowlist meant a
     // new test file outside src/sdk or src/crm was silently never run.

--- a/packages/services/src/services/transcription/transcription.service.ts
+++ b/packages/services/src/services/transcription/transcription.service.ts
@@ -8,6 +8,7 @@ import {
 import {
   Call,
   CallRepository,
+  CallStatus,
   CallTranscription,
   CallTranscriptionRepository,
   CallTranscriptionWithSegments,
@@ -270,11 +271,33 @@ export class TranscriptionService {
 
   /**
    * Stop realtime transcription. The media bridge finalizes the header status
-   * when Telnyx closes the socket; here we just stop the Telnyx stream and, as
-   * a safety net, demote a never-started header to `stopped`.
+   * when Telnyx closes the socket; here we only stop the provider's stream and
+   * drop the live partial.
+   *
+   * The carrier is only asked to stop a stream that can still be running. This
+   * runs on every hangup, whether or not the call was ever transcribed, and a
+   * `streaming_stop` sent to a leg Telnyx has already torn down comes back as
+   * 422 `90018` — a failure logged for every completed call, for a stream that
+   * either never existed or was already closed by the hangup itself.
    */
   async stopRealtimeForCall(call: Call): Promise<void> {
-    if (call.callControlId) {
+    const inFlight: TranscriptionStatus[] = [
+      TranscriptionStatus.starting,
+      TranscriptionStatus.transcribing,
+    ];
+    const header = await this.transcriptionRepo.findHeaderByCallAndSource(
+      call.id,
+      TranscriptionSource.realtime,
+    );
+    const isLive =
+      call.status !== CallStatus.completed && call.status !== CallStatus.failed;
+
+    if (
+      call.callControlId &&
+      isLive &&
+      header &&
+      inFlight.includes(header.status)
+    ) {
       await this.telephonyService
         .stopStreaming(call.callControlId)
         .catch((err) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour changes

- Realtime shutdown now calls Telnyx only for active calls with an in-flight realtime transcription.
- Telnyx error `90018` no longer fails hangup processing when the call leg already ended.
- Other streaming-stop errors remain visible to the transcription service.

## Architectural impact

- `@ringee/services` now decides whether a realtime stream should stop.
- `@ringee/platform` owns Telnyx-specific terminal-error detection.
- No database or public API contract changes are included.

## Risk areas

- Call status and transcription header state can become stale between lookup and `streaming_stop`.
- The `90018` matcher must not classify unrelated Telnyx failures as terminal.
- The service-level catch logs all failures as warnings, while platform-level handling already suppresses `90018`. This can obscure the distinction between expected and unexpected failures.
- The branch also contains a large unrelated change set. Confirm that the four telephony/transcription files are the intended review scope.

## Files that carry the risk

- `packages/services/src/services/transcription/transcription.service.ts`
- `packages/platform/src/telephony/telnyx/telnyx.service.ts`
- `packages/platform/src/telephony/telnyx/telnyx.error.ts`
- `packages/platform/src/telephony/telnyx/telnyx.error.test.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->