### PR TITLE
feat: enhance phone number mapping in Attio integration

### DIFF
--- a/packages/platform/src/crm/providers/attio/attio.mapper.test.ts
+++ b/packages/platform/src/crm/providers/attio/attio.mapper.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { buildAttioPersonName } from "./attio.mapper";
+import {
+  buildAttioPersonName,
+  mapAttioCompanyToSyncResult,
+  mapAttioPersonToMatch,
+  mapAttioPersonToSyncResult,
+} from "./attio.mapper";
+import type { AttioCompanyRecord, AttioPersonRecord } from "./attio.types";
+
+function personWithPhone(
+  phone: NonNullable<AttioPersonRecord["values"]["phone_numbers"]>[number],
+): AttioPersonRecord {
+  return {
+    id: {
+      workspace_id: "workspace-1",
+      object_id: "people",
+      record_id: "person-1",
+    },
+    values: { phone_numbers: [phone] },
+  };
+}
 
 describe("buildAttioPersonName", () => {
   // Attio's object syntax requires first_name, last_name AND full_name to all
@@ -68,5 +87,60 @@ describe("buildAttioPersonName", () => {
     expect(
       buildAttioPersonName({ displayName: "  ", firstName: " ", lastName: "" }),
     ).toBeNull();
+  });
+});
+
+describe("Attio phone mapping", () => {
+  it("uses Attio's normalized_phone_number for a locally formatted person number", () => {
+    const record = personWithPhone({
+      original_phone_number: "(415) 555-2671",
+      normalized_phone_number: "+14155552671",
+      country_code: "US",
+    });
+
+    expect(mapAttioPersonToSyncResult(record).phones).toEqual(["+14155552671"]);
+    expect(mapAttioPersonToMatch(record, "+14155552671").phoneNumbers).toEqual([
+      "+14155552671",
+    ]);
+  });
+
+  it("uses country_code when an older payload omits the normalized value", () => {
+    const record = personWithPhone({
+      original_phone_number: "020 7946 0958",
+      country_code: "GB",
+    });
+
+    expect(mapAttioPersonToSyncResult(record).phones).toEqual([
+      "+442079460958",
+    ]);
+  });
+
+  it("keeps supporting legacy phone_number payloads", () => {
+    const record = personWithPhone({ phone_number: "+33142345678" });
+
+    expect(mapAttioPersonToSyncResult(record).phones).toEqual(["+33142345678"]);
+  });
+
+  it("uses the normalized value for company phone numbers too", () => {
+    const record: AttioCompanyRecord = {
+      id: {
+        workspace_id: "workspace-1",
+        object_id: "companies",
+        record_id: "company-1",
+      },
+      values: {
+        name: [{ value: "Acme" }],
+        domains: [],
+        phone_numbers: [
+          {
+            original_phone_number: "809-555-1234",
+            normalized_phone_number: "+18095551234",
+            country_code: "DO",
+          },
+        ],
+      },
+    };
+
+    expect(mapAttioCompanyToSyncResult(record).phone).toBe("+18095551234");
   });
 });

--- a/packages/platform/src/crm/providers/attio/attio.mapper.ts
+++ b/packages/platform/src/crm/providers/attio/attio.mapper.ts
@@ -11,8 +11,35 @@ import { normalizePhoneE164, phoneMatchesSuffix } from "../../phone";
 import type {
   AttioCompanyRecord,
   AttioPersonRecord,
+  AttioPhoneNumberValue,
   AttioWorkspaceMember,
 } from "./attio.types";
+
+/**
+ * Read Attio phone values using the provider's current response contract.
+ *
+ * Attio returns both the user's original input and an E.164
+ * `normalized_phone_number`. Prefer the normalized value: the original may be
+ * a country-local number (for example, `(415) 555-2671`) that Ringee cannot
+ * interpret correctly without the record's country. Older payloads used by
+ * existing integrations may still carry `phone_number`, so it remains a
+ * compatibility fallback before considering the original input.
+ */
+function mapAttioPhoneNumbers(values: AttioPhoneNumberValue[] = []): string[] {
+  return values
+    .map((phone) => {
+      const normalized =
+        normalizePhoneE164(phone.normalized_phone_number) ??
+        normalizePhoneE164(phone.phone_number);
+      if (normalized) return normalized;
+
+      return normalizePhoneE164(
+        phone.original_phone_number,
+        phone.country_code ?? undefined,
+      );
+    })
+    .filter((phone): phone is string => Boolean(phone));
+}
 
 export function mapAttioPersonToMatch(
   record: AttioPersonRecord,
@@ -26,13 +53,7 @@ export function mapAttioPersonToMatch(
   const displayName =
     nameVal?.full_name ?? nameVal?.value ?? (assembledName || "Unnamed person");
 
-  const rawPhones =
-    record.values.phone_numbers?.map(
-      (p) => p.original_phone_number ?? p.phone_number ?? "",
-    ) ?? [];
-  const normalizedPhones = rawPhones
-    .map((p) => normalizePhoneE164(p))
-    .filter((p): p is string => Boolean(p));
+  const normalizedPhones = mapAttioPhoneNumbers(record.values.phone_numbers);
 
   const exact = normalizedPhones.includes(targetPhoneE164);
   const matchedOn: "phone_exact" | "phone_suffix" = exact
@@ -195,13 +216,7 @@ export function mapAttioPersonToSyncResult(
   const displayName =
     nameVal?.full_name ?? nameVal?.value ?? (assembledName || null);
 
-  const rawPhones =
-    record.values.phone_numbers?.map(
-      (p) => p.original_phone_number ?? p.phone_number ?? "",
-    ) ?? [];
-  const phones = rawPhones
-    .map((p) => normalizePhoneE164(p))
-    .filter((p): p is string => Boolean(p));
+  const phones = mapAttioPhoneNumbers(record.values.phone_numbers);
 
   const emails =
     record.values.email_addresses?.map((e) => e.email_address) ?? [];
@@ -253,12 +268,12 @@ export function mapAttioCompanyToSyncResult(
   const domains = record.values.domains
     ?.map((d) => d.domain)
     .filter(Boolean) as string[];
-  const rawPhones =
-    record.values.phone_numbers?.map(
-      (p) => p.original_phone_number ?? p.phone_number ?? "",
-    ) ?? [];
-  const phone = rawPhones[0]
-    ? (normalizePhoneE164(rawPhones[0]) ?? rawPhones[0])
+  const firstPhone = record.values.phone_numbers?.[0];
+  const phone = firstPhone
+    ? (mapAttioPhoneNumbers([firstPhone])[0] ??
+      firstPhone.original_phone_number ??
+      firstPhone.phone_number ??
+      null)
     : null;
 
   return {

--- a/packages/platform/src/crm/providers/attio/attio.types.ts
+++ b/packages/platform/src/crm/providers/attio/attio.types.ts
@@ -28,9 +28,22 @@ export type AttioWorkspaceResponse = {
 export type AttioAttributeValue =
   | { value: string | number | boolean | null }
   | { email_address: string }
-  | { original_phone_number: string; country_code?: string | null }
+  | {
+      original_phone_number: string;
+      normalized_phone_number?: string;
+      country_code?: string | null;
+    }
   | { full_name?: string; first_name?: string; last_name?: string }
   | { target_object: "people" | "companies"; target_record_id: string };
+
+export type AttioPhoneNumberValue = {
+  /** Current Attio API field: an E.164 number including its country code. */
+  normalized_phone_number?: string;
+  original_phone_number?: string;
+  country_code?: string | null;
+  /** Kept for compatibility with older payloads and fixtures. */
+  phone_number?: string;
+};
 
 export type AttioPersonRecord = {
   id: { workspace_id: string; object_id: string; record_id: string };
@@ -42,10 +55,7 @@ export type AttioPersonRecord = {
       last_name?: string;
     }>;
     email_addresses?: Array<{ email_address: string }>;
-    phone_numbers?: Array<{
-      phone_number?: string;
-      original_phone_number?: string;
-    }>;
+    phone_numbers?: AttioPhoneNumberValue[];
     primary_location?: Array<{ locality?: string }>;
   };
 };
@@ -104,10 +114,7 @@ export type AttioCompanyRecord = {
     domains?: Array<{ domain?: string }>;
     description?: Array<{ value?: string }>;
     primary_location?: Array<{ locality?: string }>;
-    phone_numbers?: Array<{
-      phone_number?: string;
-      original_phone_number?: string;
-    }>;
+    phone_numbers?: AttioPhoneNumberValue[];
     categories?: Array<{
       option?: {
         id: {


### PR DESCRIPTION
- Introduced a new utility function `mapAttioPhoneNumbers` to standardize phone number extraction from Attio records.
- Updated `mapAttioPersonToMatch`, `mapAttioPersonToSyncResult`, and `mapAttioCompanyToSyncResult` to utilize the new phone mapping function.
- Enhanced type definitions for phone numbers in `attio.types.ts` to include `normalized_phone_number` and maintain compatibility with legacy payloads.
- Added unit tests for phone number mapping scenarios, ensuring correct handling of normalized and original phone numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behaviour

- Attio phone mapping now prefers `normalized_phone_number`.
- It falls back to legacy `phone_number`.
- It derives an E.164 number from `original_phone_number` and `country_code` when required.
- Person matching, person sync, and company sync use the same mapping path.
- Legacy Attio payloads remain supported.

## Architectural impact

- `mapAttioPhoneNumbers` owns phone extraction in the Attio adapter.
- `AttioPhoneNumberValue` defines the shared provider phone shape.
- No changes affect `@ringee/services`, `@ringee/platform`, or `@ringee/database` contracts.

## Risk areas

- Incorrect precedence can produce a different phone number for matching or sync.
- Missing or invalid `country_code` can prevent normalization of legacy values.
- The public provider type now exposes `normalized_phone_number`, while legacy fields remain accepted.

## Files to review

- `packages/platform/src/crm/providers/attio/attio.mapper.ts`
- `packages/platform/src/crm/providers/attio/attio.types.ts`
- `packages/platform/src/crm/providers/attio/attio.mapper.test.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->